### PR TITLE
orb-ui: in idle, turn on unused LEDs

### DIFF
--- a/orb-ui/src/engine/operator/connection.rs
+++ b/orb-ui/src/engine/operator/connection.rs
@@ -126,12 +126,8 @@ impl Animation for Connection {
         if !idle {
             frame[3] = wlan_color * wlan_m;
             frame[2] = internet_color * internet_m;
-            frame[1] = if internet_color == color_amber {
-                color_default
-            } else {
-                internet_color
-            };
-            frame[0] = frame[1];
+            frame[1] = color_default;
+            frame[0] = color_default;
         }
         AnimationState::Running
     }


### PR DESCRIPTION
so that it doesn't look too weird, and it doesn't show 'something' as not working.

before this PR, if internet connection was missing, all the 3 last LED would turn off.

cc @dangirsh @matthewpaul 

fixes  O-2652