### PR TITLE
slot-ctrl: fix binary name in postinst

### DIFF
--- a/orb-slot-ctrl/debpkg/DEBIAN/postinst
+++ b/orb-slot-ctrl/debpkg/DEBIAN/postinst
@@ -2,5 +2,5 @@
 set -e
 if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
         # install get-slot
-        ln -s /usr/bin/slot-ctrl /usr/bin/get-slot
+        ln -s /usr/bin/orb-slot-ctrl /usr/bin/get-slot
 fi


### PR DESCRIPTION
This is currently breaking `orb-core`, since the `CURRENT_BOOT_SLOT` environment variable `orb-core` requires is not being set:

`/usr/local/lib/systemd/system-environment-generators/10-boot-slot.sh`:

```
echo "CURRENT_BOOT_SLOT=$(/usr/bin/get-slot)"
```