### PR TITLE
cargo: centralize features into workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1905,7 +1905,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -4196,18 +4196,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,20 +30,26 @@ license = "MIT OR (Apache-2.0 WITH LLVM-exception)"
 repository = "https://github.com/worldcoin/orb-software"
 rust-version = "1.77.0" # See rust-version.toml
 
+# We centralize feature flags here, because it improves build caches and helps
+# prevent edge cases where CI doesn't catch build errors due to more features
+# being present in a --all vs -p build.
 [workspace.dependencies]
-clap = "4.5"
+clap = { version = "4.5", features = ["derive"] }
 color-eyre = "0.6.2"
 eyre = "0.6.12"
 libc = "0.2.153"
-thiserror = "1"
-nix = { version = "0.28", default-features = false }
+thiserror = "1.0.60" 
+nix = { version = "0.28", default-features = false, features = [] }
 console-subscriber = "0.2"
-derive_more = { version = "0.99", default-features = false }
+derive_more = { version = "0.99", default-features = false, features = ["display", "from"] }
 futures = "0.3.30"
-serde = "1.0.197"
-tokio = { version = "1", default-features = false }
+serde = { version = "1.0.197", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 alsa-sys = "0.3.1"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+zbus = { version = "4", default-features = false, features = ["tokio"] }
 
 [workspace.dependencies.orb-messages]
 git = "https://github.com/worldcoin/orb-messages"

--- a/artificer/Cargo.toml
+++ b/artificer/Cargo.toml
@@ -13,20 +13,20 @@ rust-version.workspace = true
 [dependencies]
 build-info.path = "../build-info"
 cacache = "12"
-clap = { version = "4", features = ["derive"] }
-color-eyre = "0.6"
-derive_more = { version = "0.99", default-features = false, features = ["display", "from"] }
-futures = "0.3"
+clap.workspace = true
+color-eyre.workspace = true
+derive_more.workspace = true
+futures.workspace = true
 indicatif = { version = "0.17", features = ["tokio"] }
 octocrab = "0.32"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "stream"] }
+reqwest.workspace = true
 semver = { version = "1", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1", default-features = false, features = ["macros", "fs", "rt", "rt-multi-thread"] }
+serde.workspace = true
+tokio.workspace = true
 tokio-util = { version =  "0.7", default-features = false, features = ["compat"] } 
 toml = "0.8.8"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [build-dependencies]
 build-info = { path = "../build-info", features = ["build-script"] }

--- a/mcu-util/Cargo.toml
+++ b/mcu-util/Cargo.toml
@@ -14,13 +14,13 @@ rust-version.workspace = true
 anyhow = "1.0.79"
 async-trait = "0.1.77"
 can-rs = { path = "../can", features = ["isotp"] }
-clap = { workspace = true, features = ["derive"] }
+clap.workspace = true
 crc32fast = "1.3.2"
 color-eyre.workspace = true
 image = "0.24.8"
 orb-messages.workspace = true
 prost = "0.12.3"
-tokio = { version = "1.36.0", features = ["rt", "rt-multi-thread", "macros", "time", "io-util"] }
+tokio.workspace = true
 tokio-serial = "5.4.1"
-tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing.workspace = true
+tracing-subscriber.workspace = true

--- a/orb-attest/Cargo.toml
+++ b/orb-attest/Cargo.toml
@@ -14,21 +14,21 @@ rust-version.workspace = true
 const_format = "0.2"
 data-encoding = "2.3"
 event-listener = "*"
-eyre = "0.6"
-futures = "0.3"
+eyre.workspace = true
+futures.workspace = true
 lazy_static = "1.4"
 ring = "0.16"
 secrecy = { version = "0.8.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"]}
+serde.workspace = true
 serde_json = "~1.0"
 serde_with = { version = "3.2", features=["base64"]}
-thiserror = "1.0"
-tokio = { version = "1", features = ["full", "sync"] }
-tracing = "0.1"
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 tracing-journald = "0.3"
-tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "std"] }
+tracing-subscriber.workspace = true
 url = "2.2"
-zbus = { version = "4", default-features = false, features = ["tokio"] }
+zbus.workspace = true
 
 [dependencies.reqwest]
 version = "0.11.4"

--- a/orb-backend-state/Cargo.toml
+++ b/orb-backend-state/Cargo.toml
@@ -16,17 +16,17 @@ stage = []
 
 [dependencies]
 build-info.path = "../build-info"
-clap = { version = "4", features = ["derive"] }
-color-eyre = "0.6"
-derive_more = { workspace = true, default-features = false, features = ["display", "from"] }
-futures = "0.3"
+clap.workspace = true
+color-eyre.workspace = true
+derive_more.workspace = true
+futures.workspace = true
 header-parsing.path = "../header-parsing"
 orb-security-utils = { path = "../security-utils", features = ["reqwest"] }
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
-tokio = { version = "1", default-features = false, features = ["macros"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-zbus = { version = "4", default-features = false, features = ["tokio"] }
+reqwest.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+zbus.workspace = true
 
 [build-dependencies]
 build-info = { path = "../build-info", features = ["build-script"] }

--- a/orb-ui/Cargo.toml
+++ b/orb-ui/Cargo.toml
@@ -12,9 +12,9 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait = "0.1.74"
-clap = { workspace = true, features = ["derive"] }
+clap.workspace = true
 dashmap = "5.5.3"
-derive_more = { workspace = true, default-features = false, features = ["display", "from"] }
+derive_more.workspace = true
 eyre.workspace = true
 futures.workspace = true
 orb-messages.workspace = true
@@ -22,13 +22,13 @@ orb-uart.path = "uart"
 orb-sound.path = "sound"
 pid.path = "pid"
 prost = "0.12.3"
-serde = { workspace = true, features = ["derive"] }
+serde.workspace = true
 serde_json = "1.0.108"
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true
 tokio-stream = "0.1.14"
 tracing.workspace = true
-tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-zbus = { version = "4", default-features = false, features = ["tokio"] }
+tracing-subscriber.workspace = true
+zbus.workspace = true
 
 [target.'cfg(tokio_unstable)'.dependencies]
 console-subscriber.workspace = true

--- a/orb-ui/sound/Cargo.toml
+++ b/orb-ui/sound/Cargo.toml
@@ -19,4 +19,4 @@ tracing.workspace = true
 
 [dev-dependencies]
 color-eyre.workspace = true
-tokio = { workspace = true, features = ["full"] }
+tokio.workspace = true


### PR DESCRIPTION
Currently, CI only builds with `--all` and doesn't go build individual crates. This means that cargo features are [unified across the workspace](https://doc.rust-lang.org/cargo/reference/features.html#feature-unification).

There are two footguns with this:
* Building a crate directly with -p may reduce the set of features in use to exactly what is in that crate`s cargo.toml. This can break the build if we forgot to specify all the needed features, and we don't check that in CI.
* Changing the features on a crate likely causes the crate to need to be rebuilt. This means that all dependent crates also need to be rebuilt.

To improve both those footguns, it makes sense to just specify features on common crates directly in the workspace.