### PR TITLE
ci: pass secrets to workflow_call

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -2,6 +2,12 @@ name: Python CI
 on:
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      GIT_HUB_TOKEN:
+        required: true
+      CACHIX_AUTH_TOKEN:
+        required: false
   push:
     branches:
       - main
@@ -25,6 +31,10 @@ jobs:
         with:
           name: worldcoin
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Print environment
+        run: |
+          uname -a
+          nix develop -c env
 
       - name: Check Python formatting
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -107,6 +107,7 @@ jobs:
     needs: check-inputs
     secrets:
       GIT_HUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   release:
     name: Create Release and Tag


### PR DESCRIPTION
Previously when we invoked rust-ci as a reusable workflow, the secrets weren't getting passed. This also adds a workflow_call to the python-ci.