### PR TITLE
docs: Make SEEK_SDK_OVERRIDE more consistent across documentation and…

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,5 +1,5 @@
-# VENDORED_SEEK_PATH=~/P/wc/seek-thermal-sdk
-# use flake --override-input seekSdk $VENDORED_SEEK_PATH
+# FLAKE_OVERRIDE_SEEK_SDK=~/P/wc/seek-thermal-sdk
+# use flake --override-input seekSdk $FLAKE_OVERRIDE_SEEK_SDK
 use flake
 
 # export CACHIX_AUTH_TOKEN=<TOKEN>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,9 +87,9 @@ probably don't have your personal access token set up right - post in
 2. Download the 4.1.0.0 version of the SDK (its in the developer forums).
 3. Extract its contents, and note down the dir that *contains* the
 `Seek_Thermal_SDK_4.1.0.0` dir. Save this in an environment variable of your
-choice, such as `SEEK_SDK_OVERRIDE`.
+choice, such as `FLAKE_OVERRIDE_SEEK_SDK`.
 4. modify your `.envrc` like this: `use flake --override-input seekSdk
-"$SEEK_SDK_OVERRIDE"`
+"$FLAKE_OVERRIDE_SEEK_SDK"`
 
 ## Building
 


### PR DESCRIPTION
When setting up repo https://github.com/worldcoin/orb-software/blob/main/CONTRIBUTING.md tells you to set SEEK_SDK_OVERRIDE in .envrc.example in which VENDORED_SEEK_PATH is used.

Also seek-camera will ignore both VENDORED_SEEK_PATH/SEEK_SDK_OVERRIDE. 

Not a big change but improves onboarding process a bit.