### PR TITLE
supervisor: added .service file

### DIFF
--- a/orb-supervisor/Cargo.toml
+++ b/orb-supervisor/Cargo.toml
@@ -34,3 +34,10 @@ dbus-launch = "0.2.0"
 tokio = { version = "1.25.0", features = ["sync", "test-util"] }
 
 [package.metadata.deb]
+maintainer-scripts = "debian/"
+assets = [
+  ["target/release/orb-supervisor", "/usr/local/bin/", "755"]
+]
+systemd-units = [
+  { unit-name = "worldcoin-supervisor" },
+]

--- a/orb-supervisor/debian/orb-supervisor.worldcoin-supervisor.service
+++ b/orb-supervisor/debian/orb-supervisor.worldcoin-supervisor.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Worldcoin Supervisor
+
+[Service]
+Type=dbus
+BusName=org.worldcoin.OrbSupervisor1
+SyslogIdentifier=worldcoin-supervisor
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
+Environment="RUST_LOG=debug"
+ExecStart=/usr/local/bin/orb-supervisor
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
As part of merging orb-supervisor into orb-software, we need to make it's .deb file include the service file. Previously this lived in orb-os, but to be consistent with the way we do other stuff, I believe it should be moved into orb-software.

There is an associated PR at worldcoin/orb-os#478