### PR TITLE
orb-ui: QrScanTimeout Event

### DIFF
--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -426,6 +426,26 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 }
                 QrScanSchema::Wifi => {}
             },
+            Event::QrScanTimeout { schema } => {
+                self.sound
+                    .queue(sound::Type::Voice(sound::Voice::Timeout))?;
+                match schema {
+                    QrScanSchema::User | QrScanSchema::Operator => {
+                        self.stop_ring(LEVEL_FOREGROUND, true);
+                        self.stop_center(LEVEL_FOREGROUND, true);
+                        self.set_center(
+                            LEVEL_FOREGROUND,
+                            center::Static::<DIAMOND_CENTER_LED_COUNT>::new(
+                                Argb::OFF,
+                                None,
+                            ),
+                        );
+                        self.operator_signup_phase.failure();
+                    }
+                    QrScanSchema::Wifi => {}
+                }
+                self.stop_ring(LEVEL_FOREGROUND, true);
+            }
             Event::MagicQrActionCompleted { success } => {
                 let melody = if *success {
                     sound::Melody::QrLoadSuccess

--- a/orb-ui/src/engine/mod.rs
+++ b/orb-ui/src/engine/mod.rs
@@ -193,9 +193,14 @@ event_enum! {
             schema: QrScanSchema,
             reason: QrScanUnexpectedReason,
         },
-        /// QR scan failed (Timeout, Invalid QR or magic QR)
+        /// QR scan failed
         #[event_enum(method = qr_scan_fail)]
         QrScanFail {
+            schema: QrScanSchema,
+        },
+        /// QR scan timeout
+        #[event_enum(method = qr_scan_timeout)]
+        QrScanTimeout {
             schema: QrScanSchema,
         },
         /// Magic QR action completed

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -396,6 +396,20 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     }
                 }
             }
+            Event::QrScanTimeout { schema } => {
+                self.sound
+                    .queue(sound::Type::Voice(sound::Voice::Timeout))?;
+                match schema {
+                    QrScanSchema::User | QrScanSchema::Operator => {
+                        // in case schema is user qr
+                        self.stop_ring(LEVEL_FOREGROUND, true);
+                        self.operator_signup_phase.failure();
+                    }
+                    QrScanSchema::Wifi => {}
+                }
+                // stop wave
+                self.stop_center(LEVEL_FOREGROUND, true);
+            }
             Event::MagicQrActionCompleted { success } => {
                 let melody = if *success {
                     sound::Melody::QrLoadSuccess


### PR DESCRIPTION
This PR adds a new orb-ui Event, `QrScanTimeout`. 
The behavior is the same as `QrScanFail` with the addition of the `voice::Timeout`, both for Pearl and Diamond.
Goes with https://github.com/worldcoin/priv-orb-core/pull/1144