### PR TITLE
OSS: add CODEOWNERS for .github/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/* @fouge @TheButlah


### PR DESCRIPTION
For compliance with our security requirement we require a CODEOWNERs file for the .github/workflows directory.

