### PR TITLE
mcu-interface: isotp: set block size to 8

### DIFF
--- a/can/src/isotp/flowcontrol.rs
+++ b/can/src/isotp/flowcontrol.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, Clone, Copy)]
 pub struct FlowControlOptions {
     pub block_size: Blocksize,
-    pub seperation_time: SeparationTime,
+    pub separation_time: SeparationTime,
     pub wait_transmission: WaitFrameTransmission,
 }
 
@@ -9,7 +9,7 @@ impl Default for FlowControlOptions {
     fn default() -> Self {
         Self {
             block_size: Blocksize::Off,
-            seperation_time: SeparationTime::Off,
+            separation_time: SeparationTime::Off,
             wait_transmission: WaitFrameTransmission::Off,
         }
     }
@@ -83,7 +83,7 @@ pub(crate) mod imp {
                     Blocksize::Off => 0,
                     Blocksize::Limited(lim) => lim,
                 },
-                stmin: match fco.seperation_time {
+                stmin: match fco.separation_time {
                     SeparationTime::Off => 0,
                     SeparationTime::Coarse(val) => val & CAN_ISOTP_FC_ST_COARSE_MASK,
                     SeparationTime::Fine(val) => val & CAN_ISOTP_FC_ST_FINE_MASK,

--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -178,21 +178,21 @@ impl Board for MainBoard {
 
         while let Some(payload) = block_iter.next() {
             if canfd {
-                while self
+                while let Err(e) = self
                     .canfd_iface
                     .send(McuPayload::ToMain(payload.clone()))
                     .await
-                    .is_err()
                 {
+                    error!("Error sending block [can-fd]: {e}");
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             } else {
-                while self
+                while let Err(e) = self
                     .isotp_iface
                     .send(McuPayload::ToMain(payload.clone()))
                     .await
-                    .is_err()
                 {
+                    error!("Error sending block [isotp]: {e}");
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
             }


### PR DESCRIPTION
when the MCU tries to send payloads that are
larger than 7 bytes, ISO-TP chunks the data.
The block size is set by the receiver and
indicates to the sender when a flow control
packed must be awaited.
8 CF (consecutive frames) are now sent
by the sender before one FC (flow control)
frame is sent back.