### PR TITLE
mcu-util: explicitly join on task handles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,6 +2924,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "crc32fast",
+ "futures",
  "image",
  "orb-mcu-interface",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,7 +2907,9 @@ dependencies = [
  "color-eyre",
  "futures",
  "orb-messages",
+ "pin-project",
  "prost",
+ "thiserror",
  "tokio",
  "tokio-serial",
  "tracing",
@@ -3152,18 +3154,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mcu-interface/Cargo.toml
+++ b/mcu-interface/Cargo.toml
@@ -14,12 +14,14 @@ rust-version.workspace = true
 async-trait = "0.1.77"
 can-rs = { path = "../can", features = ["isotp"] }
 color-eyre.workspace = true
+futures.workspace = true
 orb-messages.workspace = true
 prost = "0.12.3"
-tokio.workspace = true
+pin-project = "1.1.5"
+thiserror.workspace = true
 tokio-serial = "5.4.1"
+tokio.workspace = true
 tracing.workspace = true
-futures.workspace = true
 
 [package.metadata.orb]
 unsupported_targets = [

--- a/mcu-interface/src/can/canfd.rs
+++ b/mcu-interface/src/can/canfd.rs
@@ -157,6 +157,7 @@ fn can_rx(
                 Err(oneshot::error::TryRecvError::Empty) => (),
             }
 
+            trace!("reading from raw");
             match stream.recv(&mut frame, 0) {
                 Ok(_nbytes) => {
                     break;

--- a/mcu-interface/src/can/canfd.rs
+++ b/mcu-interface/src/can/canfd.rs
@@ -81,6 +81,7 @@ impl CanRawMessaging {
                     Ok(Err(err)) => Err(CanTaskJoinError::Err(err)),
                     Err(panic) => Err(CanTaskPanic::new(panic).into()),
                 };
+            debug!(result=?result, "raw can_rx task terminated");
             task_join_tx.send(result)
         });
 

--- a/mcu-interface/src/can/canfd.rs
+++ b/mcu-interface/src/can/canfd.rs
@@ -66,7 +66,7 @@ impl CanRawMessaging {
         // for two reaasons:
         //
         // 1. Under normal conditions, this closure runs forever, and tokio
-        // advises only using pawn_blocking for operations that "eventually
+        // advises only using spawn_blocking for operations that "eventually
         // finish on their own"
         // 2. tokio::main will not return until all tasks are completed. And
         // unlike regular async tasks, blocking tasks cannot be cancelled.

--- a/mcu-interface/src/can/isotp.rs
+++ b/mcu-interface/src/can/isotp.rs
@@ -130,7 +130,7 @@ impl CanIsoTpMessaging {
         // for two reaasons:
         //
         // 1. Under normal conditions, this closure runs forever, and tokio
-        // advises only using pawn_blocking for operations that "eventually
+        // advises only using spawn_blocking for operations that "eventually
         // finish on their own"
         // 2. tokio::main will not return until all tasks are completed. And
         // unlike regular async tasks, blocking tasks cannot be cancelled.

--- a/mcu-interface/src/can/isotp.rs
+++ b/mcu-interface/src/can/isotp.rs
@@ -4,6 +4,7 @@ use futures::FutureExt as _;
 use orb_messages::CommonAckError;
 use prost::Message;
 use std::io::{Read, Write};
+use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicU16, Ordering};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::timeout;
@@ -13,12 +14,13 @@ use can_rs::isotp::addr::CanIsotpAddr;
 use can_rs::isotp::stream::IsotpStream;
 use can_rs::{Id, CAN_DATA_LEN};
 
+use crate::can::CanTaskPanic;
 use crate::{
     create_ack, handle_main_mcu_message, handle_sec_mcu_message, McuPayload,
     MessagingInterface,
 };
 
-use super::ACK_RX_TIMEOUT;
+use super::{CanTaskHandle, CanTaskJoinError, ACK_RX_TIMEOUT};
 
 /// ISO-TP addressing scheme
 /// 11-bit standard ID
@@ -92,6 +94,9 @@ impl CanIsoTpMessaging {
     /// pairs of addresses, one for transmission of ISO-TP messages and one for reception.
     /// A blocking thread is created for listening to new incoming messages.
     ///
+    /// Returns a handle to join on the blocking thread and retrieve any errors it
+    /// produces.
+    ///
     /// One pair of addresses _should_ be uniquely used on the bus to prevent misinterpretation of
     /// transmitted messages.
     /// If a pair of addresses is used by several programs, they must ensure one, and only one,
@@ -101,7 +106,7 @@ impl CanIsoTpMessaging {
         local: IsoTpNodeIdentifier,
         remote: IsoTpNodeIdentifier,
         new_message_queue: mpsc::UnboundedSender<McuPayload>,
-    ) -> Result<CanIsoTpMessaging> {
+    ) -> Result<(Self, CanTaskHandle)> {
         let (tx_stdid_src, tx_stdid_dst) = create_pair(local, remote)?;
         debug!("Sending on 0x{:x}->0x{:x}", tx_stdid_src, tx_stdid_dst);
 
@@ -119,17 +124,39 @@ impl CanIsoTpMessaging {
 
         let (ack_tx, ack_rx) = mpsc::unbounded_channel();
         let (kill_tx, kill_rx) = oneshot::channel();
-        // spawn CAN receiver
-        tokio::task::spawn_blocking(move || {
-            can_rx(bus, remote, local, ack_tx, new_message_queue, kill_rx)
+        let (task_join_tx, task_join_rx) = oneshot::channel();
+        let task_join_rx = CanTaskHandle(task_join_rx);
+        // We directly spawn a thread instead of tokio::task::spawn_blocking,
+        // for two reaasons:
+        //
+        // 1. Under normal conditions, this closure runs forever, and tokio
+        // advises only using pawn_blocking for operations that "eventually
+        // finish on their own"
+        // 2. tokio::main will not return until all tasks are completed. And
+        // unlike regular async tasks, blocking tasks cannot be cancelled.
+        // `kill_tx` partially solves this, but I think its just better to
+        // decouple tokio from this task.
+        std::thread::spawn(move || {
+            let result: Result<(), CanTaskJoinError> =
+                match std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    can_rx(bus, remote, local, ack_tx, new_message_queue, kill_rx)
+                })) {
+                    Ok(Ok(())) => Ok(()),
+                    Ok(Err(err)) => Err(CanTaskJoinError::Err(err)),
+                    Err(panic) => Err(CanTaskPanic::new(panic).into()),
+                };
+            task_join_tx.send(result)
         });
 
-        Ok(CanIsoTpMessaging {
-            stream: tx_isotp_stream,
-            ack_num_lsb: AtomicU16::new(0),
-            ack_queue: ack_rx,
-            _kill_tx: kill_tx,
-        })
+        Ok((
+            CanIsoTpMessaging {
+                stream: tx_isotp_stream,
+                ack_num_lsb: AtomicU16::new(0),
+                ack_queue: ack_rx,
+                _kill_tx: kill_tx,
+            },
+            task_join_rx,
+        ))
     }
 
     async fn wait_ack(&mut self, expected_ack_number: u32) -> Result<CommonAckError> {

--- a/mcu-interface/src/can/isotp.rs
+++ b/mcu-interface/src/can/isotp.rs
@@ -145,6 +145,7 @@ impl CanIsoTpMessaging {
                     Ok(Err(err)) => Err(CanTaskJoinError::Err(err)),
                     Err(panic) => Err(CanTaskPanic::new(panic).into()),
                 };
+            debug!(result=?result, "isotp can_rx task terminated");
             task_join_tx.send(result)
         });
 
@@ -233,6 +234,7 @@ fn can_rx(
             Err(oneshot::error::TryRecvError::Empty) => (),
         }
 
+        trace!("reading from isotp");
         let buffer = match rx_isotp_stream.read(&mut buffer) {
             Ok(_) => buffer,
             Err(e) => {

--- a/mcu-interface/src/can/mod.rs
+++ b/mcu-interface/src/can/mod.rs
@@ -1,6 +1,80 @@
-use std::time::Duration;
+use std::{any::Any, task::Poll, time::Duration};
+
+use pin_project::pin_project;
+use tokio::sync::oneshot;
 
 pub mod canfd;
 pub mod isotp;
 
 const ACK_RX_TIMEOUT: Duration = Duration::from_millis(1500);
+
+pub type CanTaskResult = Result<(), CanTaskJoinError>;
+
+/// Handle that can be used to detect errors in the can receive task.
+///
+/// Note that dropping this handle doesn't kill the task.
+#[pin_project]
+#[derive(Debug)]
+pub struct CanTaskHandle(#[pin] oneshot::Receiver<CanTaskResult>);
+
+impl std::future::Future for CanTaskHandle {
+    type Output = CanTaskResult;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        let rx = self.project().0;
+        rx.poll(cx).map(|recv| match recv {
+            Ok(Ok(())) | Err(oneshot::error::RecvError { .. }) => Ok(()),
+            Ok(Err(err)) => Err(err),
+        })
+    }
+}
+
+impl CanTaskHandle {
+    /// Blocks until the task is complete.
+    ///
+    /// It is recommended to simply .await instead, since `CanTaskHandle` implements
+    /// `Future`.
+    pub fn join(self) -> CanTaskResult {
+        match self.0.blocking_recv() {
+            Ok(Ok(())) | Err(oneshot::error::RecvError { .. }) => Ok(()),
+            Ok(Err(err)) => Err(err),
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum CanTaskJoinError {
+    #[error(transparent)]
+    Panic(#[from] CanTaskPanic),
+    #[error(transparent)]
+    Err(#[from] color_eyre::Report),
+}
+
+#[derive(thiserror::Error)]
+#[error("panic in thread used to receive from canbus")]
+// Mutex is there to make it implement Sync without using `unsafe`
+pub struct CanTaskPanic(std::sync::Mutex<Box<dyn Any + Send + 'static>>);
+
+impl CanTaskPanic {
+    fn new(err: Box<dyn Any + Send + 'static>) -> Self {
+        Self(std::sync::Mutex::new(err))
+    }
+
+    /// Returns the object with which the task panicked.
+    ///
+    /// You can pass this into [`std::panic::resume_unwind()`] to propagate the
+    /// panic.
+    pub fn into_panic(self) -> Box<dyn Any + Send + 'static> {
+        self.0.into_inner().expect("infallible")
+    }
+}
+
+impl std::fmt::Debug for CanTaskPanic {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple(std::any::type_name::<CanTaskPanic>())
+            .finish()
+    }
+}

--- a/mcu-util/Cargo.toml
+++ b/mcu-util/Cargo.toml
@@ -20,6 +20,7 @@ orb-mcu-interface.path = "../mcu-interface"
 tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
+futures.workspace = true
 
 [package.metadata.orb]
 unsupported_targets = [

--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -178,6 +178,8 @@ async fn execute(args: Args) -> Result<()> {
             }
         },
     }
+
+    drop(orb);
     orb_tasks.join().await
 }
 


### PR DESCRIPTION
This PR adds explicit task handles for `can_rx`, and also propagates them up through all of the callers. It also does a bit of refactoring to mcu-util's board info logic to make it slightly more correct and easier to read.

The reason this change is needed is so that panics or other errors inside the can_rx task can be observed by the rest of the program. Otherwise, the task could silently die but the process itself and the other threads would continue happily along.