### PR TITLE
orb-ui: Dynamically change language

### DIFF
--- a/orb-ui/examples/ui-replay.rs
+++ b/orb-ui/examples/ui-replay.rs
@@ -56,7 +56,7 @@ impl FromStr for EventRecord {
         // split line to take everything after "UI event:"
         let (_, event) = line
             .split_once("UI event: ")
-            .wrap_err("Unable to split line")?;
+            .wrap_err(format!("Unable to split line: {}", line))?;
         let event = event.to_string();
         match timestamp_str.parse::<DateTime<Utc>>() {
             Ok(timestamp) => {
@@ -100,7 +100,10 @@ async fn main() -> Result<()> {
         let event = record.event;
         info!("Sending: {}", event);
         // send the event to orb-ui over dbus
-        if let Err(e) = proxy.orb_signup_state_event(format!("{event}")).await {
+        if let Err(e) = proxy
+            .orb_signup_state_event(event.clone().to_string())
+            .await
+        {
             warn!("Error sending event {event}: {:?}", e);
         }
 

--- a/orb-ui/examples/ui-replay.rs
+++ b/orb-ui/examples/ui-replay.rs
@@ -7,7 +7,7 @@ use std::io::BufRead;
 use std::str::FromStr;
 use tokio::time::sleep;
 use tracing::level_filters::LevelFilter;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -21,7 +21,7 @@ const RECORDS_FILE: &str = "worldcoin-ui-logs.txt";
     interface = "org.worldcoin.OrbUiState1"
 )]
 trait SignupState {
-    fn orb_signup_state_event(&self, serialized_event: String) -> zbus::Result<String>;
+    fn orb_signup_state_event(&self, serialized_event: String) -> zbus::Result<()>;
 }
 
 /// Utility args
@@ -83,13 +83,6 @@ async fn main() -> Result<()> {
     let connection = Connection::session().await?;
     let proxy = SignupStateProxy::new(&connection).await?;
 
-    // set initial state
-    let _ = proxy.orb_signup_state_event("\"Bootup\"".to_string()).await;
-    let _ = proxy.orb_signup_state_event("\"Idle\"".to_string()).await;
-    let _ = proxy
-        .orb_signup_state_event("\"SoundVolume {{ level: 10 }}\"".to_string())
-        .await;
-
     // get path to records file from program arguments or use default
     let path = args.path.unwrap_or(RECORDS_FILE.to_string());
     let file =
@@ -107,7 +100,9 @@ async fn main() -> Result<()> {
         let event = record.event;
         info!("Sending: {}", event);
         // send the event to orb-ui over dbus
-        let _ = proxy.orb_signup_state_event(format!("\"{event}\"")).await;
+        if let Err(e) = proxy.orb_signup_state_event(format!("{event}")).await {
+            warn!("Error sending event {event}: {:?}", e);
+        }
 
         last_timestamp = Some(record.timestamp);
     }

--- a/orb-ui/src/dbus.rs
+++ b/orb-ui/src/dbus.rs
@@ -3,7 +3,6 @@
 use crate::engine;
 use crate::engine::Event;
 use tokio::sync::mpsc;
-use tracing::debug;
 use zbus::interface;
 
 /// Dbus interface object for OrbUiState1.
@@ -23,14 +22,13 @@ impl Interface {
     /// Forward events to UI engine by sending serialized engine::Event to the event channel.
     async fn orb_signup_state_event(&mut self, event: String) -> zbus::fdo::Result<()> {
         // parse event to engine::Event using json_serde
-        debug!("received JSON event: {}", event);
+        tracing::debug!("received JSON event: {}", event);
         let event: engine::Event = serde_json::from_str(&event).map_err(|e| {
             zbus::fdo::Error::InvalidArgs(format!(
                 "invalid event: failed to parse {}",
                 e
             ))
         })?;
-        debug!("received event: {:?}", event);
         self.events.send(event).map_err(|e| {
             zbus::fdo::Error::Failed(format!("failed to queue event: {}", e))
         })?;

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -184,7 +184,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
 impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
     #[allow(clippy::too_many_lines)]
     fn event(&mut self, event: &Event) -> Result<()> {
-        tracing::info!("UI event: {:?}", event);
+        tracing::info!("UI event: {:?}", serde_json::to_string(event)?);
         match event {
             Event::Bootup => {
                 self.stop_ring(LEVEL_NOTICE, true);

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -1,3 +1,6 @@
+use std::f64::consts::PI;
+use std::time::Duration;
+
 use async_trait::async_trait;
 use eyre::Result;
 use futures::channel::mpsc;
@@ -6,12 +9,11 @@ use futures::future::Either;
 use futures::{future, StreamExt};
 use orb_messages::mcu_main::mcu_message::Message;
 use orb_messages::mcu_main::{jetson_to_mcu, JetsonToMcu};
-use pid::{InstantTimer, Timer};
-use std::f64::consts::PI;
-use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time;
 use tokio_stream::wrappers::{IntervalStream, UnboundedReceiverStream};
+
+use pid::{InstantTimer, Timer};
 
 use crate::engine::rgb::Argb;
 use crate::engine::{
@@ -184,7 +186,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
 impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
     #[allow(clippy::too_many_lines)]
     fn event(&mut self, event: &Event) -> Result<()> {
-        tracing::info!("UI event: {:?}", serde_json::to_string(event)?);
+        tracing::info!("UI event: {}", serde_json::to_string(event)?.as_str());
         match event {
             Event::Bootup => {
                 self.stop_ring(LEVEL_NOTICE, true);
@@ -777,8 +779,16 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             Event::SoundVolume { level } => {
                 self.sound.set_master_volume(*level);
             }
-            Event::SoundLanguage { lang: _lang } => {
-                // fixme
+            Event::SoundLanguage { lang } => {
+                let language = lang.clone();
+                let sound = self.sound.clone();
+                // spawn a new task because we need some async work here
+                tokio::task::spawn(async move {
+                    let language: Option<&str> = language.as_deref();
+                    if let Err(e) = sound.load_sound_files(language, true).await {
+                        tracing::error!("Error loading sound files: {:?}", e);
+                    }
+                });
             }
         }
         Ok(())


### PR DESCRIPTION
tested with UI events below, to be used with the `ui-replay` binary.

```
Apr 16 15:39:31 localhost worldcoin-ui[17338]: 2024-04-16T15:39:31.442272Z  INFO orb_ui::engine::pearl: UI event: {"SoundVolume":{"level":40}}
Apr 16 15:39:31 localhost worldcoin-ui[17338]: 2024-04-16T15:39:31.443722Z  INFO orb_ui::engine::pearl: UI event: {"SoundLanguage":{"lang":"en-US"}}
Apr 16 15:39:31 localhost worldcoin-ui[17338]: 2024-04-16T15:39:31.706397Z  INFO orb_ui::engine::pearl: UI event: {"QrScanTimeout":{"schema": "Operator"}}
Apr 16 15:39:31 localhost worldcoin-ui[17338]: 2024-04-16T15:39:31.813578Z  INFO orb_ui::engine::pearl: UI event: {"SoundVolume":{"level":40}}
Apr 16 15:39:31 localhost worldcoin-ui[17338]: 2024-04-16T15:39:31.814760Z  INFO orb_ui::engine::pearl: UI event: {"SoundLanguage":{"lang":"es-ES"}}
Apr 16 15:39:31 localhost worldcoin-ui[17338]: 2024-04-16T15:39:31.996397Z  INFO orb_ui::engine::pearl: UI event: {"QrScanTimeout":{"schema": "Operator"}}
```

fixes O-2610