### PR TITLE
build-info: add dirty and revision detect

### DIFF
--- a/build-info/helper/src/lib.rs
+++ b/build-info/helper/src/lib.rs
@@ -10,24 +10,37 @@ const ENV_PREFIX: &str = "WORLDCOIN_BUILD_INFO_";
 /// Call this from within your build script.
 pub fn initialize() -> Result<()> {
     color_eyre::install().ok();
-    let git_head_path = workspace_dir().join(".git").join("HEAD");
-    println!("cargo:rerun-if-changed={}", git_head_path.display());
+    let git_path = workspace_dir().join(".git");
+    let git_head_path = git_path.join("HEAD");
+    let git_index_path = git_path.join("index");
+    for p in [git_head_path, git_index_path] {
+        println!("cargo:rerun-if-changed={}", p.display());
+    }
 
-    let git_describe = read_env("GIT_DESCRIBE").unwrap_or(
-        std::str::from_utf8(
-            &Command::new("git")
-                .arg("describe")
-                .arg("--always")
-                .arg("--dirty=-modified")
-                .output()
-                .wrap_err("Failed to run `git describe`")
-                .suggestion("Is `git` installed?")?
-                .stdout,
-        )?
-        .trim_end()
-        .to_string(),
-    );
+    let git_describe = read_env("GIT_DESCRIBE")
+        .ok_or(())
+        .or_else(|()| git_describe())
+        .wrap_err("failed to compute value for GIT_DESCRIBE")?;
     set_env("GIT_DESCRIBE", &git_describe);
+
+    let git_dirty = read_env("GIT_DIRTY")
+        .ok_or(())
+        .map(|s| match s.to_lowercase().as_str() {
+            "0" => false,
+            "1" => true,
+            "true" => true,
+            "false" => false,
+            _ => panic!("unexpected value"),
+        })
+        .or_else(|()| git_dirty())
+        .wrap_err("failed to compute value for GIT_DIRTY")?;
+    set_env("GIT_DIRTY", if git_dirty { "1" } else { "0" });
+
+    let git_rev_short = read_env("GIT_REV_SHORT")
+        .ok_or(())
+        .or_else(|()| git_current_rev_short())
+        .wrap_err("failed to compute value for GIT_REV_SHORT")?;
+    set_env("GIT_REV_SHORT", &git_rev_short);
 
     Ok(())
 }
@@ -49,13 +62,50 @@ fn set_env(var: &str, value: &str) {
 // https://stackoverflow.com/a/74942075
 fn workspace_dir() -> PathBuf {
     let output = std::process::Command::new(env!("CARGO"))
-        .arg("locate-project")
-        .arg("--workspace")
-        .arg("--message-format=plain")
+        .args(["locate-project", "--workspace", "--message-format=plain"])
         .output()
         .unwrap()
         .stdout;
     let workpace_cargo_toml_path =
         Path::new(std::str::from_utf8(&output).unwrap().trim());
     workpace_cargo_toml_path.parent().unwrap().to_path_buf()
+}
+
+fn git_describe() -> Result<String> {
+    let stdout = Command::new("git")
+        .args(["describe", "--always", "--dirty=-modified"])
+        .output()
+        .wrap_err("Failed to run `git describe --always --dirty=-modified`")
+        .suggestion("Is `git` installed?")?
+        .stdout;
+    let cleaned_stdout = std::str::from_utf8(&stdout)?.trim();
+
+    Ok(cleaned_stdout.to_owned())
+}
+
+/// Uses git status to determine if the repo is dirty.
+fn git_dirty() -> Result<bool> {
+    let stdout = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .wrap_err("failed to run `git status --porcelain`")
+        .suggestion("Is `git` installed?")?
+        .stdout;
+    let cleaned_stdout = std::str::from_utf8(&stdout)?.trim();
+    let is_dirty = !cleaned_stdout.is_empty();
+
+    Ok(is_dirty)
+}
+
+/// Uses git rev-parse to get the current git revision.
+fn git_current_rev_short() -> Result<String> {
+    let stdout = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .wrap_err("failed to run `git rev-parse --short HEAD`")
+        .suggestion("Is `git` installed?`")?
+        .stdout;
+    let cleaned_stdout = std::str::from_utf8(&stdout)?.trim();
+
+    Ok(cleaned_stdout.to_owned())
 }

--- a/orb-attest/src/lib.rs
+++ b/orb-attest/src/lib.rs
@@ -24,8 +24,7 @@ const HTTP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 pub async fn main() -> eyre::Result<()> {
     logging::init();
 
-    info!("Version: {}", BUILD_INFO.cargo.pkg_version);
-    info!("git sha: {}", BUILD_INFO.git.describe);
+    info!("Version: {}", BUILD_INFO.version);
 
     let orb_id =
         std::env::var("ORB_ID").wrap_err("env variable `ORB_ID` should be set")?;


### PR DESCRIPTION
Previously, git describe would sometimes show the revision and sometimes show the tag.
Now, we always ensure that we only show the revision, and do our own dirty detection.