### PR TITLE
ci: autodetect cargo deb crates

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -167,17 +167,8 @@ jobs:
           set -Eeuxo pipefail
           uname -a
           nix develop -c env
-          binaries=(
-            orb-attest
-            orb-backend-state
-            orb-mcu-util
-            orb-slot-ctrl
-            orb-thermal-cam-ctrl
-            orb-ui
-            verity-tree-calc
-          )
           nix develop -c scripts/build_rust_artifacts.py \
-            binaries ${CI_PROFILE} ${binaries[@]}
+            --out_dir binaries --cargo_profile ${CI_PROFILE}
           ls -aRsh binaries
 
       - name: Bundle artifacts

--- a/scripts/build_rust_artifacts.py
+++ b/scripts/build_rust_artifacts.py
@@ -7,52 +7,87 @@ import os
 import shlex
 
 
-def cmd(command):
+def run(command):
     assert isinstance(command, str)
-    # This allows us to avoid manually splitting strings into arguments
-    command = shlex.split(command)
-    print(f"Running: {' '.join(command)}")
-    subprocess.check_call(command)
+    print(f"Running: {command}")
+    exit_code = subprocess.check_call(command, shell=True, text=True)
+    assert exit_code == 0
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Builds rust artifacts for CI")
-    parser.add_argument("out_dir", help="Output directory for artifacts")
-    parser.add_argument(
-        "cargo_profile", help="Cargo profile to use for compiling the crates"
+def run_with_stdout(command):
+    assert isinstance(command, str)
+    print(f"Running: {command}")
+    cmd_output = subprocess.check_output(command, shell=True, text=True)
+    return cmd_output
+
+
+def find_cargo_deb_crates():
+    jq_query = (
+        ".workspace_members[] as $wm "
+        "| .packages[ ] "
+        "| .id as $id "
+        "| select( $wm | contains($id)) "
+        '| select( .metadata | has("deb")) '
+        "| .name"
     )
-    parser.add_argument("crates", nargs="+", help="List of crate names to be processed")
+    command = f"cargo metadata --format-version=1 | jq '{jq_query}'"
+    cmd_output = subprocess.check_output(command, shell=True, text=True)
+    crates = [c.strip('"') for c in cmd_output.strip().split("\n")]
+    return crates
 
-    args = parser.parse_args()
 
-    targets = ["aarch64", "x86_64"]
-
+def build_all_crates(*, cargo_profile, targets):
     targets_option = " ".join([f"--target {t}-unknown-linux-gnu" for t in targets])
-    print(f"TARGETS={targets_option}")
-
-    cmd(
+    run(
         f"cargo zigbuild --all "
-        f"--profile {args.cargo_profile} "
+        f"--profile {cargo_profile} "
         f"{targets_option} "
         f"--no-default-features"
     )
 
-    for b in args.crates:
-        os.makedirs(os.path.join(args.out_dir, b), exist_ok=True)
-        print(f"Creating .deb package for {b}:")
+
+def run_cargo_deb(*, out_dir, cargo_profile, targets, crates):
+    for c in crates:
+        os.makedirs(os.path.join(out_dir, c), exist_ok=True)
+        print(f"Creating .deb package for {c}:")
         for t in targets:
-            cmd(
+            run(
                 f"cargo deb --no-build --no-strip "
-                f"--profile {args.cargo_profile} "
-                f"-p {b} "
+                f"--profile {cargo_profile} "
+                f"-p {c} "
                 f"--target {t}-unknown-linux-gnu "
-                f"-o {args.out_dir}/{b}/{b}_{t}.deb"
+                f"-o {out_dir}/{c}/{c}_{t}.deb"
             )
-            cmd(
+            run(
                 f"cp -L "
-                f"target/{t}-unknown-linux-gnu/{args.cargo_profile}/{b} "
-                f"{args.out_dir}/{b}/{b}_{t}"
+                f"target/{t}-unknown-linux-gnu/{cargo_profile}/{c} "
+                f"{out_dir}/{c}/{c}_{t}"
             )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Builds rust artifacts for CI")
+    parser.add_argument(
+        "--out_dir", required=True, help="Output directory for artifacts"
+    )
+    parser.add_argument(
+        "--cargo_profile",
+        required=True,
+        help="Cargo profile to use for compiling the crates",
+    )
+    args = parser.parse_args()
+
+    targets = ["aarch64", "x86_64"]
+    print("building all crates")
+    build_all_crates(cargo_profile=args.cargo_profile, targets=targets)
+    deb_crates = find_cargo_deb_crates()
+    print(f"Running cargo deb for: {deb_crates}")
+    run_cargo_deb(
+        out_dir=args.out_dir,
+        cargo_profile=args.cargo_profile,
+        targets=targets,
+        crates=deb_crates,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Lets us stop having to manually write out the list of binaries. Also will allow us to reuse this workflow in orb-internal, since it is no longer specific to this repo.

Also seeking opinions: Would it be better for me to keep the json parsing in jq, or do you want me to port it to native python?