### PR TITLE
orb-const-concat: initial commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -967,26 +967,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_format"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,12 +2795,12 @@ name = "orb-attest"
 version = "0.2.8"
 dependencies = [
  "anyhow",
- "const_format",
  "data-encoding",
  "event-listener 5.2.0",
  "eyre",
  "futures",
  "lazy_static",
+ "orb-const-concat",
  "reqwest",
  "ring 0.16.20",
  "secrecy",
@@ -2872,6 +2852,10 @@ version = "0.0.0"
 dependencies = [
  "color-eyre",
 ]
+
+[[package]]
+name = "orb-const-concat"
+version = "0.0.0"
 
 [[package]]
 name = "orb-endpoints"
@@ -4823,12 +4807,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "build-info",
   "build-info/helper",
   "can",
+  "const-concat",
   "deps-tests",
   "endpoints",
   "header-parsing",

--- a/const-concat/Cargo.toml
+++ b/const-concat/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "orb-const-concat"
+version = "0.0.0"
+description = "Concatenates strings at compile time"
+authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
+publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true

--- a/const-concat/README.md
+++ b/const-concat/README.md
@@ -1,0 +1,7 @@
+# orb-const-fmt
+
+This crate implements the `const_concat!()` macro, which provides the ability to
+concatenate strings at compile time.
+
+Unlike other crates like [`const_format`](https://docs.rs/const_format), this crate
+uses 0 unsafe and is very narrowly scoped.

--- a/const-concat/src/lib.rs
+++ b/const-concat/src/lib.rs
@@ -1,0 +1,69 @@
+/// Concatenates const strings. Unlike [`std::concat!()`], arguments can be full
+/// expressions rather than only string literals.
+#[macro_export]
+macro_rules! const_concat {
+    // Recursive case
+    ($a:expr, $b:expr, $($tail:expr),+ $(,)?) => {
+        $crate::const_concat!($crate::const_concat!($a, $b), $($tail),+)
+    };
+    // Base case
+    ($a:expr, $b:expr $(,)?) => {
+        // outer const block forces evaluation at compile time, even when assigned
+        // to a regular variable.
+        const {
+            let Ok(s) = ::core::str::from_utf8(
+                // using const block prevents dangling reference
+                &const { $crate::concat_strs($a, $b, [0; $a.len() + $b.len()]) },
+            ) else {
+                panic!("not utf8");
+            };
+            s
+        }
+    };
+}
+
+#[doc(hidden)]
+pub const fn concat_strs<const BUF_SIZE: usize>(
+    a: &'static str,
+    b: &'static str,
+    buf: [u8; BUF_SIZE],
+) -> [u8; BUF_SIZE] {
+    assert!(a.len() + b.len() == BUF_SIZE);
+    let buf = copy_slice(a.as_bytes(), buf, 0);
+    copy_slice(b.as_bytes(), buf, a.len())
+}
+
+#[doc(hidden)]
+pub const fn copy_slice<const BUF_SIZE: usize>(
+    from: &[u8],
+    mut to: [u8; BUF_SIZE],
+    offset: usize,
+) -> [u8; BUF_SIZE] {
+    let mut index = 0;
+    while index < from.len() {
+        to[offset + index] = from[index];
+        index += 1;
+    }
+    to
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_const_concat() {
+        const FOO: &str = "foo";
+        const BAR: &str = "bar";
+        const BAZ: &str = "baz";
+
+        const FOOBAR: &str = const_concat!(FOO, BAR);
+        assert_eq!(FOOBAR, "foobar");
+
+        const FOOBARBAZ: &str = const_concat!(FOO, BAR, BAZ);
+        assert_eq!(FOOBARBAZ, "foobarbaz");
+
+        const FOOBARBAZ_COMMA: &str = const_concat!(FOO, BAR, BAZ,);
+        assert_eq!(FOOBARBAZ_COMMA, "foobarbaz");
+    }
+}

--- a/orb-attest/Cargo.toml
+++ b/orb-attest/Cargo.toml
@@ -11,12 +11,12 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-const_format = "0.2"
 data-encoding = "2.3"
 event-listener = "*"
 eyre.workspace = true
 futures.workspace = true
 lazy_static = "1.4"
+orb-const-concat.path = "../const-concat"
 ring.workspace = true
 secrecy = { version = "0.8.0", features = ["serde"] }
 serde.workspace = true
@@ -24,9 +24,9 @@ serde_json = "~1.0"
 serde_with = { version = "3.2", features=["base64"]}
 thiserror.workspace = true
 tokio.workspace = true
-tracing.workspace = true
 tracing-journald = "0.3"
 tracing-subscriber.workspace = true
+tracing.workspace = true
 url = "2.2"
 zbus.workspace = true
 

--- a/orb-attest/src/client.rs
+++ b/orb-attest/src/client.rs
@@ -1,14 +1,15 @@
-use const_format::formatcp;
 use futures::TryFutureExt;
+use orb_const_concat::const_concat;
 use reqwest::{Certificate, Client};
 use secrecy::ExposeSecret;
 use tokio::sync::OnceCell;
 use tracing::{error, info, warn};
 
-const USER_AGENT: &str = formatcp!(
-    "ShortLivedTokenDaemon/{}-{}",
+const USER_AGENT: &str = const_concat!(
+    "ShortLivedTokenDaemon/",
     env!("CARGO_PKG_VERSION"),
-    env!("VERGEN_GIT_SHA")
+    "-",
+    env!("VERGEN_GIT_SHA"),
 );
 
 const AMAZON_ROOT_CA_1_PEM: &[u8] =


### PR DESCRIPTION
I didn't like that the const_format crate is so incredibly complex. There is a lot of unsafe and also a lot of cursed code in it.
I would much rather use a solution that covers the 80% use case of concatenating strings with 0 unsafe, minimal LOC, and less SBOM risk.


