### PR TITLE
orb-qr-link: Add pcp_version field to UserData

### DIFF
--- a/orb-qr-link/src/user_data.rs
+++ b/orb-qr-link/src/user_data.rs
@@ -11,6 +11,9 @@ pub struct UserData {
     pub self_custody_public_key: String,
     /// User's biometric data policy.
     pub data_policy: DataPolicy,
+    /// Personal Custody Package version.
+    #[serde(default = "pcp_version_default")]
+    pub pcp_version: u16,
 }
 
 /// User's biometric data policy. Part of [`UserData`].
@@ -51,10 +54,12 @@ impl UserData {
             identity_commitment,
             self_custody_public_key,
             data_policy,
+            pcp_version,
         } = self;
         hasher.update(identity_commitment.as_bytes());
         hasher.update(self_custody_public_key.as_bytes());
         hasher.update(&[*data_policy as u8]);
+        hasher.update(&pcp_version.to_ne_bytes());
     }
 }
 
@@ -76,4 +81,8 @@ impl ToString for DataPolicy {
             DataPolicy::OptOut => "opt_out".to_string(),
         }
     }
+}
+
+fn pcp_version_default() -> u16 {
+    2
 }

--- a/orb-qr-link/tests/verification.rs
+++ b/orb-qr-link/tests/verification.rs
@@ -12,6 +12,7 @@ MCowBQYDK2VuAyEA2boNBmJX4lGkA9kjthS5crXOBxu2BPycKRMakpzgLG4=
         identity_commitment: identity_commitment.to_string(),
         self_custody_public_key: self_custody_public_key.to_string(),
         data_policy: DataPolicy::OptOut,
+        pcp_version: 3,
     };
     let qr = encode_qr(&session_id, user_data.hash(16));
     let (parsed_session_id, parsed_user_data_hash) = decode_qr(&qr).unwrap();


### PR DESCRIPTION
This PR is a part of the new PCP v3 spec:

https://www.notion.so/worldcoin/Personal-Data-Custody-Package-Versions-4d70da1201bc4d2da200769968c5b275?d=4a2afb31339745c8be05b1d2582f24f4#ee7d1958b23641028905ce2cda9d4a0c