### PR TITLE
ci: add check for missing binaries in .deb

### DIFF
--- a/ci/rust_ci_helper.py
+++ b/ci/rust_ci_helper.py
@@ -85,12 +85,17 @@ def run_cargo_deb(*, out_dir, cargo_profile, targets, crate):
     os.makedirs(out, exist_ok=True)
     stderr(f"Creating .deb packages for {crate_name} and copying to {out}:")
     for t in targets:
+        output_deb_path = f"{out}/{crate_name}_{t}.deb"
         run(
             f"cargo deb --no-build --no-strip "
             f"--profile {cargo_profile} "
             f"-p {crate_name} "
             f"--target {t}-unknown-linux-gnu "
-            f"-o {out}/{crate_name}_{t}.deb"
+            f"-o {output_deb_path}"
+        )
+        # Ensures that the .deb actually contains the binary
+        run(
+            f"dpkg --contents {output_deb_path} | grep -E 'usr(/local)?/bin/{crate_name}'"
         )
 
 

--- a/nix/shells/development.nix
+++ b/nix/shells/development.nix
@@ -57,6 +57,7 @@ in
         cargo-deny # Checks licenses and security advisories
         cargo-expand # Useful for inspecting macros
         cargo-zigbuild # Used to cross compile rust
+        dpkg # Used to test outputs of cargo-deb
         mdbook-mermaid # Adds mermaid support
         mdbook # Generates site for docs
         nixpkgs-fmt # Nix autoformatter

--- a/orb-ui/Cargo.toml
+++ b/orb-ui/Cargo.toml
@@ -50,7 +50,8 @@ chrono = "0.4.35"
 [package.metadata.deb]
 maintainer-scripts = "debian/"
 assets = [
-  ["sound/assets/*.wav", "/home/worldcoin/data/sounds/", "644"]
+  ["sound/assets/*.wav", "/home/worldcoin/data/sounds/", "644"],
+  ["target/release/orb-ui", "/usr/local/bin/", "755"],
 ]
 systemd-units = [
   { unit-name = "worldcoin-ui" },

--- a/orb-ui/debian/orb-ui.worldcoin-ui.service
+++ b/orb-ui/debian/orb-ui.worldcoin-ui.service
@@ -13,7 +13,7 @@ Environment="DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket"
 Environment="RUST_BACKTRACE=1"
 SyslogIdentifier=worldcoin-ui
 WorkingDirectory=/home/worldcoin
-ExecStart=/usr/bin/orb-ui daemon
+ExecStart=/usr/local/bin/orb-ui daemon
 Restart=always
 
 [Install]


### PR DESCRIPTION
Fixes the missing orb-ui binary. Also relocates it to /usr/local/bin.