### PR TITLE
orb-ui: allow switching between api and core modes

### DIFF
--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -1014,12 +1014,6 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 }
             }
         }
-        // one last update of the UI has been performed since api_mode has been set,
-        // (to set the api_mode UI state), so we can now pause the engine
-        if self.is_api_mode && !self.paused {
-            self.paused = true;
-            tracing::info!("UI paused in API mode");
-        }
 
         if let Some((x, y)) = self.gimbal {
             interface_tx.try_send(Message::JMessage(JetsonToMcu {
@@ -1039,6 +1033,17 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             // send only once
             self.gimbal = None;
         }
+
+        // one last update of the UI has been performed since api_mode has been set,
+        // (to set the api_mode UI state), so we can now pause the engine
+        if self.is_api_mode && !self.paused {
+            self.paused = true;
+            tracing::info!("UI paused in API mode");
+        } else if !self.is_api_mode && self.paused {
+            self.paused = false;
+            tracing::info!("UI resumed from API mode");
+        }
+
         Ok(())
     }
 }

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -868,6 +868,9 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
         if self.is_api_mode && !self.paused {
             self.paused = true;
             tracing::info!("UI paused in API mode");
+        } else if !self.is_api_mode && self.paused {
+            self.paused = false;
+            tracing::info!("UI resumed from API mode");
         }
         Ok(())
     }


### PR DESCRIPTION
ui is paused when using orb-ui in api mode, to allow user to set ring colors etc.
but when starting core, the ui engine should resume.