### PR TITLE
ci: generalize MAC_EXCLUDE

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -113,25 +113,20 @@ jobs:
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2
 
       - name: Configure cargo to exclude platform-specific crates
-        if: ${{ matrix.platform == 'macos-13' }}
         run: |
-          MAC_EXCLUDE=(
-            "--exclude can-rs"
-            "--exclude orb-mcu-util"
-            "--exclude orb-sound"
-            "--exclude orb-thermal-cam-ctrl"
-            "--exclude orb-ui"
-            "--exclude seek-camera"
-            "--exclude seek-camera-sys"
-          )
-          echo MAC_EXCLUDE="${MAC_EXCLUDE[*]}" >>${GITHUB_ENV}
+          tmp=($(scripts/get_excludes.py))
+          EXCLUDES=""
+          for e in ${tmp[@]}; do
+            EXCLUDES+="--exclude ${e} "
+          done
+          echo EXCLUDES="${EXCLUDES}" >>${GITHUB_ENV}
           cat ${GITHUB_ENV}
       - name: Cargo Test
         run: |
           uname -a
           nix develop -c env
           nix develop -c \
-            cargo test --all --all-features --all-targets $MAC_EXCLUDE
+            cargo test --all --all-features --all-targets $EXCLUDES
 
   build:
     name: Build

--- a/can/Cargo.toml
+++ b/can/Cargo.toml
@@ -23,3 +23,9 @@ thiserror.workspace = true
 
 [features]
 isotp = []
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]

--- a/mcu-util/Cargo.toml
+++ b/mcu-util/Cargo.toml
@@ -24,3 +24,9 @@ tokio.workspace = true
 tokio-serial = "5.4.1"
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]

--- a/orb-thermal-cam-ctrl/Cargo.toml
+++ b/orb-thermal-cam-ctrl/Cargo.toml
@@ -24,3 +24,9 @@ seek-camera.path = "../seek-camera/wrapper"
 [build-dependencies]
 orb-build-info = { path = "../build-info", features = ["build-script"] }
 color-eyre = "0.6.2"
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]

--- a/orb-ui/Cargo.toml
+++ b/orb-ui/Cargo.toml
@@ -49,3 +49,9 @@ maintainer-scripts = "debian/"
 systemd-units = [
   { unit-name = "worldcoin-ui" },
 ]
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]

--- a/orb-ui/sound/Cargo.toml
+++ b/orb-ui/sound/Cargo.toml
@@ -20,3 +20,9 @@ tracing.workspace = true
 [dev-dependencies]
 color-eyre.workspace = true
 tokio.workspace = true
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]

--- a/scripts/get_excludes.py
+++ b/scripts/get_excludes.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+
+import argparse
+import subprocess
+import sys
+import os
+import shlex
+
+
+def run_with_stdout(command):
+    assert isinstance(command, str)
+    print(f"Running: {command}", file=sys.stderr)
+    cmd_output = subprocess.check_output(command, shell=True, text=True)
+    return cmd_output
+
+
+def get_target_triple():
+    cmd_output = run_with_stdout("rustc -vV").strip().split("\n")
+    for s in cmd_output:
+        if s.startswith("host:"):
+            return s.split(" ")[1]
+    raise Exception("no target triple detected")
+
+
+def main():
+    target = get_target_triple()
+    print(f"identified target triple as: {target}", file=sys.stderr)
+    jq_query = (
+        ".workspace_members[] as $wm"
+        "| .packages[ ] "
+        "| .id as $id "
+        "| select( $wm | contains($id)) "
+        "| .name as $n "
+        "| select (.metadata.orb.unsupported_targets "
+        f'| index("{target}") != null) | .name'
+    )
+
+    command = f"cargo metadata --format-version=1 | jq -r '{jq_query}'"
+    cmd_output = run_with_stdout(command).strip()
+    print(cmd_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/seek-camera/sys/Cargo.toml
+++ b/seek-camera/sys/Cargo.toml
@@ -16,3 +16,9 @@ rust-version.workspace = true
 bindgen = "0.69"
 color-eyre = "0.6"
 convert_case = "0.6"
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]

--- a/seek-camera/wrapper/Cargo.toml
+++ b/seek-camera/wrapper/Cargo.toml
@@ -20,3 +20,9 @@ thiserror = "1"
 [dev-dependencies]
 rusty-fork = "0.3"
 tempfile = "3.9"
+
+[package.metadata.orb]
+unsupported_targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+]


### PR DESCRIPTION
In order to reuse rust-ci.yaml, we need to automatically exclude crates that don't work on various platforms, without manually specifying them in CI.

To do this, I first introduced a custom metadata section for first party crates under [package.metadata.orb]. This can be used going forward as a place to put custom metadata for our crates that cargo subcommands and CI can inspect.

Next, I added a custom field under it called `unsupported_targets`, which lists out any of the target triples that CI runs that the crate is known to be incompatible with. 

Finally, I created a script to parse this data with jq and then call it in CI to get the crate exclusions for the current host architecture.