### PR TITLE
Remove get-slot symlink

### DIFF
--- a/orb-slot-ctrl/README.md
+++ b/orb-slot-ctrl/README.md
@@ -4,7 +4,7 @@ The Slot Control is a tool to read and write the slot and rootfs state of the Or
 
 ## Command line arguments
 
-For available command line arguments see `slot-ctrl --help`.
+For available command line arguments see `orb-slot-ctrl --help`.
 Those are the high level commands:
 
 ```sh
@@ -22,7 +22,7 @@ Commands:
 And here are the subcommands for `status`:
 
 ```sh
-Usage: slot-ctrl status [OPTIONS] <COMMAND>
+Usage: orb-slot-ctrl status [OPTIONS] <COMMAND>
 
 Commands:
   get, -g      Get the rootfs status

--- a/orb-slot-ctrl/debpkg/DEBIAN/postinst
+++ b/orb-slot-ctrl/debpkg/DEBIAN/postinst
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-if [ "$1" = "configure" ] || [ "$1" = "abort-upgrade" ] || [ "$1" = "abort-deconfigure" ] || [ "$1" = "abort-remove" ] ; then
-        # install get-slot
-        ln -s /usr/bin/orb-slot-ctrl /usr/bin/get-slot
-fi

--- a/orb-slot-ctrl/debpkg/DEBIAN/prerm
+++ b/orb-slot-ctrl/debpkg/DEBIAN/prerm
@@ -1,6 +1,0 @@
-#!/bin/sh
-set -e
-if [ "$1" = remove ]; then
-        # remove get-slot
-        rm /usr/bin/get-slot
-fi

--- a/orb-slot-ctrl/src/main.rs
+++ b/orb-slot-ctrl/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use std::{env, path::Path, process::exit};
+use std::{env, process::exit};
 
 #[derive(Parser)]
 #[command(
@@ -69,22 +69,6 @@ fn check_running_as_root(error: orb_slot_ctrl::Error) {
 }
 
 fn main() -> eyre::Result<()> {
-    // executable path can be found as first element of `std::end::args()`
-    if let Some(exe_path) = env::args().next() {
-        if let Some(executable_name) = Path::new(&exe_path).file_name() {
-            match executable_name.to_str() {
-                Some("get-slot") => {
-                    // print current slot if called by get-slot and exit
-                    println!("{}", orb_slot_ctrl::get_current_slot()?);
-                    return Ok(());
-                }
-                None => {
-                    println!("Could not decode executable path as valid Unicode/UTF-8")
-                }
-                _ => (),
-            };
-        };
-    };
     let cli = Cli::parse();
     match cli.subcmd {
         Commands::GetSlot => {


### PR DESCRIPTION
get-slot is just a symlink to `orb-slot-ctrl`. The binary does introspection on its own name to determine its behavior. I don't see any reason for that complexity, so I'm removing this. It also simplifies the deb packaging for `orb-slot-ctrl`.