### PR TITLE
orb-mcu-util: don't fail on building boards object

### DIFF
--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -83,7 +83,7 @@ impl MainBoardBuilder {
                 }
             })
             .unwrap_or_else(|e| {
-                error!("Failed to send heartbeat to main mcu: {:?}", e);
+                error!("Failed to send heartbeat to main mcu: {:#?}", e);
                 Err(eyre!("Failed to send heartbeat to main mcu"))
             });
 

--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -66,7 +66,7 @@ impl MainBoardBuilder {
         // Send a heartbeat to the main mcu to ensure it is alive
         // & "subscribe" to the main mcu messages: messages to the Jetson
         // are going to be sent after the heartbeat
-        let _ = canfd_iface
+        let ack_result = canfd_iface
             .send(McuPayload::ToMain(
                 main_messaging::jetson_to_mcu::Payload::Heartbeat(
                     main_messaging::Heartbeat {
@@ -81,11 +81,10 @@ impl MainBoardBuilder {
                 } else {
                     Err(eyre!("ack error: {c}"))
                 }
-            })
-            .unwrap_or_else(|e| {
-                error!("Failed to send heartbeat to main mcu: {:#?}", e);
-                Err(eyre!("Failed to send heartbeat to main mcu"))
             });
+        if let Err(e) = ack_result {
+            error!("Failed to send heartbeat to main mcu: {:#?}", e);
+        }
 
         Ok((
             MainBoard {

--- a/mcu-util/src/orb/security_board.rs
+++ b/mcu-util/src/orb/security_board.rs
@@ -78,8 +78,8 @@ impl SecurityBoardBuilder {
                 }
             })
             .unwrap_or_else(|e| {
-                error!("Failed to send heartbeat to main mcu: {:?}", e);
-                Err(eyre!("Failed to send heartbeat to main mcu"))
+                error!("Failed to send heartbeat to security mcu: {:#?}", e);
+                Err(eyre!("Failed to send heartbeat to security mcu"))
             });
 
         Ok((
@@ -380,7 +380,7 @@ impl SecurityBoardInfo {
             .await
         {
             is_err = true;
-            error!("Failed to fetch firmware versions: {:?}", e);
+            error!("Failed to fetch firmware versions: {:#?}", e);
         }
 
         if let Err(e) = sec_board
@@ -396,7 +396,7 @@ impl SecurityBoardInfo {
             .await
         {
             is_err = true;
-            error!("Failed to fetch hardware versions: {:?}", e);
+            error!("Failed to fetch hardware versions: {:#?}", e);
         }
 
         if let Err(e) = sec_board
@@ -412,7 +412,7 @@ impl SecurityBoardInfo {
             .await
         {
             is_err = true;
-            error!("Failed to fetch battery status: {:?}", e);
+            error!("Failed to fetch battery status: {:#?}", e);
         }
 
         match tokio::time::timeout(

--- a/mcu-util/src/orb/security_board.rs
+++ b/mcu-util/src/orb/security_board.rs
@@ -61,7 +61,7 @@ impl SecurityBoardBuilder {
         // Send a heartbeat to the mcu to ensure it is alive
         // & "subscribe" to the mcu messages: messages to the Jetson
         // are going to be sent after the heartbeat
-        let _ = canfd_iface
+        let ack_result = canfd_iface
             .send(McuPayload::ToSec(
                 security_messaging::jetson_to_sec::Payload::Heartbeat(
                     security_messaging::Heartbeat {
@@ -76,11 +76,10 @@ impl SecurityBoardBuilder {
                 } else {
                     Err(eyre!("ack error: {c}"))
                 }
-            })
-            .unwrap_or_else(|e| {
-                error!("Failed to send heartbeat to security mcu: {:#?}", e);
-                Err(eyre!("Failed to send heartbeat to security mcu"))
             });
+        if let Err(e) = ack_result {
+            error!("Failed to send heartbeat to security mcu: {:#?}", e);
+        }
 
         Ok((
             SecurityBoard {


### PR DESCRIPTION
heartbeat is sent, when initializing orb-mcu-util, to check that microcontrollers are alive
but if it's not, don't fail because the orb-mcu-util command (ie reboot, update..) might be targeted to the other, responsive, MCU

- [x] make error cleaner
```
(venv) (os-9828b07) worldcoin@id-eff7c442:/mnt/scratch$ ./orb-mcu-util info
2024-06-14T08:04:41.249445Z ERROR orb_mcu_util::orb::security_board: Failed to send heartbeat to security mcu: Error {
    msg: "ack not received (raw)",
    source: Elapsed(
        (),
    ),
}
```