### PR TITLE
nix: switch to nixpkgs-23.11

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -62,6 +62,8 @@ jobs:
         run: git config --global url."https://${{ secrets.GIT_HUB_TOKEN }}@github.com".insteadOf https://github.com
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2
+        with:
+          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
       - name: Print environment
         run: |
           uname -a
@@ -91,6 +93,8 @@ jobs:
         run: git config --global url."https://${{ secrets.GIT_HUB_TOKEN }}@github.com".insteadOf https://github.com
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2
+        with:
+          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
       - name: Print environment
         run: |
           uname -a
@@ -123,6 +127,8 @@ jobs:
         run: git config --global url."https://${{ secrets.GIT_HUB_TOKEN }}@github.com".insteadOf https://github.com
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2
+        with:
+          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
       - name: Print environment
         run: |
           uname -a
@@ -161,6 +167,8 @@ jobs:
         run: git config --global url."https://${{ secrets.GIT_HUB_TOKEN }}@github.com".insteadOf https://github.com
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2
+        with:
+          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
       - name: Print environment
         run: |
           uname -a

--- a/flake.lock
+++ b/flake.lock
@@ -23,16 +23,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711333969,
-        "narHash": "sha256-5PiWGn10DQjMZee5NXzeA6ccsv60iLu+Xtw+mfvkUAs=",
+        "lastModified": 1716633019,
+        "narHash": "sha256-xim1b5/HZYbWaZKyI7cn9TJCM6ewNVZnesRr00mXeS4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57e6b3a9e4ebec5aa121188301f04a6b8c354c9b",
+        "rev": "9d29cd266cebf80234c98dd0b87256b6be0af44e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "orb-software flake";
   inputs = {
     # Worlds largest repository of linux software
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     # Provides eachDefaultSystem and other utility functions
     utils.url = "github:numtide/flake-utils";
     # Replacement for rustup


### PR DESCRIPTION
one thing to note: this will change the versions of any dynamically linked deps. But It should not matter for this repo AFAICT.

I've also keyed the rust cache on the flake.{nix,lock}. Because I found that the cache was stale. Note: If we used nix build in CI (which I was originally opposed to), this would have been a non-issue.
