### PR TITLE
build-info: add orb prefix and improve caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 name = "artificer"
 version = "0.0.0"
 dependencies = [
- "build-info",
  "cacache",
  "clap",
  "color-eyre",
@@ -200,6 +199,7 @@ dependencies = [
  "futures",
  "indicatif",
  "octocrab",
+ "orb-build-info",
  "reqwest",
  "semver",
  "serde",
@@ -641,21 +641,6 @@ dependencies = [
  "futures-lite 2.2.0",
  "piper",
  "tracing",
-]
-
-[[package]]
-name = "build-info"
-version = "0.0.0"
-dependencies = [
- "build-info-helper",
- "color-eyre",
-]
-
-[[package]]
-name = "build-info-helper"
-version = "0.0.0"
-dependencies = [
- "color-eyre",
 ]
 
 [[package]]
@@ -2792,18 +2777,33 @@ dependencies = [
 name = "orb-backend-state"
 version = "0.0.4"
 dependencies = [
- "build-info",
  "clap",
  "color-eyre",
  "derive_more",
  "futures",
  "header-parsing",
+ "orb-build-info",
  "orb-security-utils",
  "reqwest",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "zbus",
+]
+
+[[package]]
+name = "orb-build-info"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "orb-build-info-helper",
+]
+
+[[package]]
+name = "orb-build-info-helper"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
 ]
 
 [[package]]
@@ -2871,6 +2871,7 @@ dependencies = [
  "clap",
  "eyre",
  "libc",
+ "orb-build-info",
  "thiserror",
 ]
 
@@ -2892,12 +2893,12 @@ dependencies = [
 name = "orb-thermal-cam-ctrl"
 version = "0.0.5"
 dependencies = [
- "build-info",
  "bytemuck",
  "clap",
  "color-eyre",
  "eyre",
  "indicatif",
+ "orb-build-info",
  "owo-colors",
  "png",
  "seek-camera",
@@ -4747,8 +4748,8 @@ dependencies = [
 name = "verity-tree-calc"
 version = "0.0.4"
 dependencies = [
- "build-info",
  "clap",
+ "orb-build-info",
  "tracing",
  "tracing-subscriber",
 ]

--- a/artificer/Cargo.toml
+++ b/artificer/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-build-info.path = "../build-info"
+orb-build-info.path = "../build-info"
 cacache = "12"
 clap.workspace = true
 color-eyre.workspace = true
@@ -29,4 +29,4 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [build-dependencies]
-build-info = { path = "../build-info", features = ["build-script"] }
+orb-build-info = { path = "../build-info", features = ["build-script"] }

--- a/artificer/build.rs
+++ b/artificer/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    build_info::initialize().expect("failed to initialize build info")
+    orb_build_info::initialize().expect("failed to initialize build info")
 }

--- a/artificer/src/main.rs
+++ b/artificer/src/main.rs
@@ -1,6 +1,6 @@
-use build_info::{make_build_info, BuildInfo};
 use clap::Parser;
 use color_eyre::Result;
+use orb_build_info::{make_build_info, BuildInfo};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;

--- a/build-info/Cargo.toml
+++ b/build-info/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "build-info"
+name = "orb-build-info"
 version = "0.0.0"
 description = "Detects build information, makes it available for use"
 authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
@@ -11,11 +11,11 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-build-script = ["dep:build-info-helper"]
+build-script = ["dep:orb-build-info-helper"]
 
 [dependencies]
-build-info-helper = { path = "helper", optional = true }
+orb-build-info-helper = { path = "helper", optional = true }
 
 [build-dependencies]
-build-info-helper.path = "helper"
+orb-build-info-helper.path = "helper"
 color-eyre = "0.6"

--- a/build-info/build.rs
+++ b/build-info/build.rs
@@ -1,3 +1,0 @@
-fn main() -> color_eyre::Result<()> {
-    build_info_helper::initialize()
-}

--- a/build-info/helper/Cargo.toml
+++ b/build-info/helper/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "build-info-helper"
+name = "orb-build-info-helper"
 version = "0.0.0"
 description = "Detects build information, makes it available for use"
 authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]

--- a/build-info/helper/src/lib.rs
+++ b/build-info/helper/src/lib.rs
@@ -1,13 +1,17 @@
 use color_eyre::{eyre::WrapErr, Help, Result};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 // Must be the same as the one in lib.rs
 const ENV_PREFIX: &str = "WORLDCOIN_BUILD_INFO_";
 
 /// Call this from within your build script.
 pub fn initialize() -> Result<()> {
-    color_eyre::install()?;
-    println!("cargo:rerun-if-changed=.git/HEAD");
+    color_eyre::install().ok();
+    let git_head_path = workspace_dir().join(".git").join("HEAD");
+    println!("cargo:rerun-if-changed={}", git_head_path.display());
 
     let git_describe = read_env("GIT_DESCRIBE").unwrap_or(
         std::str::from_utf8(
@@ -40,4 +44,18 @@ fn read_env(var: &str) -> Option<String> {
 
 fn set_env(var: &str, value: &str) {
     println!("cargo:rustc-env={ENV_PREFIX}{var}={value}");
+}
+
+// https://stackoverflow.com/a/74942075
+fn workspace_dir() -> PathBuf {
+    let output = std::process::Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let workpace_cargo_toml_path =
+        Path::new(std::str::from_utf8(&output).unwrap().trim());
+    workpace_cargo_toml_path.parent().unwrap().to_path_buf()
 }

--- a/build-info/src/lib.rs
+++ b/build-info/src/lib.rs
@@ -3,7 +3,7 @@
 #![forbid(unsafe_code)]
 
 #[cfg(feature = "build-script")]
-pub use build_info_helper::*;
+pub use orb_build_info_helper::*;
 
 // Must be the same as the one in build.rs
 #[macro_export]

--- a/orb-backend-state/Cargo.toml
+++ b/orb-backend-state/Cargo.toml
@@ -15,18 +15,18 @@ default = ["stage"]
 stage = []
 
 [dependencies]
-build-info.path = "../build-info"
 clap.workspace = true
 color-eyre.workspace = true
 derive_more.workspace = true
 futures.workspace = true
 header-parsing.path = "../header-parsing"
+orb-build-info.path = "../build-info"
 orb-security-utils = { path = "../security-utils", features = ["reqwest"] }
 reqwest.workspace = true
 tokio.workspace = true
-tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing.workspace = true
 zbus.workspace = true
 
 [build-dependencies]
-build-info = { path = "../build-info", features = ["build-script"] }
+orb-build-info = { path = "../build-info", features = ["build-script"] }

--- a/orb-backend-state/build.rs
+++ b/orb-backend-state/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    build_info::initialize().expect("failed to initialize build info")
+    orb_build_info::initialize().expect("failed to initialize build info")
 }

--- a/orb-backend-state/src/main.rs
+++ b/orb-backend-state/src/main.rs
@@ -8,12 +8,12 @@ mod state;
 
 use std::time::{Duration, Instant};
 
-use build_info::{make_build_info, BuildInfo};
 use clap::Parser;
 use color_eyre::eyre::bail;
 use color_eyre::{eyre::WrapErr, Result};
 use context::Context;
 use futures::FutureExt;
+use orb_build_info::{make_build_info, BuildInfo};
 use tokio::{select, sync::watch};
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 use zbus::export::futures_util::StreamExt;

--- a/orb-slot-ctrl/Cargo.toml
+++ b/orb-slot-ctrl/Cargo.toml
@@ -16,7 +16,8 @@ rust-version.workspace = true
 clap = { workspace = true, features = ["derive"] }
 eyre.workspace = true
 libc.workspace = true
+orb-build-info.path = "../build-info"
 thiserror.workspace = true
 
 [build-dependencies]
-eyre.workspace = true
+orb-build-info = { path = "../build-info", features = ["build-script"] }

--- a/orb-slot-ctrl/build.rs
+++ b/orb-slot-ctrl/build.rs
@@ -1,25 +1,3 @@
-#![warn(clippy::pedantic)]
-
-use std::{fs, path::Path, process::Command, str};
-
-fn main() -> eyre::Result<()> {
-    // Save git commit hash at compile-time as environment variable
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    let git_commit = Path::new("git_commit");
-    let git_commit = if git_commit.exists() {
-        fs::read_to_string(git_commit).expect("failed to read git_commit")
-    } else {
-        str::from_utf8(
-            &Command::new("git")
-                .arg("describe")
-                .arg("--always")
-                .arg("--dirty=-modified")
-                .output()?
-                .stdout,
-        )?
-        .trim_end()
-        .to_string()
-    };
-    println!("cargo:rustc-env=GIT_COMMIT={git_commit:0>4}");
-    Ok(())
+fn main() {
+    orb_build_info::initialize().unwrap()
 }

--- a/orb-slot-ctrl/src/main.rs
+++ b/orb-slot-ctrl/src/main.rs
@@ -1,6 +1,10 @@
 use clap::{Parser, Subcommand};
 use std::{env, process::exit};
 
+use orb_build_info::{make_build_info, BuildInfo};
+
+const BUILD_INFO: BuildInfo = make_build_info!();
+
 #[derive(Parser)]
 #[command(
     author,
@@ -33,7 +37,7 @@ enum Commands {
     },
     /// Get the git commit used for this build.
     #[command(name = "git", short_flag = 'g')]
-    GitCommit,
+    GitDescribe,
 }
 
 #[derive(Subcommand)]
@@ -192,8 +196,8 @@ fn main() -> eyre::Result<()> {
                 }
             }
         }
-        Commands::GitCommit => {
-            println!("{}", env!("GIT_COMMIT"));
+        Commands::GitDescribe => {
+            println!("{}", BUILD_INFO.git.describe);
         }
     }
     Ok(())

--- a/orb-thermal-cam-ctrl/Cargo.toml
+++ b/orb-thermal-cam-ctrl/Cargo.toml
@@ -11,16 +11,16 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-build-info.path = "../build-info"
 bytemuck = { version = "1.13.1", features = ["derive"] }
 clap = { version = "4.3", features = ["derive"] }
 color-eyre = "0.6.2"
 eyre = "0.6"
 indicatif = "0.17"
+orb-build-info.path = "../build-info"
 owo-colors = "3"
 png = "0.17"
 seek-camera.path = "../seek-camera/wrapper"
 
 [build-dependencies]
-build-info = { path = "../build-info", features = ["build-script"] }
+orb-build-info = { path = "../build-info", features = ["build-script"] }
 color-eyre = "0.6.2"

--- a/orb-thermal-cam-ctrl/build.rs
+++ b/orb-thermal-cam-ctrl/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    build_info::initialize().expect("failed to initialize build info")
+    orb_build_info::initialize().expect("failed to initialize build info")
 }

--- a/orb-thermal-cam-ctrl/src/main.rs
+++ b/orb-thermal-cam-ctrl/src/main.rs
@@ -10,7 +10,6 @@ use std::{
     sync::{mpsc, OnceLock},
 };
 
-use build_info::{make_build_info, BuildInfo};
 use clap::{
     builder::{styling::AnsiColor, Styles},
     Parser, Subcommand,
@@ -19,6 +18,7 @@ use color_eyre::{
     eyre::{eyre, WrapErr},
     Help, Result,
 };
+use orb_build_info::{make_build_info, BuildInfo};
 use owo_colors::{AnsiColors, OwoColorize};
 use seek_camera::{
     manager::{CameraHandle, Event, Manager},

--- a/verity-tree-calc/Cargo.toml
+++ b/verity-tree-calc/Cargo.toml
@@ -11,10 +11,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-build-info.path = "../build-info"
 clap = { version = "4", features = ["derive"] }
+orb-build-info.path = "../build-info"
 tracing = "0.1.0"
 tracing-subscriber = "0.3"
 
 [build-dependencies]
-build-info = { path = "../build-info", features = ["build-script"] }
+orb-build-info = { path = "../build-info", features = ["build-script"] }

--- a/verity-tree-calc/build.rs
+++ b/verity-tree-calc/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    build_info::initialize().expect("failed to initialize build info")
+    orb_build_info::initialize().expect("failed to initialize build info")
 }

--- a/verity-tree-calc/src/main.rs
+++ b/verity-tree-calc/src/main.rs
@@ -2,8 +2,8 @@
 
 use std::io::{self, Write};
 
-use build_info::{make_build_info, BuildInfo};
 use clap::Parser;
+use orb_build_info::{make_build_info, BuildInfo};
 use tracing::debug;
 
 // TODO @oldgalileo document the math and magic consts


### PR DESCRIPTION
* fixes a bug in build-info that caused it to always rebuild.
* makes orb-slot-ctrl use build-info.
* renames the crate to orb-build-info