### PR TITLE
mcu-interface: fix blocking, add kill for can_rx task, fix ack

### DIFF
--- a/mcu-interface/Cargo.toml
+++ b/mcu-interface/Cargo.toml
@@ -19,6 +19,7 @@ prost = "0.12.3"
 tokio.workspace = true
 tokio-serial = "5.4.1"
 tracing.workspace = true
+futures.workspace = true
 
 [package.metadata.orb]
 unsupported_targets = [

--- a/mcu-interface/examples/log_messages.rs
+++ b/mcu-interface/examples/log_messages.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    let (msg_tx, mut msg_rx) = tokio::sync::mpsc::channel(10);
+    let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel();
     let _iface = CanRawMessaging::new(String::from("can0"), Device::Security, msg_tx)
         .wrap_err("failed to create messaging interface")?;
 

--- a/mcu-interface/src/can/canfd.rs
+++ b/mcu-interface/src/can/canfd.rs
@@ -35,7 +35,7 @@ impl CanRawMessaging {
     pub fn new(
         bus: String,
         can_node: Device,
-        new_message_queue: mpsc::Sender<McuPayload>,
+        new_message_queue: mpsc::UnboundedSender<McuPayload>,
     ) -> Result<Self> {
         // open socket
         let stream = FrameStream::<CANFD_DATA_LEN>::build()
@@ -116,7 +116,7 @@ fn can_rx(
     stream: FrameStream<CANFD_DATA_LEN>,
     remote_node: Device,
     ack_tx: mpsc::UnboundedSender<(CommonAckError, u32)>,
-    new_message_queue: mpsc::Sender<McuPayload>,
+    new_message_queue: mpsc::UnboundedSender<McuPayload>,
     mut kill_rx: oneshot::Receiver<()>,
 ) -> Result<()> {
     loop {

--- a/mcu-interface/src/can/canfd.rs
+++ b/mcu-interface/src/can/canfd.rs
@@ -18,7 +18,7 @@ use crate::{
     MessagingInterface,
 };
 
-use super::RX_TIMEOUT;
+use super::ACK_RX_TIMEOUT;
 
 pub struct CanRawMessaging {
     stream: FrameStream<CANFD_DATA_LEN>,
@@ -79,7 +79,7 @@ impl CanRawMessaging {
 
             Err(eyre!("ack queue closed"))
         };
-        timeout(RX_TIMEOUT, recv_fut)
+        timeout(ACK_RX_TIMEOUT, recv_fut)
             .map(|result| result?)
             .await
             .wrap_err("ack not received (raw)")

--- a/mcu-interface/src/can/isotp.rs
+++ b/mcu-interface/src/can/isotp.rs
@@ -1,21 +1,24 @@
 use async_trait::async_trait;
 use color_eyre::eyre::{eyre, Context, Result};
+use futures::FutureExt as _;
 use orb_messages::CommonAckError;
 use prost::Message;
 use std::io::{Read, Write};
-use std::process;
 use std::sync::atomic::{AtomicU16, Ordering};
-use std::sync::mpsc;
-use tokio::time::Duration;
-use tracing::{debug, error};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::timeout;
+use tracing::{debug, error, trace};
 
 use can_rs::isotp::addr::CanIsotpAddr;
 use can_rs::isotp::stream::IsotpStream;
 use can_rs::{Id, CAN_DATA_LEN};
 
 use crate::{
-    handle_main_mcu_message, handle_sec_mcu_message, McuPayload, MessagingInterface,
+    create_ack, handle_main_mcu_message, handle_sec_mcu_message, McuPayload,
+    MessagingInterface,
 };
+
+use super::RX_TIMEOUT;
 
 /// ISO-TP addressing scheme
 /// 11-bit standard ID
@@ -69,7 +72,8 @@ impl From<u8> for IsoTpNodeIdentifier {
 pub struct CanIsoTpMessaging {
     stream: IsotpStream<CAN_DATA_LEN>,
     ack_num_lsb: AtomicU16,
-    ack_queue: mpsc::Receiver<(CommonAckError, u32)>,
+    ack_queue: mpsc::UnboundedReceiver<(CommonAckError, u32)>,
+    _kill_tx: oneshot::Sender<()>,
 }
 
 /// Create ISO-TP pair of addresses, based on our addressing scheme
@@ -113,49 +117,58 @@ impl CanIsoTpMessaging {
             )
             .wrap_err("Failed to bind CAN ISO-TP stream")?;
 
-        let (ack_tx, ack_rx) = mpsc::channel();
-
+        let (ack_tx, ack_rx) = mpsc::unbounded_channel();
+        let (kill_tx, kill_rx) = oneshot::channel();
         // spawn CAN receiver
         tokio::task::spawn_blocking(move || {
-            can_rx(bus, remote, local, ack_tx, new_message_queue)
+            can_rx(bus, remote, local, ack_tx, new_message_queue, kill_rx)
         });
 
         Ok(CanIsoTpMessaging {
             stream: tx_isotp_stream,
             ack_num_lsb: AtomicU16::new(0),
             ack_queue: ack_rx,
+            _kill_tx: kill_tx,
         })
     }
 
     async fn wait_ack(&mut self, expected_ack_number: u32) -> Result<CommonAckError> {
-        loop {
-            match self.ack_queue.recv_timeout(Duration::from_millis(1500)) {
-                Ok((ack, number)) => {
-                    if number == expected_ack_number {
-                        return Ok(ack);
-                    }
-                }
-                Err(e) => {
-                    return Err(eyre!("ack not received (isotp): {}", e));
+        let recv_fut = async {
+            while let Some((ack, number)) = self.ack_queue.recv().await {
+                if number == expected_ack_number {
+                    return Ok(ack);
                 }
             }
-        }
+
+            Err(eyre!("ack queue closed"))
+        };
+        timeout(RX_TIMEOUT, recv_fut)
+            .map(|result| result?)
+            .await
+            .wrap_err("ack not received (isotp)")
     }
 
-    async fn send_wait_ack(&mut self, frame: Vec<u8>) -> Result<CommonAckError> {
+    async fn send_wait_ack(
+        &mut self,
+        frame: Vec<u8>,
+        ack_number: u32,
+    ) -> Result<CommonAckError> {
         let mut stream = self.stream.try_clone()?;
-        tokio::task::spawn_blocking(move || {
-            if let Err(e) = stream.write(frame.as_slice()) {
-                error!("Error writing stream: {}", e);
-            }
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let bytes = frame.as_slice();
+            let nbytes_written = stream
+                .write(bytes)
+                .wrap_err("error while writing to isotp stream")?;
+            trace!(
+                "wrote {nbytes_written} bytes, for frame of length {}",
+                frame.len()
+            );
+            Ok(())
         })
-        .await?;
+        .await
+        .wrap_err("send_wait_ack task panicked")??;
 
-        let expected_ack_number =
-            process::id() << 16 | self.ack_num_lsb.load(Ordering::Relaxed) as u32;
-        self.ack_num_lsb.fetch_add(1, Ordering::Relaxed);
-
-        self.wait_ack(expected_ack_number).await
+        self.wait_ack(ack_number).await
     }
 }
 
@@ -166,8 +179,9 @@ fn can_rx(
     bus: String,
     remote: IsoTpNodeIdentifier,
     local: IsoTpNodeIdentifier,
-    ack_tx: mpsc::Sender<(CommonAckError, u32)>,
+    ack_tx: mpsc::UnboundedSender<(CommonAckError, u32)>,
     new_message_queue: mpsc::Sender<McuPayload>,
+    mut kill_rx: oneshot::Receiver<()>,
 ) -> Result<()> {
     // rx messages <=> from remote to local
     let (rx_stdid_src, rx_stdid_dest) = create_pair(remote, local)?;
@@ -184,6 +198,14 @@ fn can_rx(
 
     loop {
         let mut buffer = [0; 1024];
+
+        // terminate task on kill signal
+        use tokio::sync::oneshot::error::TryRecvError;
+        match kill_rx.try_recv() {
+            Ok(()) | Err(TryRecvError::Closed) => return Ok(()),
+            Err(oneshot::error::TryRecvError::Empty) => (),
+        }
+
         let buffer = match rx_isotp_stream.read(&mut buffer) {
             Ok(_) => buffer,
             Err(e) => {
@@ -223,8 +245,7 @@ impl MessagingInterface for CanIsoTpMessaging {
     /// Send payload into McuMessage
     /// One could decide to only listen for ISO-TP message so allow dead code for `send` method
     async fn send(&mut self, payload: McuPayload) -> Result<CommonAckError> {
-        let ack_number =
-            process::id() << 16 | self.ack_num_lsb.load(Ordering::Relaxed) as u32;
+        let ack_number = create_ack(self.ack_num_lsb.fetch_add(1, Ordering::SeqCst));
 
         let bytes = match payload {
             McuPayload::ToMain(p) => {
@@ -258,6 +279,6 @@ impl MessagingInterface for CanIsoTpMessaging {
             _ => return Err(eyre!("Invalid payload")),
         };
 
-        self.send_wait_ack(bytes).await
+        self.send_wait_ack(bytes, ack_number).await
     }
 }

--- a/mcu-interface/src/can/isotp.rs
+++ b/mcu-interface/src/can/isotp.rs
@@ -18,7 +18,7 @@ use crate::{
     MessagingInterface,
 };
 
-use super::RX_TIMEOUT;
+use super::ACK_RX_TIMEOUT;
 
 /// ISO-TP addressing scheme
 /// 11-bit standard ID
@@ -142,7 +142,7 @@ impl CanIsoTpMessaging {
 
             Err(eyre!("ack queue closed"))
         };
-        timeout(RX_TIMEOUT, recv_fut)
+        timeout(ACK_RX_TIMEOUT, recv_fut)
             .map(|result| result?)
             .await
             .wrap_err("ack not received (isotp)")

--- a/mcu-interface/src/can/isotp.rs
+++ b/mcu-interface/src/can/isotp.rs
@@ -100,7 +100,7 @@ impl CanIsoTpMessaging {
         bus: String,
         local: IsoTpNodeIdentifier,
         remote: IsoTpNodeIdentifier,
-        new_message_queue: mpsc::Sender<McuPayload>,
+        new_message_queue: mpsc::UnboundedSender<McuPayload>,
     ) -> Result<CanIsoTpMessaging> {
         let (tx_stdid_src, tx_stdid_dst) = create_pair(local, remote)?;
         debug!("Sending on 0x{:x}->0x{:x}", tx_stdid_src, tx_stdid_dst);
@@ -180,7 +180,7 @@ fn can_rx(
     remote: IsoTpNodeIdentifier,
     local: IsoTpNodeIdentifier,
     ack_tx: mpsc::UnboundedSender<(CommonAckError, u32)>,
-    new_message_queue: mpsc::Sender<McuPayload>,
+    new_message_queue: mpsc::UnboundedSender<McuPayload>,
     mut kill_rx: oneshot::Receiver<()>,
 ) -> Result<()> {
     // rx messages <=> from remote to local

--- a/mcu-interface/src/can/mod.rs
+++ b/mcu-interface/src/can/mod.rs
@@ -1,2 +1,6 @@
+use std::time::Duration;
+
 pub mod canfd;
 pub mod isotp;
+
+const RX_TIMEOUT: Duration = Duration::from_millis(1500);

--- a/mcu-interface/src/can/mod.rs
+++ b/mcu-interface/src/can/mod.rs
@@ -3,4 +3,4 @@ use std::time::Duration;
 pub mod canfd;
 pub mod isotp;
 
-const RX_TIMEOUT: Duration = Duration::from_millis(1500);
+const ACK_RX_TIMEOUT: Duration = Duration::from_millis(1500);

--- a/mcu-interface/src/lib.rs
+++ b/mcu-interface/src/lib.rs
@@ -65,7 +65,7 @@ fn is_ack_for_us(ack_number: u32) -> bool {
 fn handle_main_mcu_message(
     message: &orb_messages::mcu_main::McuMessage,
     ack_tx: &mpsc::UnboundedSender<(CommonAckError, u32)>,
-    new_message_queue: &mpsc::Sender<McuPayload>,
+    new_message_queue: &mpsc::UnboundedSender<McuPayload>,
 ) -> Result<()> {
     match message {
         &orb_messages::mcu_main::McuMessage { version, .. }
@@ -96,7 +96,7 @@ fn handle_main_mcu_message(
                     orb_messages::mcu_main::McuToJetson { payload: Some(p) },
                 )),
         } => {
-            new_message_queue.blocking_send(McuPayload::FromMain(p.clone()))?;
+            new_message_queue.send(McuPayload::FromMain(p.clone()))?;
         }
         _ => {
             if message.message.is_some() {
@@ -113,7 +113,7 @@ fn handle_main_mcu_message(
 fn handle_sec_mcu_message(
     message: &orb_messages::mcu_sec::McuMessage,
     ack_tx: &mpsc::UnboundedSender<(CommonAckError, u32)>,
-    new_message_queue: &mpsc::Sender<McuPayload>,
+    new_message_queue: &mpsc::UnboundedSender<McuPayload>,
 ) -> Result<()> {
     match message {
         &orb_messages::mcu_sec::McuMessage { version, .. }
@@ -142,7 +142,7 @@ fn handle_sec_mcu_message(
                     orb_messages::mcu_sec::SecToJetson { payload: Some(p) },
                 )),
         } => {
-            new_message_queue.blocking_send(McuPayload::FromSec(p.clone()))?;
+            new_message_queue.send(McuPayload::FromSec(p.clone()))?;
         }
         _ => {
             if message.message.is_some() {

--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -18,7 +18,6 @@ use crate::orb::{dfu, BatteryStatus};
 use crate::orb::{Board, OrbInfo};
 
 const REBOOT_DELAY: u32 = 3;
-const MESSAGE_QUEUE_SIZE: usize = 32;
 
 pub struct MainBoard {
     canfd_iface: CanRawMessaging,
@@ -26,18 +25,18 @@ pub struct MainBoard {
     /// Optional serial interface for the main board, if available (ie orb-ui might own it)
     #[allow(dead_code)]
     serial_iface: Option<SerialMessaging>,
-    message_queue_rx: mpsc::Receiver<McuPayload>,
+    message_queue_rx: mpsc::UnboundedReceiver<McuPayload>,
 }
 
 pub struct MainBoardBuilder {
-    message_queue_rx: mpsc::Receiver<McuPayload>,
-    message_queue_tx: mpsc::Sender<McuPayload>,
+    message_queue_rx: mpsc::UnboundedReceiver<McuPayload>,
+    message_queue_tx: mpsc::UnboundedSender<McuPayload>,
 }
 
 impl MainBoardBuilder {
     pub(crate) fn new() -> Self {
         let (message_queue_tx, message_queue_rx) =
-            mpsc::channel::<McuPayload>(MESSAGE_QUEUE_SIZE);
+            mpsc::unbounded_channel::<McuPayload>();
 
         Self {
             message_queue_rx,

--- a/mcu-util/src/orb/security_board.rs
+++ b/mcu-util/src/orb/security_board.rs
@@ -18,23 +18,22 @@ use crate::orb::{dfu, BatteryStatus};
 use crate::orb::{Board, OrbInfo};
 
 const REBOOT_DELAY: u32 = 3;
-const MESSAGE_QUEUE_SIZE: usize = 32;
 
 pub struct SecurityBoard {
     canfd_iface: CanRawMessaging,
     isotp_iface: CanIsoTpMessaging,
-    message_queue_rx: mpsc::Receiver<McuPayload>,
+    message_queue_rx: mpsc::UnboundedReceiver<McuPayload>,
 }
 
 pub struct SecurityBoardBuilder {
-    message_queue_rx: mpsc::Receiver<McuPayload>,
-    message_queue_tx: mpsc::Sender<McuPayload>,
+    message_queue_rx: mpsc::UnboundedReceiver<McuPayload>,
+    message_queue_tx: mpsc::UnboundedSender<McuPayload>,
 }
 
 impl SecurityBoardBuilder {
     pub(crate) fn new() -> Self {
         let (message_queue_tx, message_queue_rx) =
-            mpsc::channel::<McuPayload>(MESSAGE_QUEUE_SIZE);
+            mpsc::unbounded_channel::<McuPayload>();
 
         Self {
             message_queue_rx,


### PR DESCRIPTION
Changes in this PR:
* Turns the std::sync::mpsc channels into tokio channels. This allows us to receive messages asynchronously and reduces the number of spots we need to call blocking code from async.
* Refactors how the ack ids are created. I suspect previously there were some edge cases that could cause bugs, this new way is simpler and probably more correct.
* Adds a oneshot "kill" channel to inform `can_rx` that it should terminate.
* Places a few remaining spots that were blocking in async code behind a `tokio::task::spawn_blocking`.