### PR TITLE
orb-ui: Handle Magic QR Code Event

### DIFF
--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -342,8 +342,6 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 );
                 match schema {
                     QrScanSchema::Operator => {
-                        self.sound
-                            .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
                         self.set_ring(
                             LEVEL_FOREGROUND,
                             ring::alert::Alert::<DIAMOND_RING_LED_COUNT>::new(
@@ -409,6 +407,8 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::QrScanSuccess { schema } => match schema {
                 QrScanSchema::Operator => {
+                    self.sound
+                        .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
                     self.operator_signup_phase.operator_qr_captured();
                 }
                 QrScanSchema::User => {

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -433,6 +433,8 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     sound::Melody::SoundError
                 };
                 self.sound.queue(sound::Type::Melody(melody))?;
+                // This justs sets the operator LEDs yellow
+                // to inform the operator to press the button.
                 self.operator_signup_phase.failure();
             }
             Event::NetworkConnectionSuccess => {

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -426,6 +426,15 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 }
                 QrScanSchema::Wifi => {}
             },
+            Event::MagicQrActionCompleted { success } => {
+                let melody = if *success {
+                    sound::Melody::QrLoadSuccess
+                } else {
+                    sound::Melody::SoundError
+                };
+                self.sound.queue(sound::Type::Melody(melody))?;
+                self.operator_signup_phase.failure();
+            }
             Event::NetworkConnectionSuccess => {
                 self.sound.queue(sound::Type::Melody(
                     sound::Melody::InternetConnectionSuccessful,

--- a/orb-ui/src/engine/mod.rs
+++ b/orb-ui/src/engine/mod.rs
@@ -198,6 +198,11 @@ event_enum! {
         QrScanFail {
             schema: QrScanSchema,
         },
+        /// Magic QR action completed
+        #[event_enum(method = magic_qr_action_completed)]
+        MagicQrActionCompleted {
+            success: bool,
+        },
         /// Network connection successful
         #[event_enum(method = network_connection_success)]
         NetworkConnectionSuccess,

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -403,6 +403,8 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     sound::Melody::SoundError
                 };
                 self.sound.queue(sound::Type::Melody(melody))?;
+                // This justs sets the operator LEDs yellow
+                // to inform the operator to press the button.
                 self.operator_signup_phase.failure();
             }
             Event::NetworkConnectionSuccess => {

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -312,10 +312,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 );
 
                 match schema {
-                    QrScanSchema::Operator => {
-                        self.sound
-                            .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
-                    }
+                    QrScanSchema::Operator => {}
                     QrScanSchema::User => {}
                     QrScanSchema::Wifi => {}
                 }
@@ -363,6 +360,8 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             Event::QrScanSuccess { schema } => {
                 match schema {
                     QrScanSchema::Operator => {
+                        self.sound
+                            .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
                         self.operator_signup_phase.operator_qr_captured();
                     }
                     QrScanSchema::User => {

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -396,6 +396,15 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     }
                 }
             }
+            Event::MagicQrActionCompleted { success } => {
+                let melody = if *success {
+                    sound::Melody::QrLoadSuccess
+                } else {
+                    sound::Melody::SoundError
+                };
+                self.sound.queue(sound::Type::Melody(melody))?;
+                self.operator_signup_phase.failure();
+            }
             Event::NetworkConnectionSuccess => {
                 self.sound.queue(sound::Type::Melody(
                     sound::Melody::InternetConnectionSuccessful,


### PR DESCRIPTION
This PR adds a new UI event to handle magic-qr-codes `MagicQrActionCompleted { success: bool }`. 

It also moves the `QrLoadSuccess` sound from `QrScanCompleted` event to `QrScanSuccess` event. 

Goes with: https://github.com/worldcoin/priv-orb-core/pull/1143