### PR TITLE
mcu-interface: add example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,11 +2905,13 @@ dependencies = [
  "async-trait",
  "can-rs",
  "color-eyre",
+ "futures",
  "orb-messages",
  "prost",
  "tokio",
  "tokio-serial",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/mcu-interface/Cargo.toml
+++ b/mcu-interface/Cargo.toml
@@ -25,3 +25,7 @@ unsupported_targets = [
   "aarch64-apple-darwin",
   "x86_64-apple-darwin",
 ]
+
+[dev-dependencies]
+tracing-subscriber.workspace = true
+futures.workspace = true

--- a/mcu-interface/examples/log_messages.rs
+++ b/mcu-interface/examples/log_messages.rs
@@ -1,0 +1,38 @@
+#![forbid(unsafe_code)]
+use color_eyre::{eyre::WrapErr as _, Result};
+use futures::FutureExt;
+use orb_mcu_interface::{can::canfd::CanRawMessaging, Device};
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+    layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let (msg_tx, msg_rx) = std::sync::mpsc::channel();
+    let _iface = CanRawMessaging::new(String::from("can0"), Device::Security, msg_tx)
+        .wrap_err("failed to create messaging interface")?;
+
+    let msg_task = tokio::task::spawn_blocking(move || {
+        while let Ok(msg) = msg_rx.recv() {
+            println!("{msg:?}");
+        }
+    })
+    .map(|err| err.wrap_err("message task terminated unexpectedly"));
+
+    tokio::select! {
+        result = msg_task => result,
+        result = tokio::signal::ctrl_c() => { println!("ctrl-c detected"); result.wrap_err("failed to listen for ctrl-c")}
+
+    }
+}


### PR DESCRIPTION
This adds an example of how to use `orb-mcu-interface`.

It also serves as a way to demonstrate that the current implementation is bugged - terminating `main` does not terminate the can_rx blocking task.