### PR TITLE
attest: remove double call to color_eyre::install

### DIFF
--- a/orb-attest/src/lib.rs
+++ b/orb-attest/src/lib.rs
@@ -22,7 +22,6 @@ const HTTP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 
 #[allow(clippy::missing_errors_doc)]
 pub async fn main() -> eyre::Result<()> {
-    color_eyre::install().unwrap();
     logging::init();
 
     info!("Version: {}", BUILD_INFO.cargo.pkg_version);


### PR DESCRIPTION
## orb-attest
### fixes
- `color_eyre::install` was being called both in `crate::main` and in `crate::orb_attest::main` causing the application to crash