### PR TITLE
binaries: improve version reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,15 +2648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,12 +2785,12 @@ dependencies = [
 name = "orb-attest"
 version = "0.2.8"
 dependencies = [
- "anyhow",
  "data-encoding",
  "event-listener 5.2.0",
  "eyre",
  "futures",
  "lazy_static",
+ "orb-build-info",
  "orb-const-concat",
  "reqwest",
  "ring 0.16.20",
@@ -2815,7 +2806,6 @@ dependencies = [
  "tracing-journald",
  "tracing-subscriber",
  "url",
- "vergen",
  "wiremock",
  "zbus",
 ]
@@ -2844,6 +2834,7 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
  "orb-build-info-helper",
+ "orb-const-concat",
 ]
 
 [[package]]
@@ -2902,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "orb-mcu-util"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -2910,6 +2901,7 @@ dependencies = [
  "crc32fast",
  "futures",
  "image",
+ "orb-build-info",
  "orb-mcu-interface",
  "tokio",
  "tracing",
@@ -3007,12 +2999,12 @@ dependencies = [
  "derive_more",
  "eyre",
  "futures",
+ "orb-build-info",
  "orb-messages",
  "orb-sound",
  "orb-uart",
  "pid",
  "prost",
- "prost-build",
  "serde",
  "serde_json",
  "tokio",
@@ -4385,8 +4377,6 @@ checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -4879,18 +4869,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vergen"
-version = "8.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
-dependencies = [
- "anyhow",
- "cfg-if",
- "rustversion",
- "time",
-]
 
 [[package]]
 name = "verity-tree-calc"

--- a/artificer/src/main.rs
+++ b/artificer/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
 }
 
 #[derive(Parser, Debug)]
-#[command(about, author, version=BUILD_INFO.git.describe, styles=make_clap_v3_styles())]
+#[command(about, author, version=BUILD_INFO.version, styles=make_clap_v3_styles())]
 struct Cli {}
 
 /// Colors the CLI help

--- a/build-info/Cargo.toml
+++ b/build-info/Cargo.toml
@@ -15,6 +15,7 @@ build-script = ["dep:orb-build-info-helper"]
 
 [dependencies]
 orb-build-info-helper = { path = "helper", optional = true }
+orb-const-concat.path = "../const-concat"
 
 [build-dependencies]
 orb-build-info-helper.path = "helper"

--- a/build-info/src/lib.rs
+++ b/build-info/src/lib.rs
@@ -5,7 +5,11 @@
 #[cfg(feature = "build-script")]
 pub use orb_build_info_helper::*;
 
-// Must be the same as the one in build.rs
+#[doc(hidden)]
+pub use orb_const_concat::const_concat;
+
+/// Must be the same as the one in build.rs
+#[doc(hidden)]
 #[macro_export]
 macro_rules! prefix_env {
     ($var:literal) => {
@@ -16,12 +20,21 @@ macro_rules! prefix_env {
 /// Information about the build.
 pub struct BuildInfo {
     pub git: GitInfo,
+    pub cargo: CargoInfo,
+    /// The user-facing version number we should report. Pass this to clap.
+    pub version: &'static str,
 }
 
-/// Information from git
+/// Information from git.
 pub struct GitInfo {
     /// The result of `git describe --always --dirty=-modified`.
     pub describe: &'static str,
+}
+
+/// Information from cargo.
+pub struct CargoInfo {
+    /// The version field in Cargo.toml.
+    pub pkg_version: &'static str,
 }
 
 /// Calling this returns an instance of [`BuildInfo`].
@@ -29,11 +42,27 @@ pub struct GitInfo {
 /// Be sure that you also call [`initialize`] in your build.rs.
 #[macro_export]
 macro_rules! make_build_info {
-    () => {{
-        $crate::BuildInfo {
-            git: $crate::GitInfo {
-                describe: $crate::prefix_env!("GIT_DESCRIBE"),
-            },
+    () => {
+        const {
+            const TMP: $crate::BuildInfo = $crate::BuildInfo {
+                git: $crate::GitInfo {
+                    describe: $crate::prefix_env!("GIT_DESCRIBE"),
+                },
+                cargo: $crate::CargoInfo {
+                    pkg_version: env!("CARGO_PKG_VERSION"),
+                },
+                version: "", // will be overwritten in a moment
+            };
+            let build_info = $crate::BuildInfo {
+                version: $crate::const_concat!(
+                    TMP.cargo.pkg_version,
+                    " ",
+                    TMP.git.describe,
+                ),
+                ..TMP
+            };
+            assert!(!build_info.version.is_empty());
+            build_info
         }
-    }};
+    };
 }

--- a/hil/src/main.rs
+++ b/hil/src/main.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 const BUILD_INFO: BuildInfo = make_build_info!();
 
 #[derive(Parser, Debug)]
-#[command(about, author, version=BUILD_INFO.git.describe, styles=make_clap_v3_styles())]
+#[command(about, author, version=BUILD_INFO.version, styles=make_clap_v3_styles())]
 struct Cli {
     /// The s3 URI of the rts.
     #[arg(long)]

--- a/mcu-util/Cargo.toml
+++ b/mcu-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-mcu-util"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Cyril Fougeray <cyril.fougeray@toolsforhumanity.com>"]
 description = "Debug microcontrollers and manage firmware images"
 publish = false
@@ -21,6 +21,10 @@ tokio.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
 futures.workspace = true
+orb-build-info.path = "../build-info"
+
+[build-dependencies]
+orb-build-info = { path = "../build-info", features = ["build-script"] }
 
 [package.metadata.orb]
 unsupported_targets = [

--- a/mcu-util/build.rs
+++ b/mcu-util/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    orb_build_info::initialize().expect("failed to initialize build info")
+}

--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -1,22 +1,26 @@
 #![forbid(unsafe_code)]
 
-extern crate core;
-use crate::orb::Orb;
-use clap::Parser;
-use color_eyre::eyre::{Context, Result};
 use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
+
+use clap::Parser;
+use color_eyre::eyre::{Context, Result};
+use orb_build_info::{make_build_info, BuildInfo};
 use tracing::{debug, error};
+
+use crate::orb::Orb;
 
 mod logging;
 mod orb;
+
+static BUILD_INFO: BuildInfo = make_build_info!();
 
 /// Utility args
 #[derive(Parser, Debug)]
 #[clap(
     author,
-    version,
+    version = BUILD_INFO.version,
     about = "Orb MCU utility",
     long_about = "Debug microcontrollers and manage firmware images"
 )]

--- a/orb-attest/Cargo.toml
+++ b/orb-attest/Cargo.toml
@@ -16,6 +16,7 @@ event-listener = "*"
 eyre.workspace = true
 futures.workspace = true
 lazy_static = "1.4"
+orb-build-info.path = "../build-info"
 orb-const-concat.path = "../const-concat"
 ring.workspace = true
 secrecy = { version = "0.8.0", features = ["serde"] }
@@ -40,8 +41,7 @@ features = [
 ]
 
 [build-dependencies]
-anyhow = "1.0"
-vergen = { version = "8.3.1", features = ["build", "git", "gitcl"] }
+orb-build-info = { path = "../build-info", features = ["build-script"] }
 
 [dev-dependencies]
 serial_test = "2.0"

--- a/orb-attest/build.rs
+++ b/orb-attest/build.rs
@@ -1,9 +1,3 @@
-use anyhow::Result;
-
-fn main() -> Result<()> {
-    // Generate vergen's instruction output
-    vergen::EmitBuilder::builder()
-        .git_sha(false)
-        .build_timestamp()
-        .emit()
+fn main() {
+    orb_build_info::initialize().expect("failed to detect build info")
 }

--- a/orb-attest/src/client.rs
+++ b/orb-attest/src/client.rs
@@ -5,11 +5,13 @@ use secrecy::ExposeSecret;
 use tokio::sync::OnceCell;
 use tracing::{error, info, warn};
 
+use crate::BUILD_INFO;
+
 const USER_AGENT: &str = const_concat!(
     "ShortLivedTokenDaemon/",
-    env!("CARGO_PKG_VERSION"),
+    BUILD_INFO.cargo.pkg_version,
     "-",
-    env!("VERGEN_GIT_SHA"),
+    BUILD_INFO.git.describe,
 );
 
 const AMAZON_ROOT_CA_1_PEM: &[u8] =

--- a/orb-attest/src/lib.rs
+++ b/orb-attest/src/lib.rs
@@ -10,10 +10,13 @@ use std::sync::Arc;
 
 use eyre::{self, bail, WrapErr};
 use futures::{FutureExt, StreamExt};
+use orb_build_info::{make_build_info, BuildInfo};
 use secrecy::ExposeSecret;
 use tokio::{select, sync::Notify, time::sleep};
 use tracing::{info, warn};
 use url::Url;
+
+const BUILD_INFO: BuildInfo = make_build_info!();
 
 const HTTP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 
@@ -21,9 +24,8 @@ const HTTP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 pub async fn main() -> eyre::Result<()> {
     logging::init();
 
-    info!("Build Timestamp: {}", env!("VERGEN_BUILD_TIMESTAMP"));
-    info!("Version: {}", env!("CARGO_PKG_VERSION"));
-    info!("git sha: {}", env!("VERGEN_GIT_SHA"));
+    info!("Version: {}", BUILD_INFO.cargo.pkg_version);
+    info!("git sha: {}", BUILD_INFO.git.describe);
 
     let orb_id =
         std::env::var("ORB_ID").wrap_err("env variable `ORB_ID` should be set")?;

--- a/orb-backend-state/src/main.rs
+++ b/orb-backend-state/src/main.rs
@@ -28,7 +28,7 @@ const RETRY_DELAY_MAX: Duration = Duration::from_secs(60);
 const BUILD_INFO: BuildInfo = make_build_info!();
 
 #[derive(Parser, Debug)]
-#[command(about, author, version=BUILD_INFO.git.describe, styles=make_clap_v3_styles())]
+#[command(about, author, version=BUILD_INFO.version, styles=make_clap_v3_styles())]
 struct Cli {}
 
 // No need to waste RAM with a threadpool.

--- a/orb-slot-ctrl/src/main.rs
+++ b/orb-slot-ctrl/src/main.rs
@@ -8,7 +8,7 @@ const BUILD_INFO: BuildInfo = make_build_info!();
 #[derive(Parser)]
 #[command(
     author,
-    version,
+    version = BUILD_INFO.version,
     long_about = "This tool is designed to read and write the slot and rootfs state of the Orb."
 )]
 struct Cli {

--- a/orb-thermal-cam-ctrl/src/main.rs
+++ b/orb-thermal-cam-ctrl/src/main.rs
@@ -38,7 +38,7 @@ fn make_clap_v3_styles() -> Styles {
 }
 
 #[derive(Debug, Parser)]
-#[command(about, author, version=BUILD_INFO.git.describe, styles=make_clap_v3_styles())]
+#[command(about, author, version=BUILD_INFO.version, styles=make_clap_v3_styles())]
 struct Cli {
     #[clap(subcommand)]
     commands: Commands,

--- a/orb-ui/Cargo.toml
+++ b/orb-ui/Cargo.toml
@@ -17,6 +17,7 @@ dashmap = "5.5.3"
 derive_more.workspace = true
 eyre.workspace = true
 futures.workspace = true
+orb-build-info.path = "../build-info"
 orb-messages.workspace = true
 orb-sound.path = "sound"
 orb-uart.path = "uart"
@@ -24,17 +25,17 @@ pid.path = "pid"
 prost = "0.12.3"
 serde.workspace = true
 serde_json = "1.0.108"
-tokio.workspace = true
 tokio-stream = "0.1.14"
-tracing.workspace = true
+tokio.workspace = true
 tracing-subscriber.workspace = true
+tracing.workspace = true
 zbus.workspace = true
 
 [target.'cfg(tokio_unstable)'.dependencies]
 console-subscriber.workspace = true
 
 [build-dependencies]
-prost-build = "0.12.3"
+orb-build-info = { path = "../build-info", features = ["build-script"] }
 
 [[example]]
 name = "ui-replay"

--- a/orb-ui/build.rs
+++ b/orb-ui/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    orb_build_info::initialize().expect("failed to initialize")
+}

--- a/orb-ui/src/main.rs
+++ b/orb-ui/src/main.rs
@@ -1,20 +1,23 @@
 #![forbid(unsafe_code)]
 
-use crate::engine::{Engine, EventChannel};
-use crate::observer::listen;
-use crate::serial::Serial;
-use crate::simulation::signup_simulation;
-use clap::Parser;
-use eyre::{Context, Result};
-use futures::channel::mpsc;
 use std::sync::OnceLock;
 use std::time::Duration;
 use std::{env, fs};
+
+use clap::Parser;
+use eyre::{Context, Result};
+use futures::channel::mpsc;
+use orb_build_info::{make_build_info, BuildInfo};
 use tokio::time;
 use tracing::debug;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{filter::LevelFilter, fmt, EnvFilter};
+
+use crate::engine::{Engine, EventChannel};
+use crate::observer::listen;
+use crate::serial::Serial;
+use crate::simulation::signup_simulation;
 
 mod dbus;
 mod engine;
@@ -24,12 +27,13 @@ mod simulation;
 pub mod sound;
 
 const INPUT_CAPACITY: usize = 100;
+const BUILD_INFO: BuildInfo = make_build_info!();
 
 /// Utility args
 #[derive(Parser, Debug)]
 #[clap(
     author,
-    version,
+    version=BUILD_INFO.version,
     about = "Orb UI daemon",
     long_about = "Handles the UI of the Orb, based on dbus messages"
 )]

--- a/verity-tree-calc/src/main.rs
+++ b/verity-tree-calc/src/main.rs
@@ -11,7 +11,7 @@ use tracing::debug;
 const BUILD_INFO: BuildInfo = make_build_info!();
 
 #[derive(Parser, Debug)]
-#[command(about, author, version=BUILD_INFO.git.describe, styles=make_clap_v3_styles())]
+#[command(about, author, version=BUILD_INFO.version, styles=make_clap_v3_styles())]
 struct Args {
     #[clap(value_parser)]
     data_size: u64,


### PR DESCRIPTION
I noticed that not all binaries were including the git sha in the build information. I've added the necessary functionality to the orb_build_info crate and updated all the binaries to use it.

I also bumped the version number for orb-mcu-util.