### PR TITLE
attest: remove flavors

### DIFF
--- a/orb-attest/Cargo.toml
+++ b/orb-attest/Cargo.toml
@@ -48,10 +48,6 @@ serial_test = "2.0"
 tempfile = "3.3"
 wiremock = "0.5"
 
-[features]
-default = []
-prod = [] # use prod backend
-
 [package.metadata.deb]
 maintainer-scripts = "debian/"
 systemd-units = [

--- a/orb-attest/src/config.rs
+++ b/orb-attest/src/config.rs
@@ -1,7 +1,6 @@
 use std::env;
 
-use eyre;
-use tracing::warn;
+use eyre::{self, bail};
 
 const ORB_BACKEND_ENV_VAR_NAME: &str = "ORB_BACKEND";
 
@@ -38,10 +37,7 @@ pub enum Backend {
     Staging,
 }
 
-#[cfg(feature = "prod")]
 const DEFAULT_BACKEND: Backend = Backend::Prod;
-#[cfg(not(feature = "prod"))]
-const DEFAULT_BACKEND: Backend = Backend::Staging;
 
 impl Default for Backend {
     fn default() -> Self {
@@ -63,11 +59,7 @@ impl Backend {
             "prod" => Ok(Backend::Prod),
             "stage" | "dev" => Ok(Backend::Staging),
             _ => {
-                warn!(
-                    "{ORB_BACKEND_ENV_VAR_NAME} is set to an unexpected value {v}, falling back \
-                     to default {DEFAULT_BACKEND:?}"
-                );
-                eyre::bail!("invalid backend");
+                bail!("unknown value for backend");
             }
         }
     }

--- a/scripts/build_rust_artifacts.py
+++ b/scripts/build_rust_artifacts.py
@@ -25,45 +25,34 @@ def main():
 
     args = parser.parse_args()
 
-    flavors = ["prod", "stage"]
     targets = ["aarch64", "x86_64"]
 
     targets_option = " ".join([f"--target {t}-unknown-linux-gnu" for t in targets])
     print(f"TARGETS={targets_option}")
 
-    for f in flavors:
-        if f == "prod":
-            features = ""
-        elif f == "stage":
-            features = "--features stage"
-        else:
-            print("Unexpected flavor")
-            sys.exit(1)
+    cmd(
+        f"cargo zigbuild --all "
+        f"--profile {args.cargo_profile} "
+        f"{targets_option} "
+        f"--no-default-features"
+    )
 
-        print(f"Building flavor={f}")
-        cmd(
-            f"cargo zigbuild --all "
-            f"--profile {args.cargo_profile} "
-            f"{targets_option} "
-            f"--no-default-features {features}"
-        )
-
-        for b in args.crates:
-            os.makedirs(os.path.join(args.out_dir, b), exist_ok=True)
-            print(f"Creating .deb package for {b}:")
-            for t in targets:
-                cmd(
-                    f"cargo deb --no-build --no-strip "
-                    f"--profile {args.cargo_profile} "
-                    f"-p {b} "
-                    f"--target {t}-unknown-linux-gnu "
-                    f"-o {args.out_dir}/{b}/{b}_{f}_{t}.deb"
-                )
-                cmd(
-                    f"cp -L "
-                    f"target/{t}-unknown-linux-gnu/{args.cargo_profile}/{b} "
-                    f"{args.out_dir}/{b}/{b}_{f}_{t}"
-                )
+    for b in args.crates:
+        os.makedirs(os.path.join(args.out_dir, b), exist_ok=True)
+        print(f"Creating .deb package for {b}:")
+        for t in targets:
+            cmd(
+                f"cargo deb --no-build --no-strip "
+                f"--profile {args.cargo_profile} "
+                f"-p {b} "
+                f"--target {t}-unknown-linux-gnu "
+                f"-o {args.out_dir}/{b}/{b}_{t}.deb"
+            )
+            cmd(
+                f"cp -L "
+                f"target/{t}-unknown-linux-gnu/{args.cargo_profile}/{b} "
+                f"{args.out_dir}/{b}/{b}_{t}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The flavors are problematic because they double compile times and cause us to have to produce and distribute prod and stage versions of every binary. However, most of the binaries are actually identical between these two versions.

Instead of doing compile time feature flags, we should simply detect this stuff with environment variables at runtime. In the absence of an env var, the code should fall back to prod behavior.

As a consequence, this also removes the `_prod_` part of the artifact names.