### PR TITLE
attest: move to /usr/local/bin

### DIFF
--- a/orb-attest/Cargo.toml
+++ b/orb-attest/Cargo.toml
@@ -43,6 +43,9 @@ wiremock = "0.5"
 
 [package.metadata.deb]
 maintainer-scripts = "debian/"
+assets = [
+  ["target/release/orb-attest", "/usr/local/bin/", "755"]
+]
 systemd-units = [
   { unit-name = "worldcoin-attest" },
 ]

--- a/orb-attest/debian/orb-attest.worldcoin-attest.service
+++ b/orb-attest/debian/orb-attest.worldcoin-attest.service
@@ -12,7 +12,7 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
 Environment=RUST_BACKTRACE=1
 SyslogIdentifier=orb-attest
 Restart=on-failure
-ExecStart=/bin/bash -c 'ORB_ID=$(/usr/local/bin/orb-id) /usr/bin/orb-attest'
+ExecStart=/bin/bash -c 'ORB_ID=$(/usr/local/bin/orb-id) /usr/local/bin/orb-attest'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We decided [in slack](https://tfh.slack.com/archives/C052G91M2Q6/p1723142104085079?thread_ts=1723140011.732869&cid=C052G91M2Q6) that first-party code will live in /usr/local/bin from now on.