### PR TITLE
orb-attest: full path to orb-mcu-util

### DIFF
--- a/orb-attest/src/remote_api.rs
+++ b/orb-attest/src/remote_api.rs
@@ -120,7 +120,7 @@ fn format_secret(val: &str) -> String {
 }
 
 fn powercycle_security_mcu() -> std::io::Result<()> {
-    Command::new("orb-mcu-util")
+    Command::new("/usr/bin/orb-mcu-util")
         .arg("reboot")
         .arg("security")
         .output()?;


### PR DESCRIPTION
more secure to prevent remote code execution
