### PR TITLE
mcu-util: rename to orb-mcu-util and add to CI release options

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ on:
           - orb-attest
           - orb-thermal-cam-ctrl
           - orb-ui
+          - orb-mcu-util
       channel:
         description: |
           Which release channel? 

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -116,13 +116,13 @@ jobs:
         if: ${{ matrix.platform == 'macos-13' }}
         run: |
           MAC_EXCLUDE=(
+            "--exclude can-rs"
+            "--exclude orb-mcu-util"
+            "--exclude orb-sound"
             "--exclude orb-thermal-cam-ctrl"
+            "--exclude orb-ui"
             "--exclude seek-camera"
             "--exclude seek-camera-sys"
-            "--exclude can-rs"
-            "--exclude mcu-util"
-            "--exclude orb-sound"
-            "--exclude orb-ui"
           )
           echo MAC_EXCLUDE="${MAC_EXCLUDE[*]}" >>${GITHUB_ENV}
           cat ${GITHUB_ENV}
@@ -168,9 +168,9 @@ jobs:
           uname -a
           nix develop -c env
           binaries=(
-            mcu-util
             orb-attest
             orb-backend-state
+            orb-mcu-util
             orb-slot-ctrl
             orb-thermal-cam-ctrl
             orb-ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,11 @@ change things in a backwards-incompatible way at any time!
   libc. PRs that use `libc` will be rejected if an equivalent safe function in
   `nix` exists.
 - PR names and the final squashed commit that gets merged, should start with an
-  area prefix, like `ir-camera:`. This helps disambigutate which part of the
+  area prefix, like `ir-camera:`. This helps disambiguate which part of the
   monorepo changed at a glance.
+- All first-party crates should start with the `orb-` prefix for the crate name,
+  and the crates' directories should omit this prefix. For example, the `attest`
+  dir contains the `orb-attest` crate.
 
 ## First time Setup
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2333,25 +2333,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "mcu-util"
-version = "0.7.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "can-rs",
- "clap",
- "crc32fast",
- "eyre",
- "image",
- "orb-messages",
- "prost",
- "tokio",
- "tokio-serial",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +2812,25 @@ version = "0.0.0"
 dependencies = [
  "hex",
  "url",
+]
+
+[[package]]
+name = "orb-mcu-util"
+version = "0.7.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "can-rs",
+ "clap",
+ "crc32fast",
+ "eyre",
+ "image",
+ "orb-messages",
+ "prost",
+ "tokio",
+ "tokio-serial",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/mcu-util/Cargo.toml
+++ b/mcu-util/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mcu-util"
+name = "orb-mcu-util"
 version = "0.7.0"
 authors = ["Cyril Fougeray <cyril.fougeray@toolsforhumanity.com>"]
 description = "Debug microcontrollers and manage firmware images"

--- a/mcu-util/README.md
+++ b/mcu-util/README.md
@@ -1,4 +1,4 @@
-# mcu-util
+# orb-mcu-util
 
 Utility for debugging microcontrollers and managing firmware.
 


### PR DESCRIPTION
Trying to keep our software consistently named. All crates should start with `orb-`.
This also allows us to begin creates releases for the `orb-mcu-util` component.