### PR TITLE
orb-ui: self-serve ui

### DIFF
--- a/orb-ui/cone/examples/cone-simulation.rs
+++ b/orb-ui/cone/examples/cone-simulation.rs
@@ -54,11 +54,11 @@ async fn simulation_task(cone: &mut Cone) -> eyre::Result<()> {
         let state_res = match counter {
             SimulationState::Idle => {
                 for pixel in pixels.iter_mut() {
-                    *pixel = Argb::DIAMOND_USER_IDLE;
+                    *pixel = Argb::DIAMOND_CONE_AMBER;
                 }
                 cone.lcd
                     .tx()
-                    .try_send(LcdCommand::try_from(Argb::DIAMOND_USER_IDLE)?)
+                    .try_send(LcdCommand::try_from(Argb::DIAMOND_CONE_AMBER)?)
                     .wrap_err("unable to send DIAMOND_USER_IDLE to lcd")
             }
             SimulationState::Red => {

--- a/orb-ui/cone/examples/cone-simulation.rs
+++ b/orb-ui/cone/examples/cone-simulation.rs
@@ -134,7 +134,7 @@ async fn simulation_task(cone: &mut Cone) -> eyre::Result<()> {
             }
             SimulationState::QrCode => {
                 for pixel in pixels.iter_mut() {
-                    *pixel = Argb::DIAMOND_USER_AMBER;
+                    *pixel = Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER;
                 }
 
                 let cmd =

--- a/orb-ui/rgb/src/lib.rs
+++ b/orb-ui/rgb/src/lib.rs
@@ -15,23 +15,12 @@ impl ops::Mul<f64> for Argb {
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     fn mul(self, rhs: f64) -> Self::Output {
-        // if intensity is led by the dimming value, use it
-        // otherwise, modify the color values
-        if let Some(dim) = self.0 {
-            Argb(
-                Some(((f64::from(dim) * rhs) as u8).clamp(0, Self::DIMMING_MAX_VALUE)),
-                self.1,
-                self.2,
-                self.3,
-            )
-        } else {
-            Argb(
-                None,
-                ((f64::from(self.1) * rhs) as u8).clamp(0, 255),
-                ((f64::from(self.2) * rhs) as u8).clamp(0, 255),
-                ((f64::from(self.3) * rhs) as u8).clamp(0, 255),
-            )
-        }
+        Argb(
+            self.0,
+            ((f64::from(self.1) * rhs) as u8).clamp(0, 254),
+            ((f64::from(self.2) * rhs) as u8).clamp(0, 254),
+            ((f64::from(self.3) * rhs) as u8).clamp(0, 254),
+        )
     }
 }
 
@@ -77,13 +66,15 @@ impl Argb {
         Argb(Some(Self::DIMMING_MAX_VALUE), 128, 128, 0);
     pub const DIAMOND_OPERATOR_VERSIONS_OUTDATED: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 0, 0);
-    pub const DIAMOND_USER_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 2, 1, 0);
-    #[allow(dead_code)]
-    pub const DIAMOND_USER_IDLE: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 18, 23, 18);
+    /// Shroud color to invite user to scan / reposition in front of the orb
+    pub const DIAMOND_SHROUD_SUMMON_USER_AMBER: Argb = Argb(Some(5), 230, 74, 5);
+    /// Shroud color during user scan (in progress)
+    pub const DIAMOND_SHROUD_SCAN_USER_AMBER: Argb = Argb(Some(2), 255, 61, 5);
     pub const DIAMOND_USER_QR_SCAN: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 17, 24, 15);
-    pub const DIAMOND_USER_SIGNUP: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 20, 15, 1);
+    /// Outer-ring color during user scan (in progress)
+    pub const DIAMOND_OUTER_USER_SIGNUP: Argb =
+        Argb(Some(Self::DIMMING_MAX_VALUE), 254, 204, 5);
     pub const DIAMOND_USER_FLASH: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 255, 255);
     pub const DIAMOND_CONE_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 25, 18, 1);

--- a/orb-ui/rgb/src/lib.rs
+++ b/orb-ui/rgb/src/lib.rs
@@ -67,17 +67,18 @@ impl Argb {
     pub const DIAMOND_OPERATOR_VERSIONS_OUTDATED: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 0, 0);
     /// Shroud color to invite user to scan / reposition in front of the orb
-    pub const DIAMOND_SHROUD_SUMMON_USER_AMBER: Argb = Argb(Some(5), 230, 74, 5);
+    pub const DIAMOND_SHROUD_SUMMON_USER_AMBER: Argb = Argb(Some(4), 148, 64, 4);
     /// Shroud color during user scan (in progress)
-    pub const DIAMOND_SHROUD_SCAN_USER_AMBER: Argb = Argb(Some(2), 255, 61, 5);
-    pub const DIAMOND_USER_QR_SCAN: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 17, 24, 15);
+    pub const DIAMOND_SHROUD_SCAN_USER_AMBER: Argb = Argb(Some(3), 140, 55, 4);
+    /// Outer-ring color during operator QR scans
+    pub const DIAMOND_OUTER_OPERATOR_QR_SCAN: Argb =
+        Argb(Some(Self::DIMMING_MAX_VALUE), 254, 204, 5);
     /// Outer-ring color during user scan (in progress)
     pub const DIAMOND_OUTER_USER_SIGNUP: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 254, 204, 5);
-    pub const DIAMOND_USER_FLASH: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 255, 255, 255);
     pub const DIAMOND_CONE_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 25, 18, 1);
+    /// Error color for outer ring
+    pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(2), 170, 0, 0);
 
     pub const FULL_RED: Argb = Argb(None, 255, 0, 0);
     pub const FULL_GREEN: Argb = Argb(None, 0, 255, 0);

--- a/orb-ui/rgb/src/lib.rs
+++ b/orb-ui/rgb/src/lib.rs
@@ -67,18 +67,16 @@ impl Argb {
     pub const DIAMOND_OPERATOR_VERSIONS_OUTDATED: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 0, 0);
     /// Shroud color to invite user to scan / reposition in front of the orb
-    pub const DIAMOND_SHROUD_SUMMON_USER_AMBER: Argb = Argb(Some(4), 148, 64, 4);
+    pub const DIAMOND_SHROUD_SUMMON_USER_AMBER: Argb = Argb(Some(4), 118, 51, 3);
     /// Shroud color during user scan (in progress)
-    pub const DIAMOND_SHROUD_SCAN_USER_AMBER: Argb = Argb(Some(3), 140, 55, 4);
+    pub const DIAMOND_SHROUD_SCAN_USER_AMBER: Argb = Argb(Some(3), 118, 51, 3);
     /// Outer-ring color during operator QR scans
-    pub const DIAMOND_OUTER_OPERATOR_QR_SCAN: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 254, 204, 5);
+    pub const DIAMOND_OUTER_OPERATOR_QR_SCAN: Argb = Argb(Some(12), 127, 102, 3);
     /// Outer-ring color during user scan (in progress)
-    pub const DIAMOND_OUTER_USER_SIGNUP: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 254, 204, 5);
+    pub const DIAMOND_OUTER_USER_SIGNUP: Argb = Argb(Some(15), 127, 102, 3);
     pub const DIAMOND_CONE_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 25, 18, 1);
     /// Error color for outer ring
-    pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(2), 170, 0, 0);
+    pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(2), 127, 20, 0);
 
     pub const FULL_RED: Argb = Argb(None, 255, 0, 0);
     pub const FULL_GREEN: Argb = Argb(None, 0, 255, 0);

--- a/orb-ui/rgb/src/lib.rs
+++ b/orb-ui/rgb/src/lib.rs
@@ -77,13 +77,13 @@ impl Argb {
         Argb(Some(Self::DIMMING_MAX_VALUE), 128, 128, 0);
     pub const DIAMOND_OPERATOR_VERSIONS_OUTDATED: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 0, 0);
-    pub const DIAMOND_USER_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 20, 16, 1);
+    pub const DIAMOND_USER_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 2, 1, 0);
     #[allow(dead_code)]
     pub const DIAMOND_USER_IDLE: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 18, 23, 18);
     pub const DIAMOND_USER_QR_SCAN: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 24, 29, 24);
+        Argb(Some(Self::DIMMING_MAX_VALUE), 17, 24, 15);
     pub const DIAMOND_USER_SIGNUP: Argb =
-        Argb(Some(Self::DIMMING_MAX_VALUE), 32, 26, 1);
+        Argb(Some(Self::DIMMING_MAX_VALUE), 20, 15, 1);
     pub const DIAMOND_USER_FLASH: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 255, 255);
     pub const DIAMOND_CONE_AMBER: Argb = Argb(Some(Self::DIMMING_MAX_VALUE), 25, 18, 1);

--- a/orb-ui/src/dbus.rs
+++ b/orb-ui/src/dbus.rs
@@ -22,7 +22,7 @@ impl Interface {
     /// Forward events to UI engine by sending serialized engine::Event to the event channel.
     async fn orb_signup_state_event(&mut self, event: String) -> zbus::fdo::Result<()> {
         // parse event to engine::Event using json_serde
-        tracing::debug!("received JSON event: {}", event);
+        tracing::trace!("received JSON event: {}", event);
         let event: engine::Event = serde_json::from_str(&event).map_err(|e| {
             zbus::fdo::Error::InvalidArgs(format!(
                 "invalid event: failed to parse {}",

--- a/orb-ui/src/engine/animations/alert.rs
+++ b/orb-ui/src/engine/animations/alert.rs
@@ -42,6 +42,8 @@ pub struct Alert<const N: usize> {
     phase: f64,
     /// first edge from pattern\[0\] to pattern\[1\] has LEDs on
     active_at_start: bool,
+    /// initial delay, in seconds, before starting the animation
+    initial_delay: f64,
 }
 
 impl<const N: usize> Alert<N> {
@@ -60,7 +62,14 @@ impl<const N: usize> Alert<N> {
             blinks,
             phase: 0.0,
             active_at_start,
+            initial_delay: 0.0,
         }
+    }
+
+    #[expect(dead_code)]
+    pub fn with_delay(mut self, delay: f64) -> Self {
+        self.initial_delay = delay;
+        self
     }
 }
 
@@ -83,6 +92,12 @@ impl<const N: usize> Animation for Alert<N> {
     ) -> AnimationState {
         let mut duration_acc = 0.0;
         let mut color = Argb::OFF;
+
+        // initial delay
+        if self.initial_delay > 0.0 {
+            self.initial_delay -= dt;
+            return AnimationState::Running;
+        }
 
         // sum up each edge duration and quit when the phase is in the current edge
         for (i, &edge_duration) in self.blinks.0.iter().enumerate() {

--- a/orb-ui/src/engine/animations/arc_dash.rs
+++ b/orb-ui/src/engine/animations/arc_dash.rs
@@ -85,7 +85,7 @@ impl<const N: usize> Animation for ArcDash<N> {
             if N == PEARL_RING_LED_COUNT {
                 current_color = Argb::PEARL_USER_FLASH;
             } else {
-                current_color = Argb::DIAMOND_USER_FLASH;
+                current_color = Argb::DIAMOND_OUTER_USER_SIGNUP;
             }
             *phase += dt;
             if *phase >= FLASH_ON_TIME {

--- a/orb-ui/src/engine/animations/wave.rs
+++ b/orb-ui/src/engine/animations/wave.rs
@@ -41,7 +41,7 @@ impl<const N: usize> Wave<N> {
         self
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub fn repeat(mut self, n_times: usize) -> Self {
         self.repeat = Some(n_times);
         self
@@ -84,8 +84,10 @@ impl<const N: usize> Animation for Wave<N> {
         // check if at the end of the animation, if phase wraps around
         if let Some(repeat) = self.repeat.as_mut() {
             if self.phase % (PI * 2.0 + self.solid_period) < self.phase {
-                *repeat -= 1;
-                if *repeat <= 0 {
+                if *repeat > 0 {
+                    *repeat -= 1;
+                }
+                if *repeat == 0 {
                     return AnimationState::Finished;
                 }
             }

--- a/orb-ui/src/engine/animations/wave.rs
+++ b/orb-ui/src/engine/animations/wave.rs
@@ -11,6 +11,7 @@ pub struct Wave<const N: usize> {
     solid_period: f64,
     inverted: bool,
     phase: f64,
+    initial_delay: f64,
 }
 
 impl<const N: usize> Wave<N> {
@@ -28,7 +29,13 @@ impl<const N: usize> Wave<N> {
             solid_period,
             inverted,
             phase: 0.0,
+            initial_delay: 0.0,
         }
+    }
+
+    pub fn with_delay(mut self, delay: f64) -> Self {
+        self.initial_delay = delay;
+        self
     }
 }
 
@@ -54,6 +61,11 @@ impl<const N: usize> Animation for Wave<N> {
         dt: f64,
         idle: bool,
     ) -> AnimationState {
+        if self.initial_delay > 0.0 {
+            self.initial_delay -= dt;
+            return AnimationState::Running;
+        }
+
         if self.phase >= self.solid_period {
             self.phase += dt * (PI * 2.0 / self.wave_period);
         } else {

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -247,7 +247,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         if *requested {
                             Argb::DIAMOND_USER_QR_SCAN
                         } else {
-                            Argb::DIAMOND_USER_AMBER
+                            Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER
                         },
                         BlinkDurations::from(vec![0.0, 0.3, 0.45, 0.3, 0.45, 0.45]),
                         None,
@@ -318,7 +318,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.set_center(
                             LEVEL_FOREGROUND,
                             animations::Static::<DIAMOND_CENTER_LED_COUNT>::new(
-                                Argb::DIAMOND_USER_AMBER,
+                                Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                                 None,
                             ),
                         );
@@ -354,7 +354,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.set_center(
                             LEVEL_FOREGROUND,
                             animations::Alert::<DIAMOND_CENTER_LED_COUNT>::new(
-                                Argb::DIAMOND_USER_AMBER,
+                                Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                                 BlinkDurations::from(vec![0.0, 0.5, 0.5]),
                                 None,
                                 false,
@@ -418,7 +418,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.set_center(
                         LEVEL_NOTICE,
                         animations::Alert::<DIAMOND_CENTER_LED_COUNT>::new(
-                            Argb::DIAMOND_USER_AMBER,
+                            Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                             BlinkDurations::from(vec![0.0, 0.5, 0.5]),
                             None,
                             false,
@@ -466,7 +466,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.set_cone(
                     LEVEL_NOTICE,
                     animations::Alert::<DIAMOND_CONE_LED_COUNT>::new(
-                        Argb::DIAMOND_USER_AMBER,
+                        Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                         BlinkDurations::from(vec![0.0, 0.5, 1.0]),
                         None,
                         false,
@@ -478,7 +478,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.set_center(
                     LEVEL_FOREGROUND,
                     animations::Wave::<DIAMOND_CENTER_LED_COUNT>::new(
-                        Argb::DIAMOND_USER_AMBER,
+                        Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                         4.0,
                         0.0,
                         self.is_self_serve, /* for a smooth transition:
@@ -516,7 +516,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         animations::Progress::<DIAMOND_RING_LED_COUNT>::new(
                             0.0,
                             None,
-                            Argb::DIAMOND_USER_SIGNUP,
+                            Argb::DIAMOND_OUTER_USER_SIGNUP,
                         ),
                     );
                 }
@@ -554,7 +554,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.set_center(
                             LEVEL_FOREGROUND,
                             animations::Wave::<DIAMOND_CENTER_LED_COUNT>::new(
-                                Argb::DIAMOND_USER_AMBER,
+                                Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                                 4.0,
                                 0.0,
                                 false,
@@ -567,7 +567,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.set_center(
                         LEVEL_FOREGROUND,
                         animations::Static::<DIAMOND_CENTER_LED_COUNT>::new(
-                            Argb::DIAMOND_USER_AMBER,
+                            Argb::DIAMOND_SHROUD_SCAN_USER_AMBER,
                             None,
                         ),
                     );
@@ -597,7 +597,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.set_center(
                         LEVEL_FOREGROUND,
                         animations::Static::<DIAMOND_CENTER_LED_COUNT>::new(
-                            Argb::DIAMOND_USER_AMBER,
+                            Argb::DIAMOND_SHROUD_SCAN_USER_AMBER,
                             None,
                         ),
                     );
@@ -608,7 +608,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.set_center(
                             LEVEL_FOREGROUND,
                             animations::Wave::<DIAMOND_CENTER_LED_COUNT>::new(
-                                Argb::DIAMOND_USER_AMBER,
+                                Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                                 4.0,
                                 0.0,
                                 false,
@@ -631,7 +631,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.set_ring(
                     LEVEL_NOTICE,
                     animations::Alert::<DIAMOND_RING_LED_COUNT>::new(
-                        Argb::DIAMOND_USER_SIGNUP,
+                        Argb::DIAMOND_OUTER_USER_SIGNUP,
                         BlinkDurations::from(vec![0.0, 0.5, 0.75, 0.2, 1.5, 0.2]),
                         Some(vec![0.49, 0.4, 0.19, 0.75, 0.2]),
                         true,
@@ -646,7 +646,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     animations::Progress::<DIAMOND_RING_LED_COUNT>::new(
                         0.0,
                         None,
-                        Argb::DIAMOND_USER_SIGNUP,
+                        Argb::DIAMOND_OUTER_USER_SIGNUP,
                     ),
                 );
 
@@ -795,7 +795,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.set_ring(
                     LEVEL_NOTICE,
                     animations::Alert::<DIAMOND_RING_LED_COUNT>::new(
-                        Argb::DIAMOND_USER_SIGNUP,
+                        Argb::DIAMOND_OUTER_USER_SIGNUP,
                         BlinkDurations::from(vec![0.0, 0.6, 3.6]),
                         None,
                         false,
@@ -867,7 +867,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.set_ring(
                         LEVEL_NOTICE,
                         animations::Spinner::<DIAMOND_RING_LED_COUNT>::triple(
-                            Argb::DIAMOND_USER_AMBER,
+                            Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
                         ),
                     );
                 }

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -236,24 +236,9 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.operator_idle.api_mode(*api_mode);
                 self.is_api_mode = *api_mode;
             }
-            Event::Shutdown { requested } => {
+            Event::Shutdown { requested: _ } => {
                 self.sound
                     .queue(sound::Type::Melody(sound::Melody::PoweringDown))?;
-                // overwrite any existing animation by setting notice-level animation
-                // as the last animation before shutdown
-                self.set_center(
-                    LEVEL_NOTICE,
-                    animations::Alert::<DIAMOND_CENTER_LED_COUNT>::new(
-                        if *requested {
-                            Argb::DIAMOND_USER_QR_SCAN
-                        } else {
-                            Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER
-                        },
-                        BlinkDurations::from(vec![0.0, 0.3, 0.45, 0.3, 0.45, 0.45]),
-                        None,
-                        false,
-                    ),
-                );
                 self.set_ring(
                     LEVEL_NOTICE,
                     animations::Static::<DIAMOND_RING_LED_COUNT>::new(Argb::OFF, None),

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -587,20 +587,17 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 if shround_breathing {
                     // stop any ongoing breathing animation
                     self.stop_center(LEVEL_NOTICE, false);
-                } else {
-                    if *in_range {
-                        if let Some(melody) = self.capture_sound.peekable().peek() {
-                            if self.sound.try_queue(sound::Type::Melody(*melody))? {
-                                self.capture_sound.next();
-                            }
+                } else if *in_range {
+                    if let Some(melody) = self.capture_sound.peekable().peek() {
+                        if self.sound.try_queue(sound::Type::Melody(*melody))? {
+                            self.capture_sound.next();
                         }
-                    } else {
-                        self.capture_sound =
-                            sound::capture::CaptureLoopSound::default();
-                        let _ = self
-                            .sound
-                            .try_queue(sound::Type::Voice(sound::Voice::Silence));
                     }
+                } else {
+                    self.capture_sound = sound::capture::CaptureLoopSound::default();
+                    let _ = self
+                        .sound
+                        .try_queue(sound::Type::Voice(sound::Voice::Silence));
                 }
             }
             Event::BiometricCaptureSuccess => {

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -597,7 +597,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                             )
                     })
                     .is_some();
-                if shround_breathing {
+                if shround_breathing && *in_range {
                     // stop any ongoing breathing animation
                     self.stop_center(LEVEL_NOTICE, false);
                 } else if *in_range {

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -417,7 +417,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         LEVEL_NOTICE,
                         animations::Wave::<DIAMOND_CENTER_LED_COUNT>::new(
                             Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
-                            4.0,
+                            3.0,
                             0.0,
                             self.is_self_serve, /* for a smooth transition:
                                                 in self-serve, center is off,
@@ -491,7 +491,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         LEVEL_NOTICE,
                         animations::Wave::<DIAMOND_CENTER_LED_COUNT>::new(
                             Argb::DIAMOND_SHROUD_SUMMON_USER_AMBER,
-                            4.0,
+                            3.0,
                             0.0,
                             self.is_self_serve, /* for a smooth transition:
                                                 in self-serve, center is off,

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -225,20 +225,21 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.operator_pulse.trigger(1., 1., false, false);
             }
             Event::NetworkConnectionSuccess => {
-                self.sound.queue(sound::Type::Melody(
-                    sound::Melody::InternetConnectionSuccessful,
-                ))?;
+                self.sound.queue(
+                    sound::Type::Melody(sound::Melody::InternetConnectionSuccessful),
+                    None,
+                )?;
             }
             Event::BootComplete { api_mode } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::BootUp))?;
+                    .queue(sound::Type::Melody(sound::Melody::BootUp), None)?;
                 self.operator_pulse.stop();
                 self.operator_idle.api_mode(*api_mode);
                 self.is_api_mode = *api_mode;
             }
             Event::Shutdown { requested: _ } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::PoweringDown))?;
+                    .queue(sound::Type::Melody(sound::Melody::PoweringDown), None)?;
                 self.set_ring(
                     LEVEL_NOTICE,
                     animations::Static::<DIAMOND_RING_LED_COUNT>::new(Argb::OFF, None),
@@ -249,7 +250,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             Event::SignupStart => {
                 self.capture_sound.reset();
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::StartSignup))?;
+                    .queue(sound::Type::Melody(sound::Melody::StartSignup), None)?;
                 // starting signup sequence
                 // animate from left to right (`operator_action`)
                 // and then keep first LED on as a background (`operator_signup_phase`)
@@ -294,9 +295,10 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     }
                     QrScanSchema::Wifi => {
                         self.operator_idle.no_wlan();
-                        self.sound.queue(sound::Type::Voice(
-                            sound::Voice::ShowWifiHotspotQrCode,
-                        ))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::ShowWifiHotspotQrCode),
+                            None,
+                        )?;
                     }
                     QrScanSchema::User => {
                         self.operator_signup_phase.user_qr_code_ok();
@@ -312,7 +314,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::QrScanCapture => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::QrCodeCapture))?;
+                    .queue(sound::Type::Melody(sound::Melody::QrCodeCapture), None)?;
             }
             Event::QrScanCompleted { schema } => {
                 self.stop_ring(LEVEL_FOREGROUND, true);
@@ -351,13 +353,16 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             Event::QrScanUnexpected { schema, reason } => {
                 match reason {
                     QrScanUnexpectedReason::Invalid => {
-                        self.sound
-                            .queue(sound::Type::Voice(sound::Voice::QrCodeInvalid))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::QrCodeInvalid),
+                            None,
+                        )?;
                     }
                     QrScanUnexpectedReason::WrongFormat => {
-                        self.sound.queue(sound::Type::Voice(
-                            sound::Voice::WrongQrCodeFormat,
-                        ))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::WrongQrCodeFormat),
+                            None,
+                        )?;
                     }
                 }
                 match schema {
@@ -373,7 +378,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::QrScanFail { schema } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::SoundError))?;
+                    .queue(sound::Type::Melody(sound::Melody::SoundError), None)?;
                 match schema {
                     QrScanSchema::User | QrScanSchema::Operator => {
                         self.stop_ring(LEVEL_FOREGROUND, true);
@@ -393,13 +398,17 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::QrScanSuccess { schema } => match schema {
                 QrScanSchema::Operator => {
-                    self.sound
-                        .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
+                    self.sound.queue(
+                        sound::Type::Melody(sound::Melody::QrLoadSuccess),
+                        None,
+                    )?;
                     self.operator_signup_phase.operator_qr_captured();
                 }
                 QrScanSchema::User => {
-                    self.sound
-                        .queue(sound::Type::Melody(sound::Melody::UserQrLoadSuccess))?;
+                    self.sound.queue(
+                        sound::Type::Melody(sound::Melody::UserQrLoadSuccess),
+                        None,
+                    )?;
                     self.operator_signup_phase.user_qr_captured();
                     // wave center LEDs to transition to biometric capture
                     // set background as static color during capture
@@ -427,13 +436,15 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.stop_cone(LEVEL_FOREGROUND, true);
                 }
                 QrScanSchema::Wifi => {
-                    self.sound
-                        .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
+                    self.sound.queue(
+                        sound::Type::Melody(sound::Melody::QrLoadSuccess),
+                        None,
+                    )?;
                 }
             },
             Event::QrScanTimeout { schema } => {
                 self.sound
-                    .queue(sound::Type::Voice(sound::Voice::Timeout))?;
+                    .queue(sound::Type::Voice(sound::Voice::Timeout), None)?;
                 match schema {
                     QrScanSchema::User | QrScanSchema::Operator => {
                         self.stop_ring(LEVEL_FOREGROUND, true);
@@ -457,7 +468,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 } else {
                     sound::Melody::SoundError
                 };
-                self.sound.queue(sound::Type::Melody(melody))?;
+                self.sound.queue(sound::Type::Melody(melody), None)?;
                 // This justs sets the operator LEDs yellow
                 // to inform the operator to press the button.
                 self.operator_signup_phase.failure();
@@ -475,8 +486,10 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 // if not self-serve, the animations to transition
                 // to biometric capture are already set in `QrScanSuccess`
                 if self.is_self_serve {
-                    self.sound
-                        .queue(sound::Type::Melody(sound::Melody::UserQrLoadSuccess))?;
+                    self.sound.queue(
+                        sound::Type::Melody(sound::Melody::UserQrLoadSuccess),
+                        None,
+                    )?;
                     // set background as static color during capture
                     // pulsing wave animation to be displayed on top
                     // while we wait for the user to be in position
@@ -602,7 +615,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::BiometricCaptureSuccess => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::IrisScanSuccess))?;
+                    .queue(sound::Type::Melody(sound::Melody::IrisScanSuccess), None)?;
                 // custom alert animation on ring
                 // a bit off for 500ms then on with fade out animation
                 // twice: first faster than the other
@@ -702,26 +715,35 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     LEVEL_BACKGROUND,
                     animations::Static::<DIAMOND_RING_LED_COUNT>::new(Argb::OFF, None),
                 );
-                self.sound
-                    .queue(sound::Type::Melody(sound::Melody::SoundError))?;
+                self.sound.queue(
+                    sound::Type::Melody(sound::Melody::SoundError),
+                    Some(Duration::from_millis(2000)),
+                )?;
                 match reason {
                     SignupFailReason::Timeout => {
                         self.sound
-                            .queue(sound::Type::Voice(sound::Voice::Timeout))?;
+                            .queue(sound::Type::Voice(sound::Voice::Timeout), None)?;
                     }
                     SignupFailReason::FaceNotFound => {
-                        self.sound
-                            .queue(sound::Type::Voice(sound::Voice::FaceNotFound))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::FaceNotFound),
+                            None,
+                        )?;
                     }
                     SignupFailReason::Server
                     | SignupFailReason::UploadCustodyImages => {
-                        self.sound
-                            .queue(sound::Type::Voice(sound::Voice::ServerError))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::ServerError),
+                            None,
+                        )?;
                     }
                     SignupFailReason::Verification => {
-                        self.sound.queue(sound::Type::Voice(
-                            sound::Voice::VerificationNotSuccessfulPleaseTryAgain,
-                        ))?;
+                        self.sound.queue(
+                            sound::Type::Voice(
+                                sound::Voice::VerificationNotSuccessfulPleaseTryAgain,
+                            ),
+                            None,
+                        )?;
                     }
                     SignupFailReason::SoftwareVersionDeprecated => {
                         self.operator_blink.trigger(
@@ -787,7 +809,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::SignupSuccess => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::SignupSuccess))?;
+                    .queue(sound::Type::Melody(sound::Melody::SignupSuccess), None)?;
 
                 self.operator_signup_phase.signup_successful();
 
@@ -855,8 +877,10 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.paused = false;
             }
             Event::RecoveryImage => {
-                self.sound
-                    .queue(sound::Type::Voice(sound::Voice::PleaseDontShutDown))?;
+                self.sound.queue(
+                    sound::Type::Voice(sound::Voice::PleaseDontShutDown),
+                    None,
+                )?;
                 // check that ring is not already in recovery mode
                 if self
                     .ring_animations_stack
@@ -878,14 +902,20 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 }
             }
             Event::NoInternetForSignup => {
-                self.sound.queue(sound::Type::Voice(
-                    sound::Voice::InternetConnectionTooSlowToPerformSignups,
-                ))?;
+                self.sound.queue(
+                    sound::Type::Voice(
+                        sound::Voice::InternetConnectionTooSlowToPerformSignups,
+                    ),
+                    None,
+                )?;
             }
             Event::SlowInternetForSignup => {
-                self.sound.queue(sound::Type::Voice(
-                    sound::Voice::InternetConnectionTooSlowSignupsMightTakeLonger,
-                ))?;
+                self.sound.queue(
+                    sound::Type::Voice(
+                        sound::Voice::InternetConnectionTooSlowSignupsMightTakeLonger,
+                    ),
+                    None,
+                )?;
             }
             Event::SoundVolume { level } => {
                 self.sound.set_master_volume(*level);
@@ -903,7 +933,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             }
             Event::SoundTest => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::BootUp))?;
+                    .queue(sound::Type::Melody(sound::Melody::BootUp), None)?;
             }
         }
         Ok(())

--- a/orb-ui/src/engine/mod.rs
+++ b/orb-ui/src/engine/mod.rs
@@ -232,6 +232,9 @@ event_enum! {
         /// Network connection successful
         #[event_enum(method = network_connection_success)]
         NetworkConnectionSuccess,
+        /// Biometric capture start.
+        #[event_enum(method = biometric_capture_start)]
+        BiometricCaptureStart,
         /// Biometric capture half of the objectives completed.
         #[event_enum(method = biometric_capture_half_objectives_completed)]
         BiometricCaptureHalfObjectivesCompleted,
@@ -436,6 +439,8 @@ struct Runner<const RING_LED_COUNT: usize, const CENTER_LED_COUNT: usize> {
     capture_sound: sound::capture::CaptureLoopSound,
     /// When set, update the UI one last time and then pause the engine, see `paused` below.
     is_api_mode: bool,
+    /// Is self-serve mode
+    is_self_serve: bool,
     /// Pause engine
     paused: bool,
 }

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -154,6 +154,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             sound,
             capture_sound: sound::capture::CaptureLoopSound::default(),
             is_api_mode: false,
+            is_self_serve: true,
             paused: false,
         }
     }
@@ -197,6 +198,11 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     animations::Idle::<PEARL_RING_LED_COUNT>::default(),
                 );
                 self.operator_pulse.trigger(1., 1., false, false);
+            }
+            Event::NetworkConnectionSuccess => {
+                self.sound.queue(sound::Type::Melody(
+                    sound::Melody::InternetConnectionSuccessful,
+                ))?;
             }
             Event::BootComplete { api_mode } => {
                 self.sound
@@ -262,6 +268,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 );
             }
             Event::QrScanStart { schema } => {
+                self.is_self_serve = false;
                 self.set_center(
                     LEVEL_FOREGROUND,
                     animations::Wave::<PEARL_CENTER_LED_COUNT>::new(
@@ -368,30 +375,8 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         self.operator_signup_phase.operator_qr_captured();
                     }
                     QrScanSchema::User => {
-                        self.sound.queue(sound::Type::Melody(
-                            sound::Melody::UserQrLoadSuccess,
-                        ))?;
                         self.operator_signup_phase.user_qr_captured();
-                        // initialize ring with animated short segment to invite user to start iris capture
-                        self.set_ring(
-                            LEVEL_NOTICE,
-                            animations::Slider::<PEARL_RING_LED_COUNT>::new(
-                                0.0,
-                                Argb::PEARL_USER_SIGNUP,
-                            )
-                            .with_pulsing(),
-                        );
-                        // remove short segment from ring (foreground, superseded by notice level above)
-                        self.stop_ring(LEVEL_FOREGROUND, false);
-                        // off background for biometric-capture, which relies on LEVEL_NOTICE animations
-                        self.stop_center(LEVEL_FOREGROUND, true);
-                        self.set_center(
-                            LEVEL_FOREGROUND,
-                            animations::Static::<PEARL_CENTER_LED_COUNT>::new(
-                                Argb::OFF,
-                                None,
-                            ),
-                        );
+                        // see `Event::BiometricCaptureStart
                     }
                     QrScanSchema::Wifi => {
                         self.sound
@@ -424,10 +409,26 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 // to inform the operator to press the button.
                 self.operator_signup_phase.failure();
             }
-            Event::NetworkConnectionSuccess => {
-                self.sound.queue(sound::Type::Melody(
-                    sound::Melody::InternetConnectionSuccessful,
-                ))?;
+            Event::BiometricCaptureStart => {
+                self.sound
+                    .queue(sound::Type::Melody(sound::Melody::UserQrLoadSuccess))?;
+                // initialize ring with animated short segment to invite user to start iris capture
+                self.set_ring(
+                    LEVEL_NOTICE,
+                    animations::Slider::<PEARL_RING_LED_COUNT>::new(
+                        0.0,
+                        Argb::PEARL_USER_SIGNUP,
+                    )
+                    .with_pulsing(),
+                );
+                // remove short segment from ring (foreground, superseded by notice level above)
+                self.stop_ring(LEVEL_FOREGROUND, false);
+                // off background for biometric-capture, which relies on LEVEL_NOTICE animations
+                self.stop_center(LEVEL_FOREGROUND, true);
+                self.set_center(
+                    LEVEL_FOREGROUND,
+                    animations::Static::<PEARL_CENTER_LED_COUNT>::new(Argb::OFF, None),
+                );
             }
             Event::BiometricCaptureHalfObjectivesCompleted => {
                 // do nothing
@@ -682,6 +683,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 self.stop_center(LEVEL_FOREGROUND, false);
                 self.stop_center(LEVEL_NOTICE, false);
                 self.operator_signup_phase.idle();
+                self.is_self_serve = true;
             }
             Event::GoodInternet => {
                 self.operator_idle.good_internet();

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -200,20 +200,21 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 self.operator_pulse.trigger(1., 1., false, false);
             }
             Event::NetworkConnectionSuccess => {
-                self.sound.queue(sound::Type::Melody(
-                    sound::Melody::InternetConnectionSuccessful,
-                ))?;
+                self.sound.queue(
+                    sound::Type::Melody(sound::Melody::InternetConnectionSuccessful),
+                    None,
+                )?;
             }
             Event::BootComplete { api_mode } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::BootUp))?;
+                    .queue(sound::Type::Melody(sound::Melody::BootUp), None)?;
                 self.operator_pulse.stop();
                 self.operator_idle.api_mode(*api_mode);
                 self.is_api_mode = *api_mode;
             }
             Event::Shutdown { requested } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::PoweringDown))?;
+                    .queue(sound::Type::Melody(sound::Melody::PoweringDown), None)?;
                 // overwrite any existing animation by setting notice-level animation
                 // as the last animation before shutdown
                 self.set_center(
@@ -239,7 +240,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             Event::SignupStart => {
                 self.capture_sound.reset();
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::StartSignup))?;
+                    .queue(sound::Type::Melody(sound::Melody::StartSignup), None)?;
                 // starting signup sequence
                 // animate from left to right (`operator_action`)
                 // and then keep first LED on as a background (`operator_signup_phase`)
@@ -285,9 +286,10 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     }
                     QrScanSchema::Wifi => {
                         self.operator_idle.no_wlan();
-                        self.sound.queue(sound::Type::Voice(
-                            sound::Voice::ShowWifiHotspotQrCode,
-                        ))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::ShowWifiHotspotQrCode),
+                            None,
+                        )?;
                     }
                     QrScanSchema::User => {
                         self.operator_signup_phase.user_qr_code_ok();
@@ -306,7 +308,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 // stop wave (foreground) & show alert/blinks (notice)
                 self.stop_center(LEVEL_FOREGROUND, true);
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::QrCodeCapture))?;
+                    .queue(sound::Type::Melody(sound::Melody::QrCodeCapture), None)?;
             }
             Event::QrScanCompleted { schema } => {
                 // stop wave (foreground) & show alert/blinks (notice)
@@ -330,13 +332,16 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             Event::QrScanUnexpected { schema, reason } => {
                 match reason {
                     QrScanUnexpectedReason::Invalid => {
-                        self.sound
-                            .queue(sound::Type::Voice(sound::Voice::QrCodeInvalid))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::QrCodeInvalid),
+                            None,
+                        )?;
                     }
                     QrScanUnexpectedReason::WrongFormat => {
-                        self.sound.queue(sound::Type::Voice(
-                            sound::Voice::WrongQrCodeFormat,
-                        ))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::WrongQrCodeFormat),
+                            None,
+                        )?;
                     }
                 }
                 match schema {
@@ -355,7 +360,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             }
             Event::QrScanFail { schema } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::SoundError))?;
+                    .queue(sound::Type::Melody(sound::Melody::SoundError), None)?;
                 match schema {
                     QrScanSchema::User | QrScanSchema::Operator => {
                         // in case schema is user qr
@@ -370,8 +375,10 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             Event::QrScanSuccess { schema } => {
                 match schema {
                     QrScanSchema::Operator => {
-                        self.sound
-                            .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
+                        self.sound.queue(
+                            sound::Type::Melody(sound::Melody::QrLoadSuccess),
+                            None,
+                        )?;
                         self.operator_signup_phase.operator_qr_captured();
                     }
                     QrScanSchema::User => {
@@ -379,14 +386,16 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         // see `Event::BiometricCaptureStart
                     }
                     QrScanSchema::Wifi => {
-                        self.sound
-                            .queue(sound::Type::Melody(sound::Melody::QrLoadSuccess))?;
+                        self.sound.queue(
+                            sound::Type::Melody(sound::Melody::QrLoadSuccess),
+                            None,
+                        )?;
                     }
                 }
             }
             Event::QrScanTimeout { schema } => {
                 self.sound
-                    .queue(sound::Type::Voice(sound::Voice::Timeout))?;
+                    .queue(sound::Type::Voice(sound::Voice::Timeout), None)?;
                 match schema {
                     QrScanSchema::User | QrScanSchema::Operator => {
                         // in case schema is user qr
@@ -404,14 +413,16 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 } else {
                     sound::Melody::SoundError
                 };
-                self.sound.queue(sound::Type::Melody(melody))?;
+                self.sound.queue(sound::Type::Melody(melody), None)?;
                 // This justs sets the operator LEDs yellow
                 // to inform the operator to press the button.
                 self.operator_signup_phase.failure();
             }
             Event::BiometricCaptureStart => {
-                self.sound
-                    .queue(sound::Type::Melody(sound::Melody::UserQrLoadSuccess))?;
+                self.sound.queue(
+                    sound::Type::Melody(sound::Melody::UserQrLoadSuccess),
+                    None,
+                )?;
                 // initialize ring with animated short segment to invite user to start iris capture
                 self.set_ring(
                     LEVEL_NOTICE,
@@ -497,7 +508,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             }
             Event::BiometricCaptureSuccess => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::IrisScanSuccess))?;
+                    .queue(sound::Type::Melody(sound::Melody::IrisScanSuccess), None)?;
                 // set ring to full circle based on previous progress animation
                 // ring will be reset when biometric pipeline starts showing progress
                 let _ = self
@@ -586,25 +597,32 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             }
             Event::SignupFail { reason } => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::SoundError))?;
+                    .queue(sound::Type::Melody(sound::Melody::SoundError), None)?;
                 match reason {
                     SignupFailReason::Timeout => {
                         self.sound
-                            .queue(sound::Type::Voice(sound::Voice::Timeout))?;
+                            .queue(sound::Type::Voice(sound::Voice::Timeout), None)?;
                     }
                     SignupFailReason::FaceNotFound => {
-                        self.sound
-                            .queue(sound::Type::Voice(sound::Voice::FaceNotFound))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::FaceNotFound),
+                            None,
+                        )?;
                     }
                     SignupFailReason::Server
                     | SignupFailReason::UploadCustodyImages => {
-                        self.sound
-                            .queue(sound::Type::Voice(sound::Voice::ServerError))?;
+                        self.sound.queue(
+                            sound::Type::Voice(sound::Voice::ServerError),
+                            None,
+                        )?;
                     }
                     SignupFailReason::Verification => {
-                        self.sound.queue(sound::Type::Voice(
-                            sound::Voice::VerificationNotSuccessfulPleaseTryAgain,
-                        ))?;
+                        self.sound.queue(
+                            sound::Type::Voice(
+                                sound::Voice::VerificationNotSuccessfulPleaseTryAgain,
+                            ),
+                            None,
+                        )?;
                     }
                     SignupFailReason::SoftwareVersionDeprecated => {
                         self.operator_blink.trigger(
@@ -649,7 +667,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             }
             Event::SignupSuccess => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::SignupSuccess))?;
+                    .queue(sound::Type::Melody(sound::Melody::SignupSuccess), None)?;
 
                 self.operator_signup_phase.signup_successful();
 
@@ -716,8 +734,10 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 self.paused = false;
             }
             Event::RecoveryImage => {
-                self.sound
-                    .queue(sound::Type::Voice(sound::Voice::PleaseDontShutDown))?;
+                self.sound.queue(
+                    sound::Type::Voice(sound::Voice::PleaseDontShutDown),
+                    None,
+                )?;
                 // check that ring is not already in recovery mode
                 if self
                     .ring_animations_stack
@@ -739,14 +759,20 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 }
             }
             Event::NoInternetForSignup => {
-                self.sound.queue(sound::Type::Voice(
-                    sound::Voice::InternetConnectionTooSlowToPerformSignups,
-                ))?;
+                self.sound.queue(
+                    sound::Type::Voice(
+                        sound::Voice::InternetConnectionTooSlowToPerformSignups,
+                    ),
+                    None,
+                )?;
             }
             Event::SlowInternetForSignup => {
-                self.sound.queue(sound::Type::Voice(
-                    sound::Voice::InternetConnectionTooSlowSignupsMightTakeLonger,
-                ))?;
+                self.sound.queue(
+                    sound::Type::Voice(
+                        sound::Voice::InternetConnectionTooSlowSignupsMightTakeLonger,
+                    ),
+                    None,
+                )?;
             }
             Event::SoundVolume { level } => {
                 self.sound.set_master_volume(*level);
@@ -764,7 +790,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             }
             Event::SoundTest => {
                 self.sound
-                    .queue(sound::Type::Melody(sound::Melody::BootUp))?;
+                    .queue(sound::Type::Melody(sound::Melody::BootUp), None)?;
             }
         }
         Ok(())

--- a/orb-ui/src/main.rs
+++ b/orb-ui/src/main.rs
@@ -142,10 +142,10 @@ async fn main() -> Result<()> {
             };
             match args {
                 SimulationArgs::SelfServe => {
-                    signup_simulation(ui.as_ref(), true).await?
+                    signup_simulation(ui.as_ref(), true, true).await?
                 }
                 SimulationArgs::Operator => {
-                    signup_simulation(ui.as_ref(), false).await?
+                    signup_simulation(ui.as_ref(), false, true).await?
                 }
             }
         }

--- a/orb-ui/src/simulation.rs
+++ b/orb-ui/src/simulation.rs
@@ -15,7 +15,7 @@ pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> 
     ui.battery_capacity(100);
     ui.good_internet();
     ui.good_wlan();
-    time::sleep(Duration::from_secs(1)).await;
+    time::sleep(Duration::from_secs(2)).await;
 
     if !self_serve {
         // operator presses the button to initiate signup
@@ -23,13 +23,17 @@ pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> 
         time::sleep(Duration::from_secs(1)).await;
 
         ui.qr_scan_start(QrScanSchema::Operator);
-        time::sleep(Duration::from_secs(4)).await;
+        time::sleep(Duration::from_secs(3)).await;
+        ui.qr_scan_capture();
+        time::sleep(Duration::from_secs(1)).await;
         ui.qr_scan_completed(QrScanSchema::Operator);
 
         ui.qr_scan_success(QrScanSchema::Operator);
         time::sleep(Duration::from_secs(1)).await;
         ui.qr_scan_start(QrScanSchema::User);
-        time::sleep(Duration::from_secs(4)).await;
+        time::sleep(Duration::from_secs(3)).await;
+        ui.qr_scan_capture();
+        time::sleep(Duration::from_secs(1)).await;
         ui.qr_scan_completed(QrScanSchema::User);
 
         ui.qr_scan_success(QrScanSchema::User);
@@ -38,7 +42,7 @@ pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> 
         // - cone button pressed, or
         // - app button pressed
         ui.biometric_capture_start();
-        time::sleep(Duration::from_secs(2)).await;
+        time::sleep(Duration::from_secs(1)).await;
     }
 
     // waiting for the user to be in correct position
@@ -84,14 +88,15 @@ pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> 
             // biometric pipeline, in 2 stages
             // to test `starting_enrollment`
             time::sleep(Duration::from_secs(1)).await;
-            for i in 0..5 {
-                ui.biometric_pipeline_progress(i as f64 / 10.0);
+            for i in 0..=2 {
+                ui.biometric_pipeline_progress(i as f64 / 5.0);
                 time::sleep(Duration::from_secs(1)).await;
             }
+            time::sleep(Duration::from_secs(1)).await;
             ui.starting_enrollment();
-            time::sleep(Duration::from_secs(4)).await;
-            for i in 5..10 {
-                ui.biometric_pipeline_progress(i as f64 / 10.0);
+            time::sleep(Duration::from_secs(2)).await;
+            for i in 2..5 {
+                ui.biometric_pipeline_progress(i as f64 / 5.0);
                 time::sleep(Duration::from_millis(500)).await;
             }
             ui.biometric_pipeline_success();

--- a/orb-ui/src/simulation.rs
+++ b/orb-ui/src/simulation.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use tokio::time;
 use tracing::info;
 
-pub async fn signup_simulation(ui: &dyn Engine) -> Result<()> {
-    info!("🔹 Starting simulation");
+pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> {
+    info!("🔹 Starting simulation (self-serve: {})", self_serve);
 
     ui.bootup();
     time::sleep(Duration::from_secs(5)).await;
@@ -17,33 +17,44 @@ pub async fn signup_simulation(ui: &dyn Engine) -> Result<()> {
     ui.good_wlan();
     time::sleep(Duration::from_secs(5)).await;
 
-    ui.signup_start();
+    if !self_serve {
+        // operator presses the button to initiate signup
+        ui.signup_start();
+        time::sleep(Duration::from_secs(1)).await;
+
+        ui.qr_scan_start(QrScanSchema::Operator);
+        time::sleep(Duration::from_secs(4)).await;
+        ui.qr_scan_completed(QrScanSchema::Operator);
+
+        ui.qr_scan_success(QrScanSchema::Operator);
+        time::sleep(Duration::from_secs(1)).await;
+        ui.qr_scan_start(QrScanSchema::User);
+        time::sleep(Duration::from_secs(4)).await;
+        ui.qr_scan_completed(QrScanSchema::User);
+
+        ui.qr_scan_success(QrScanSchema::User);
+    }
+
+    // biometric capture start, either:
+    // - cone button pressed, or
+    // - app button pressed
+    ui.biometric_capture_start();
     time::sleep(Duration::from_secs(2)).await;
-    ui.qr_scan_start(QrScanSchema::Operator);
+
+    // waiting for the user to be in correct position
+    ui.biometric_capture_distance(false);
     time::sleep(Duration::from_secs(4)).await;
-    ui.qr_scan_completed(QrScanSchema::Operator);
 
-    ui.qr_scan_success(QrScanSchema::Operator);
-    time::sleep(Duration::from_secs(1)).await;
-    ui.qr_scan_start(QrScanSchema::User);
-    time::sleep(Duration::from_secs(4)).await;
-    ui.qr_scan_completed(QrScanSchema::User);
-
-    ui.qr_scan_success(QrScanSchema::User);
-    time::sleep(Duration::from_secs(1)).await;
-
-    ui.biometric_capture_occlusion(true);
-
-    time::sleep(Duration::from_secs(2)).await;
+    // user is in correct position
     ui.biometric_capture_distance(true);
-
-    time::sleep(Duration::from_secs(2)).await;
     ui.biometric_capture_occlusion(false);
     for i in 0..10 {
         if (4..=6).contains(&i) {
+            // simulate user moving away
             ui.biometric_capture_distance(false);
             ui.biometric_capture_occlusion(true);
         } else {
+            // capture is making progress
             ui.biometric_capture_distance(true);
             ui.biometric_capture_occlusion(false);
             ui.biometric_capture_distance(true);
@@ -52,34 +63,37 @@ pub async fn signup_simulation(ui: &dyn Engine) -> Result<()> {
 
         time::sleep(Duration::from_secs(1)).await;
     }
+    // fill the ring
     ui.biometric_capture_progress(1.1);
     time::sleep(Duration::from_secs(1)).await;
 
     ui.biometric_capture_success();
 
-    // biometric pipeline, in 2 stages
-    // to test `starting_enrollment`
-    time::sleep(Duration::from_secs(1)).await;
-    for i in 0..5 {
-        ui.biometric_pipeline_progress(i as f64 / 10.0);
+    if !self_serve {
+        // biometric pipeline, in 2 stages
+        // to test `starting_enrollment`
         time::sleep(Duration::from_secs(1)).await;
-    }
-    ui.starting_enrollment();
-    time::sleep(Duration::from_secs(4)).await;
-    for i in 5..10 {
-        ui.biometric_pipeline_progress(i as f64 / 10.0);
-        time::sleep(Duration::from_millis(500)).await;
-    }
-    ui.biometric_pipeline_success();
+        for i in 0..5 {
+            ui.biometric_pipeline_progress(i as f64 / 10.0);
+            time::sleep(Duration::from_secs(1)).await;
+        }
+        ui.starting_enrollment();
+        time::sleep(Duration::from_secs(4)).await;
+        for i in 5..10 {
+            ui.biometric_pipeline_progress(i as f64 / 10.0);
+            time::sleep(Duration::from_millis(500)).await;
+        }
+        ui.biometric_pipeline_success();
 
-    time::sleep(Duration::from_secs(1)).await;
-    if rand::random::<u8>() % 2 == 0 {
-        ui.signup_success();
-    } else {
-        let fail_reason = SignupFailReason::from(
-            rand::random::<u8>() % SignupFailReason::Unknown as u8,
-        );
-        ui.signup_fail(fail_reason);
+        time::sleep(Duration::from_secs(1)).await;
+        if rand::random::<u8>() % 2 == 0 {
+            ui.signup_success();
+        } else {
+            let fail_reason = SignupFailReason::from(
+                rand::random::<u8>() % SignupFailReason::Unknown as u8,
+            );
+            ui.signup_fail(fail_reason);
+        }
     }
 
     ui.idle();

--- a/orb-ui/src/simulation.rs
+++ b/orb-ui/src/simulation.rs
@@ -4,8 +4,9 @@ use std::time::Duration;
 use tokio::time;
 use tracing::info;
 
-pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> {
-    info!("🔹 Starting simulation (self-serve: {})", self_serve);
+#[expect(dead_code)]
+pub async fn bootup_simulation(ui: &dyn Engine) -> Result<()> {
+    info!("🔹 Starting boot-up simulation");
 
     ui.bootup();
     time::sleep(Duration::from_secs(1)).await;
@@ -17,105 +18,131 @@ pub async fn signup_simulation(ui: &dyn Engine, self_serve: bool) -> Result<()> 
     ui.good_wlan();
     time::sleep(Duration::from_secs(2)).await;
 
+    Ok(())
+}
+
+pub async fn signup_simulation(
+    ui: &dyn Engine,
+    self_serve: bool,
+    looping: bool,
+) -> Result<()> {
+    info!("🔹 Starting signup simulation (self-serve: {})", self_serve);
+
+    ui.idle();
+    time::sleep(Duration::from_secs(1)).await;
+
     if !self_serve {
         // operator presses the button to initiate signup
         ui.signup_start();
         time::sleep(Duration::from_secs(1)).await;
+    }
 
+    loop {
+        // scanning operator QR code
         ui.qr_scan_start(QrScanSchema::Operator);
-        time::sleep(Duration::from_secs(3)).await;
+        time::sleep(Duration::from_secs(4)).await;
         ui.qr_scan_capture();
-        time::sleep(Duration::from_secs(1)).await;
+        time::sleep(Duration::from_secs(2)).await;
         ui.qr_scan_completed(QrScanSchema::Operator);
-
         ui.qr_scan_success(QrScanSchema::Operator);
+
+        // scanning user QR code
         time::sleep(Duration::from_secs(1)).await;
         ui.qr_scan_start(QrScanSchema::User);
-        time::sleep(Duration::from_secs(3)).await;
+        time::sleep(Duration::from_secs(4)).await;
         ui.qr_scan_capture();
-        time::sleep(Duration::from_secs(1)).await;
+        time::sleep(Duration::from_secs(2)).await;
         ui.qr_scan_completed(QrScanSchema::User);
-
         ui.qr_scan_success(QrScanSchema::User);
-    } else {
+
         // biometric capture start, either:
         // - cone button pressed, or
         // - app button pressed
         ui.biometric_capture_start();
         time::sleep(Duration::from_secs(1)).await;
-    }
 
-    // waiting for the user to be in correct position
-    ui.biometric_capture_distance(false);
-    time::sleep(Duration::from_secs(3)).await;
+        // waiting for the user to be in correct position
+        ui.biometric_capture_distance(false);
+        time::sleep(Duration::from_secs(6)).await;
 
-    let mut biometric_capture_error = false;
+        let mut biometric_capture_error = false;
 
-    // user is in correct position
-    ui.biometric_capture_distance(true);
-    ui.biometric_capture_occlusion(false);
-    for i in 0..20 {
-        if (8..=12).contains(&i) {
-            // simulate user moving away
-            ui.biometric_capture_distance(false);
-            ui.biometric_capture_occlusion(true);
-        } else {
-            // capture is making progress
-            ui.biometric_capture_distance(true);
-            ui.biometric_capture_occlusion(false);
-            ui.biometric_capture_distance(true);
-            ui.biometric_capture_progress(i as f64 / 20.0);
+        // user is in correct position
+        ui.biometric_capture_distance(true);
+        ui.biometric_capture_occlusion(false);
+        for i in 0..100 {
+            if (30..=50).contains(&i) {
+                // simulate user moving away
+                ui.biometric_capture_distance(false);
+                ui.biometric_capture_occlusion(true);
+            } else {
+                // capture is making progress
+                ui.biometric_capture_distance(true);
+                ui.biometric_capture_occlusion(false);
+                ui.biometric_capture_distance(true);
+                ui.biometric_capture_progress(i as f64 / 100.0);
+            }
+
+            // randomly simulate error
+            if i == 50 && rand::random::<u8>() % 5 == 0 {
+                info!("⚠️ Simulating biometric capture error");
+                biometric_capture_error = true;
+                ui.signup_fail(SignupFailReason::Timeout);
+                break;
+            }
+
+            time::sleep(Duration::from_millis(100)).await;
         }
 
-        // randomly simulate error
-        if i == 12 && rand::random::<u8>() % 5 == 0 {
-            biometric_capture_error = true;
-            ui.signup_fail(SignupFailReason::Timeout);
+        if !biometric_capture_error {
+            // fill the ring
+            ui.biometric_capture_progress(1.1);
+            time::sleep(Duration::from_secs(1)).await;
+
+            ui.biometric_capture_success();
+
+            if !self_serve {
+                // biometric pipeline, in 2 stages
+                // to test `starting_enrollment`
+                time::sleep(Duration::from_secs(1)).await;
+                for i in 0..=2 {
+                    ui.biometric_pipeline_progress(i as f64 / 5.0);
+                    time::sleep(Duration::from_secs(1)).await;
+                }
+                time::sleep(Duration::from_secs(1)).await;
+                ui.starting_enrollment();
+                time::sleep(Duration::from_secs(2)).await;
+                for i in 2..5 {
+                    ui.biometric_pipeline_progress(i as f64 / 5.0);
+                    time::sleep(Duration::from_millis(500)).await;
+                }
+                ui.biometric_pipeline_success();
+
+                time::sleep(Duration::from_secs(1)).await;
+                if rand::random::<u8>() % 2 == 0 {
+                    ui.signup_success();
+                } else {
+                    let fail_reason = SignupFailReason::from(
+                        rand::random::<u8>() % SignupFailReason::Unknown as u8,
+                    );
+                    ui.signup_fail(fail_reason);
+                }
+            }
+        }
+
+        ui.idle();
+        time::sleep(Duration::from_secs(20)).await;
+
+        if !looping {
             break;
         }
-
-        time::sleep(Duration::from_millis(500)).await;
     }
 
-    if !biometric_capture_error {
-        // fill the ring
-        ui.biometric_capture_progress(1.1);
-        time::sleep(Duration::from_secs(1)).await;
+    Ok(())
+}
 
-        ui.biometric_capture_success();
-
-        if !self_serve {
-            // biometric pipeline, in 2 stages
-            // to test `starting_enrollment`
-            time::sleep(Duration::from_secs(1)).await;
-            for i in 0..=2 {
-                ui.biometric_pipeline_progress(i as f64 / 5.0);
-                time::sleep(Duration::from_secs(1)).await;
-            }
-            time::sleep(Duration::from_secs(1)).await;
-            ui.starting_enrollment();
-            time::sleep(Duration::from_secs(2)).await;
-            for i in 2..5 {
-                ui.biometric_pipeline_progress(i as f64 / 5.0);
-                time::sleep(Duration::from_millis(500)).await;
-            }
-            ui.biometric_pipeline_success();
-
-            time::sleep(Duration::from_secs(1)).await;
-            if rand::random::<u8>() % 2 == 0 {
-                ui.signup_success();
-            } else {
-                let fail_reason = SignupFailReason::from(
-                    rand::random::<u8>() % SignupFailReason::Unknown as u8,
-                );
-                ui.signup_fail(fail_reason);
-            }
-        }
-    }
-
-    ui.idle();
-    time::sleep(Duration::from_secs(7)).await;
-
+#[expect(dead_code)]
+pub async fn shutdown_simulation(ui: &dyn Engine) -> Result<()> {
     ui.shutdown(true);
     time::sleep(Duration::from_secs(2)).await;
 


### PR DESCRIPTION
tweaked colors
new event for biometric capture start
new scenario: self-serve or operator-assisted

new simulation modes:
```
Signup simulation

Usage: orb-ui simulation <COMMAND>

Commands:
  self-serve  Self-serve signup, app-based
  operator    Operator-based signup, with QR codes
  help        Print this message or the help of the given subcommand(s)
```