### PR TITLE
ci: ensure lockfile is up to date

### DIFF
--- a/scripts/rust_ci_helper.py
+++ b/scripts/rust_ci_helper.py
@@ -72,6 +72,7 @@ def build_all_crates(*, cargo_profile, targets):
     targets_option = " ".join([f"--target {t}-unknown-linux-gnu" for t in targets])
     run(
         f"cargo zigbuild --all "
+        f"--locked "  # ensures that the lockfile is up to date.
         f"--profile {cargo_profile} "
         f"{targets_option} "
         f"--no-default-features"


### PR DESCRIPTION
One reason why I didn't have CI create releases by detecting when the version in the cargo.toml gets changed, is because I couldn't guarantee that the lockfile was up to date with the toml file.

This PR fixes that, and also should prevent us from ever again accidentally committing a version bump change without the associated Cargo.lock change.