### PR TITLE
orb-ui: sound files in debian package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.wav filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/check-sound-files.yaml
+++ b/.github/workflows/check-sound-files.yaml
@@ -1,0 +1,22 @@
+name: Check Sound Files
+
+on:
+  push:
+    paths:
+      - 'orb-ui/sound/assets/**'
+      - '.github/workflows/check-sound-files.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
+        with:
+          lfs: true
+      - run: sudo apt-get install -y sox
+      - name: Check sound files
+        run: |
+          bash ./orb-ui/sound/utils/check_sounds.sh orb-ui/sound/assets/
+          # ensure error code is 0
+          exit $?

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -158,6 +158,7 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
           token: ${{ secrets.GIT_HUB_TOKEN }}
+          lfs: true
       - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # pin@v27
         with:
           github_access_token: ${{ secrets.GIT_HUB_TOKEN }}

--- a/orb-ui/Cargo.toml
+++ b/orb-ui/Cargo.toml
@@ -49,6 +49,9 @@ chrono = "0.4.35"
 
 [package.metadata.deb]
 maintainer-scripts = "debian/"
+assets = [
+  ["sound/assets/*.wav", "/home/worldcoin/data/sounds/", "644"]
+]
 systemd-units = [
   { unit-name = "worldcoin-ui" },
 ]

--- a/orb-ui/sound/assets/silence.wav
+++ b/orb-ui/sound/assets/silence.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8357b2963577f7e06c2fc1cc79e99880d7939141fba020371eb1e7a893d1708d
+size 44292

--- a/orb-ui/sound/assets/silence__es-ES.wav
+++ b/orb-ui/sound/assets/silence__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8357b2963577f7e06c2fc1cc79e99880d7939141fba020371eb1e7a893d1708d
+size 44292

--- a/orb-ui/sound/assets/sound_bootup.wav
+++ b/orb-ui/sound/assets/sound_bootup.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a24e8a9ceea46eb62640cf73e117a6e3349835bd0972f5e4bacc2fdcc43d8a5d
+size 684740

--- a/orb-ui/sound/assets/sound_error.wav
+++ b/orb-ui/sound/assets/sound_error.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fed9dab45b8349446bd50cea5a6e586e6af0695e64787720f6218db7575bb04c
+size 64344

--- a/orb-ui/sound/assets/sound_internet_connection_successful.wav
+++ b/orb-ui/sound/assets/sound_internet_connection_successful.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cc05f347d56ff1ad20e326f62b31122c552db59eb0ceef8606787a638517769
+size 299360

--- a/orb-ui/sound/assets/sound_iris_scan_success.wav
+++ b/orb-ui/sound/assets/sound_iris_scan_success.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e15689573106093d9608c59eb84ae92ec4fd61de53b933a3debe507a345aec3
+size 417732

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_01.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_01.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b103377fd0097ea58adb2aacef18e1e58a5f6f358a2ab32b567f29c31f22f89c
+size 923332

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_01A.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_01A.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2373f34fc8cd9273a43dd9fd85e730fb185dd098b0c6eba4a506453b7488586
+size 348496

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_01B.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_01B.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca6a7897edd3668e2f0253b4ce4f2216ee53fb04f75a3f5c6ad8bd5e87031283
+size 351028

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_01C.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_01C.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6eadf18a3008eeb2f3ef231b726748bae330d21a0e8622e9314e120f96e618b7
+size 236504

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_02.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_02.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbbea27694bee03e2e96990e657746329bb6bededeba5c990d42338c3077beff
+size 923332

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_02A.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_02A.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51215e7fe1caa143df32843b830f90356d04faad221f34478ebe21f287411f6d
+size 347092

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_02B.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_02B.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9fb244534525140e61ed5e43098b06500e7bbdbefc6d5f4abfa040ad9059f99
+size 406928

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_02C.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_02C.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b33d45faee162d4821dced8f92a4abffe588feb8abc306634200a5a3f80fe261
+size 179768

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_03.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_03.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bc82b8d2d14341d354a9b9be2ae3689cebb905d01ac9cfeec57c339b60f7a41
+size 923332

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_03A.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_03A.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c1a0c16387e5c57f7e9e6fa26ead9a27aa70e8b23ad1ae66d44bd9b41626fdc
+size 346116

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_03B.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_03B.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e8523601cb1e810bba9fd18198d715f76fb455f4345c8a5c96817e65b81901d
+size 354124

--- a/orb-ui/sound/assets/sound_iris_scanning_loop_03C.wav
+++ b/orb-ui/sound/assets/sound_iris_scanning_loop_03C.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb526a31436fd2b0b148b1f5ede5bc45e0a12a5654b1dddf33ec9d38dfa5fa2f
+size 236632

--- a/orb-ui/sound/assets/sound_overheating.wav
+++ b/orb-ui/sound/assets/sound_overheating.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eae3d36ad0254daeb10bf19d492cd32e87725a2ffb3535123d837abe7aa7983
+size 354590

--- a/orb-ui/sound/assets/sound_powering_down.wav
+++ b/orb-ui/sound/assets/sound_powering_down.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b2a071a891efbc771ac4f20c770ccbf13c69d72a688c68e4e90f24c11020651
+size 566364

--- a/orb-ui/sound/assets/sound_qr_code_capture.wav
+++ b/orb-ui/sound/assets/sound_qr_code_capture.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ccc92c2ceb66465ef5e69222b7ca7e214c3ab6940c8c66230cbfb7b315570fa
+size 120320

--- a/orb-ui/sound/assets/sound_qr_load_success.wav
+++ b/orb-ui/sound/assets/sound_qr_load_success.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb25523d233fd5e981bfabb10fb334d5f1c3c9991ab4a18ba687846a2457893c
+size 389828

--- a/orb-ui/sound/assets/sound_signup_success.wav
+++ b/orb-ui/sound/assets/sound_signup_success.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f939b3b6ac9143ce2df481dfc39e57091c7ac357a57d33bb35c4b68d8678c4e3
+size 471596

--- a/orb-ui/sound/assets/sound_start_idle.wav
+++ b/orb-ui/sound/assets/sound_start_idle.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f6c183bbbd78d90005df00fabb7c95de2bc60112b997f2a9d0298fc224f2368
+size 614444

--- a/orb-ui/sound/assets/sound_start_signup.wav
+++ b/orb-ui/sound/assets/sound_start_signup.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c898a9dede138439d442539c72428f83f34d3933883ea9db60243c3f5bd6dd56
+size 366276

--- a/orb-ui/sound/assets/sound_user_qr_load_success.wav
+++ b/orb-ui/sound/assets/sound_user_qr_load_success.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a9ba06cd2072b6a3818990bf0445c5792509e8d3a68f4aa4ea49f3ca544600c
+size 352844

--- a/orb-ui/sound/assets/voice_biometrics_finished.wav
+++ b/orb-ui/sound/assets/voice_biometrics_finished.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:505aae924a8a1e7a4c899844cd3a5a6c230962f01327a4b6ab9c13df914950b0
+size 128890

--- a/orb-ui/sound/assets/voice_biometrics_finished__es-ES.wav
+++ b/orb-ui/sound/assets/voice_biometrics_finished__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b3420594333f092a4b9dc5d575ed4794a67ad1b66b978453763f4196e16cab2
+size 128264

--- a/orb-ui/sound/assets/voice_face_detected.wav
+++ b/orb-ui/sound/assets/voice_face_detected.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:89118a51cafc3b08f8f9bc1900eeb4d27d988967b01cbf9772d0d1d25e99ef61
+size 40078

--- a/orb-ui/sound/assets/voice_face_detected__es-ES.wav
+++ b/orb-ui/sound/assets/voice_face_detected__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cd316daf1e301715cdaf2ef2d803658aace8dec37f30784e0eb2fba2875345a
+size 48336

--- a/orb-ui/sound/assets/voice_face_not_found.wav
+++ b/orb-ui/sound/assets/voice_face_not_found.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f0793935c71edfbf15bcca4fa1b7313fb68ca30336209ced61d90996f91e630
+size 125264

--- a/orb-ui/sound/assets/voice_face_not_found__es-ES.wav
+++ b/orb-ui/sound/assets/voice_face_not_found__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:79063621f9a2debb8ef9b98cf7763374671634c0b2599ba63b58e1ccde483c61
+size 134222

--- a/orb-ui/sound/assets/voice_internet_connection_too_slow_signups_might_take_longer_than_expected.wav
+++ b/orb-ui/sound/assets/voice_internet_connection_too_slow_signups_might_take_longer_than_expected.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7593435b59ef6cb91f415d92d8c7c3cf472b6df88faf8563d1c8c4c0ece25577
+size 255822

--- a/orb-ui/sound/assets/voice_internet_connection_too_slow_signups_might_take_longer_than_expected__es-ES.wav
+++ b/orb-ui/sound/assets/voice_internet_connection_too_slow_signups_might_take_longer_than_expected__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08dd5e363786dd999e3e3c0a093a161d3b9c3b2e7737f990a4105d5298f6fb1a
+size 256384

--- a/orb-ui/sound/assets/voice_internet_connection_too_slow_to_perform_signups.wav
+++ b/orb-ui/sound/assets/voice_internet_connection_too_slow_to_perform_signups.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:900d6a254f9d2a9034793a1f8cc6b193a32b75672a96b1ade8ac66d40926f802
+size 159020

--- a/orb-ui/sound/assets/voice_internet_connection_too_slow_to_perform_signups__es-ES.wav
+++ b/orb-ui/sound/assets/voice_internet_connection_too_slow_to_perform_signups__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ac2e2793fdd16a22d79b86406e3814a58b032c7a8e1c7a3acd09543190c0d650
+size 183034

--- a/orb-ui/sound/assets/voice_iris_detected_initiating_scan.wav
+++ b/orb-ui/sound/assets/voice_iris_detected_initiating_scan.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6099a60ae773b457ae9da7cdfc4f51b62625d7416e538baf34fb1bb1c29f768
+size 117092

--- a/orb-ui/sound/assets/voice_iris_detected_initiating_scan__es-ES.wav
+++ b/orb-ui/sound/assets/voice_iris_detected_initiating_scan__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:613732434968a92c4c1c62d0702e876c8bf3b3e7b39f93f9a02ea74304a489b6
+size 106192

--- a/orb-ui/sound/assets/voice_iris_duplicates.wav
+++ b/orb-ui/sound/assets/voice_iris_duplicates.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aa13a95dea8972523000ec6644328875ab095e08a813f5ec4dd5cfc4ba9a394
+size 78596

--- a/orb-ui/sound/assets/voice_iris_duplicates__es-ES.wav
+++ b/orb-ui/sound/assets/voice_iris_duplicates__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c64bf09a060671feaf64ac3165b32c98f8f13de2a2486edae835c33239abef54
+size 99206

--- a/orb-ui/sound/assets/voice_iris_move_closer.wav
+++ b/orb-ui/sound/assets/voice_iris_move_closer.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e4189a67e3f21ee6cd067526ff360e4febbf378a5fddc980a6f0383a526ef12
+size 59286

--- a/orb-ui/sound/assets/voice_iris_move_closer__es-ES.wav
+++ b/orb-ui/sound/assets/voice_iris_move_closer__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd9b987d8bf60caa15528b909b81bed252cce10c62b738e96350d412cdc0aa75
+size 61452

--- a/orb-ui/sound/assets/voice_iris_move_farther.wav
+++ b/orb-ui/sound/assets/voice_iris_move_farther.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:daffe55b3986a96e3974bccd26839686cc865fc72ebba7a6687ad8179efceefb
+size 58008

--- a/orb-ui/sound/assets/voice_iris_move_farther__es-ES.wav
+++ b/orb-ui/sound/assets/voice_iris_move_farther__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3c5de81591493b91493d6882181dd0bdd61691623e529b58689f11852cb9173
+size 62902

--- a/orb-ui/sound/assets/voice_iris_open.wav
+++ b/orb-ui/sound/assets/voice_iris_open.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:95cc5cbc0de275f8823c7f7414f6e099031f5baa8938468becae34da4b276367
+size 51008

--- a/orb-ui/sound/assets/voice_iris_open__es-ES.wav
+++ b/orb-ui/sound/assets/voice_iris_open__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75f55863e530f78965c9b2e144944da2542a56f3ba7dd7b39117a9208de72185
+size 51388

--- a/orb-ui/sound/assets/voice_network_unreachable.wav
+++ b/orb-ui/sound/assets/voice_network_unreachable.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60182cc1a19bc3d21e73caaf164c3be712a3ce652ee04bf0d43e0615d2991623
+size 705644

--- a/orb-ui/sound/assets/voice_network_unreachable__es-ES.wav
+++ b/orb-ui/sound/assets/voice_network_unreachable__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53190f14713d4eee6d0fbf240e8feeef4ab4ece3de05d7760780941468983020
+size 149788

--- a/orb-ui/sound/assets/voice_overheating.wav
+++ b/orb-ui/sound/assets/voice_overheating.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feccf8729261bc77e35978fcd88d584981fa4411658ea41fe6cc4aa48f3bfada
+size 110636

--- a/orb-ui/sound/assets/voice_overheating__es-ES.wav
+++ b/orb-ui/sound/assets/voice_overheating__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3fb48c7b4ffbdd539cfa10b12a95cb9e8b05272fa598b5a1f087a7fa12cfeb06
+size 116850

--- a/orb-ui/sound/assets/voice_please_do_not_move_the_calibration_target.wav
+++ b/orb-ui/sound/assets/voice_please_do_not_move_the_calibration_target.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4a204fcfcf895170aa0b54bc3f9dd5f9f96c4ac2bc3a7ef29b200ae91b3bb51
+size 130220

--- a/orb-ui/sound/assets/voice_please_do_not_move_the_calibration_target__es-ES.wav
+++ b/orb-ui/sound/assets/voice_please_do_not_move_the_calibration_target__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66099e78a572fa9bec9b42ccd01541bebe033c3fa42ff68deb2c9329eeab00f2
+size 118964

--- a/orb-ui/sound/assets/voice_please_do_not_shutdown.wav
+++ b/orb-ui/sound/assets/voice_please_do_not_shutdown.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b9844d0a76f6361283b5f439be60206c121b88eecff7a6b194b16563ab76fb2
+size 176318

--- a/orb-ui/sound/assets/voice_please_do_not_shutdown__es-ES.wav
+++ b/orb-ui/sound/assets/voice_please_do_not_shutdown__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:872719ad58b62bee60a03ab73a75981f6f257d2acb3956ed401ad04fa6d32744
+size 180462

--- a/orb-ui/sound/assets/voice_please_put_the_calibration_target_in_the_frame.wav
+++ b/orb-ui/sound/assets/voice_please_put_the_calibration_target_in_the_frame.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:454117b39b94b1249d964320e5871c7b216c586ddb05eda937c4ceeeab7b99a8
+size 157868

--- a/orb-ui/sound/assets/voice_please_put_the_calibration_target_in_the_frame__es-ES.wav
+++ b/orb-ui/sound/assets/voice_please_put_the_calibration_target_in_the_frame__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:594f80adb5ff1762e68873d5c696e396bb57eff529f2b737c725561365dd5661
+size 139822

--- a/orb-ui/sound/assets/voice_qr_code_invalid.wav
+++ b/orb-ui/sound/assets/voice_qr_code_invalid.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80d96f7f2b9bebcde3db512c5e4784ffb63bbded4f8f50c3b2386f7b192e505d
+size 119852

--- a/orb-ui/sound/assets/voice_qr_code_invalid__es-ES.wav
+++ b/orb-ui/sound/assets/voice_qr_code_invalid__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f8ee69fa89ae99c57e15a8d59bb5bbcb1687f54036c730fab0e079f5c6d2e1ed
+size 70874

--- a/orb-ui/sound/assets/voice_qr_code_not_found.wav
+++ b/orb-ui/sound/assets/voice_qr_code_not_found.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98acfeb7670d4a3d90d94948cc69698dc41c927fbc86cacb7716643665f10e33
+size 153840

--- a/orb-ui/sound/assets/voice_qr_code_not_found__es-ES.wav
+++ b/orb-ui/sound/assets/voice_qr_code_not_found__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29f4687a1fd31f4c5a976905afb72bb5a418b7e947231ebb783fac1531c910d4
+size 173926

--- a/orb-ui/sound/assets/voice_server_error.wav
+++ b/orb-ui/sound/assets/voice_server_error.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b7497fa4bf73382b1df2721963850e5566ef6848742c3c318072b17a9c7b974
+size 179756

--- a/orb-ui/sound/assets/voice_server_error__es-ES.wav
+++ b/orb-ui/sound/assets/voice_server_error__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:69903fe8bfa156acc78417ee7e02d1b47253f9a7967c9c139ba5f11baacf32f7
+size 124142

--- a/orb-ui/sound/assets/voice_show_wifi_hotspot_qr_code.wav
+++ b/orb-ui/sound/assets/voice_show_wifi_hotspot_qr_code.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d5d297a187d65333324f2f6f37060e8f68b282004229edf840ca52b93133d25
+size 127916

--- a/orb-ui/sound/assets/voice_show_wifi_hotspot_qr_code__es-ES.wav
+++ b/orb-ui/sound/assets/voice_show_wifi_hotspot_qr_code__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f2016e068bf6f3cb64bd8a757ea546e196a67e49ce699b6c42efe102c005632
+size 118578

--- a/orb-ui/sound/assets/voice_software_outdated.wav
+++ b/orb-ui/sound/assets/voice_software_outdated.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7365247c7576d1086b55404048d64fa640adb807c543e695dde6a697d6e6d0ca
+size 200492

--- a/orb-ui/sound/assets/voice_test_firmware_warning.wav
+++ b/orb-ui/sound/assets/voice_test_firmware_warning.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0405b6c79d4fcd3d0bd698b33a8e7fd294cb66ba23b27d1146a8f9c99d39b02
+size 194296

--- a/orb-ui/sound/assets/voice_test_firmware_warning__es-ES.wav
+++ b/orb-ui/sound/assets/voice_test_firmware_warning__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f8e7bd906721cfaee9f9f85ec9ed6a915a3e6c3dfe4e7052666ba583daa4795
+size 163046

--- a/orb-ui/sound/assets/voice_timeout.wav
+++ b/orb-ui/sound/assets/voice_timeout.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:935f004001e62be39e6ede2f53561e104584a492697ab8db32377bc0d2272602
+size 87964

--- a/orb-ui/sound/assets/voice_timeout__es-ES.wav
+++ b/orb-ui/sound/assets/voice_timeout__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfa9244524a568cb6f51af878132d002d93e2301192562e081a5c5b279bbcf34
+size 154434

--- a/orb-ui/sound/assets/voice_verification_not_successful_please_try_again.wav
+++ b/orb-ui/sound/assets/voice_verification_not_successful_please_try_again.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f522975b698174c883bb2175a96183b65992f83569f7612012d1bdcc1894edaa
+size 212012

--- a/orb-ui/sound/assets/voice_verification_not_successful_please_try_again__es-ES.wav
+++ b/orb-ui/sound/assets/voice_verification_not_successful_please_try_again__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:682ac16aa0ff6fc5ba87d709bd21e1b0df57e9499793afb3c1e29a14477afbe8
+size 164882

--- a/orb-ui/sound/assets/voice_whole_pattern_is_visible.wav
+++ b/orb-ui/sound/assets/voice_whole_pattern_is_visible.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b523d73cb8047dd6d542094723012b6021bae8ffc570c554f3cb737b0158fd79
+size 80194

--- a/orb-ui/sound/assets/voice_whole_pattern_is_visible__es-ES.wav
+++ b/orb-ui/sound/assets/voice_whole_pattern_is_visible__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f60e907bc6e8fe4fd1d629f55d77727978a3d422079bb95a31108454e0b8f42
+size 85528

--- a/orb-ui/sound/assets/voice_wrong_qr_code_format.wav
+++ b/orb-ui/sound/assets/voice_wrong_qr_code_format.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14dae99600f52aaec49177d5f808a6aa577b3660af319aa4f39640e817510c0b
+size 130220

--- a/orb-ui/sound/assets/voice_wrong_qr_code_format__es-ES.wav
+++ b/orb-ui/sound/assets/voice_wrong_qr_code_format__es-ES.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:513b6dc10653cad3176f1b86fde89a2372e2886fe02cbc80ac1c8632b5c50966
+size 113928

--- a/orb-ui/sound/utils/README.md
+++ b/orb-ui/sound/utils/README.md
@@ -1,0 +1,9 @@
+# Sound utils
+
+## `check_sounds.sh`
+
+Ensure that all sounds are `.wav` files with 16-bit/sample.
+
+```shell
+$ bash ./check_sounds.sh ../assets/
+```

--- a/orb-ui/sound/utils/check_sounds.sh
+++ b/orb-ui/sound/utils/check_sounds.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -o errexit   # abort on nonzero exitstatus
+set -o nounset   # abort on unbound variable
+set -o pipefail  # don't hide errors within pipes
+
+# Checks that the sounds directory only includes *.wav files
+# Checks that the sounds are sampled on 16 bits
+# Guards against bad archive preparation.
+
+validate_sounds::validate() {
+    local -r sounds_dir=${1}
+
+    pushd "${sounds_dir}" >/dev/null
+
+    local check_bit_sampling=true
+    if ! [[ -x "$(command -v soxi)" ]]; then
+        echo "Install sox (soxi) to check bits per sample" >>/dev/stderr
+        check_bit_sampling=false
+    fi
+
+    for file in *; do
+        if ! [[ "${file}" =~ \.wav$ ]] ; then
+            echo "Invalid sounds directory: '${file}' is not a wav file"
+            exit 1
+        fi
+
+        if [[ "${check_bit_sampling}" = true ]]; then
+            local -i bits_per_sample
+            bits_per_sample="$(soxi -b "${file}")"
+
+            if [[ "${bits_per_sample}" != 16 ]]; then
+                echo "${file} must be converted to 16 bits per sample"
+                exit 1
+            fi
+        fi
+    done
+
+    popd >/dev/null
+
+    echo "Sounds directory successfully validated."
+}
+
+main() {
+    trap trap_err ERR
+
+    validate_sounds::validate "${1}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
ensure compatibility & correctness of the sounds with a specific orb-ui binary: we don't rely anymore on a sound package version tracked in orb-os. See also https://github.com/worldcoin/orb-os/pull/507

I tested that it correctly fails on checking the sound files in case something is wrong in the `assets` directory, [see job](https://github.com/worldcoin/orb-software/actions/runs/10831070034).