### PR TITLE
supervisor: add version reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3124,12 +3124,14 @@ dependencies = [
 name = "orb-supervisor"
 version = "0.5.0"
 dependencies = [
+ "clap",
  "color-eyre",
  "dbus-launch",
  "futures",
  "libc",
  "listenfd",
  "once_cell",
+ "orb-build-info",
  "tap",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 zbus = { version = "4", default-features = false, features = ["tokio"] }
 
+orb-build-info.path = "build-info"
+orb-const-concat.path = "const-concat"
 orb-security-utils.path = "security-utils"
 
 [workspace.dependencies.orb-messages]

--- a/build-info/README.md
+++ b/build-info/README.md
@@ -1,4 +1,34 @@
-# build-info
+# orb-build-info
 
 Helper library for collecting information about the artifact
 being built.
+
+## How to use
+
+First, add the following dependencies:
+```toml
+[dependencies]
+orb-build-info.workspace = true
+
+[build-dependencies]
+orb-build-info = { workspace = true, features = ["build-script"] }
+```
+
+Then make a `build.rs` script:
+```rust
+fn main() {
+    orb_build_info::initialize().expect("failed to initialize")
+}
+```
+
+Finally, in `lib.rs` or `main.rs`:
+
+```rust
+use orb_build_info::{BuildInfo, make_build_info};
+
+const BUILD_INFO: BuildInfo = make_build_info!();
+```
+
+You can now access the `BUILD_INFO` constant anywhere in your crate, and do things
+like report the git commit, etc. See how it is used in `orb-mcu-util` and other
+binaries.

--- a/orb-attest/Cargo.toml
+++ b/orb-attest/Cargo.toml
@@ -16,8 +16,8 @@ data-encoding = "2.3"
 event-listener = "*"
 eyre.workspace = true
 futures.workspace = true
-orb-build-info.path = "../build-info"
-orb-const-concat.path = "../const-concat"
+orb-build-info.workspace = true
+orb-const-concat.workspace = true
 orb-security-utils = { workspace = true, features = ["reqwest"] }
 reqwest = { workspace = true, features = ["json", "multipart"] }
 ring.workspace = true
@@ -34,7 +34,7 @@ url = "2.2"
 zbus.workspace = true
 
 [build-dependencies]
-orb-build-info = { path = "../build-info", features = ["build-script"] }
+orb-build-info = { workspace = true, features = ["build-script"] }
 
 [dev-dependencies]
 serial_test = "2.0"

--- a/orb-supervisor/CHANGELOG.md
+++ b/orb-supervisor/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## 0.5.0
 
-### Changed
-
++ Version/build info via --version
 * Merged into the orb-software repo.
-* Updated lockfile
-* Added cargo-deb packaging, same as the rest of orb-software
+* Switched to cargo-deb packaging, same as the rest of orb-software
+* Switched lockfile to orb-software's workspace lockfile
+* Stopped spawning tokio tasks for dbus calls
+* Reworked parsing of ScheduleShutdown arguments
+* Errors are propagated to caller over DBus now.
 
 ## 0.4.1
 

--- a/orb-supervisor/Cargo.toml
+++ b/orb-supervisor/Cargo.toml
@@ -14,20 +14,25 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-color-eyre = "0.6.3"
-libc = "0.2.135"
+clap = { workspace = true, features = ["derive"] }
+color-eyre.workspace = true
+futures.workspace = true
+libc.workspace = true
 listenfd = "1.0.0"
-tokio = { version = "1.21.2", features = ["macros", "net", "rt-multi-thread"] }
+once_cell = "1.15.0"
+orb-build-info.workspace = true
+tap = "1.0.1"
+thiserror.workspace = true
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread"] }
 tokio-stream = "0.1.11"
-tracing = { version = "0.1.37", features = ["attributes"] }
+tracing = { workspace = true, features = ["attributes"] }
+tracing-journald = "0.3.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 zbus = { version = "3.9.0", default-features = false, features = ["tokio"] }
 zbus_systemd = { version = "0.0.8", features = [ "systemd1", "login1" ] }
-thiserror = "1.0.37"
-futures = "0.3.24"
-once_cell = "1.15.0"
-tap = "1.0.1"
-tracing-journald = "0.3.0"
+
+[build-dependencies]
+orb-build-info = { workspace = true, features = ["build-script"] }
 
 [dev-dependencies]
 dbus-launch = "0.2.0"

--- a/orb-supervisor/build.rs
+++ b/orb-supervisor/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    orb_build_info::initialize().expect("failed to initialize")
+}

--- a/orb-supervisor/src/lib.rs
+++ b/orb-supervisor/src/lib.rs
@@ -13,3 +13,7 @@ pub mod shutdown;
 pub mod startup;
 pub mod tasks;
 pub mod telemetry;
+
+use orb_build_info::{make_build_info, BuildInfo};
+
+pub static BUILD_INFO: BuildInfo = make_build_info!();

--- a/orb-supervisor/src/main.rs
+++ b/orb-supervisor/src/main.rs
@@ -1,3 +1,7 @@
+use clap::{
+    builder::{styling::AnsiColor, Styles},
+    Parser,
+};
 use color_eyre::eyre::WrapErr as _;
 use orb_supervisor::{
     startup::{Application, Settings},
@@ -6,12 +10,33 @@ use orb_supervisor::{
 use tracing::debug;
 use tracing_subscriber::filter::LevelFilter;
 
+use orb_supervisor::BUILD_INFO;
+
+/// Utility args
+#[derive(Parser, Debug)]
+#[clap(
+    version = BUILD_INFO.version,
+    about,
+    styles = clap_v3_styles(),
+)]
+struct Cli {}
+
+fn clap_v3_styles() -> Styles {
+    Styles::styled()
+        .header(AnsiColor::Yellow.on_default())
+        .usage(AnsiColor::Green.on_default())
+        .literal(AnsiColor::Green.on_default())
+        .placeholder(AnsiColor::Green.on_default())
+}
+
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
     telemetry::start::<ExecContext, _>(LevelFilter::INFO, std::io::stdout)
         .wrap_err("failed to initialize tracing; bailing")?;
     debug!("initialized telemetry");
+
+    let _args = Cli::parse();
 
     let settings = Settings::default();
     debug!(?settings, "starting supervisor with settings");


### PR DESCRIPTION
Added a clap CLI so that we can call it with `--version` and get the build info. I also added build info into the binary.