### PR TITLE
telemetry: introduce orb-telemetry crate and use it in orb-ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4631,6 +4631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "orb-telemetry"
+version = "0.0.0"
+dependencies = [
+ "console-subscriber",
+ "tracing",
+ "tracing-journald",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "orb-thermal-cam-ctrl"
 version = "0.0.5"
 dependencies = [
@@ -4660,7 +4670,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "console-subscriber",
+ "color-eyre",
  "dashmap",
  "derive_more",
  "eyre",
@@ -4669,6 +4679,7 @@ dependencies = [
  "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=787ab78581b705af0946bcfe3a0453b64af2193f)",
  "orb-rgb",
  "orb-sound",
+ "orb-telemetry",
  "orb-uart",
  "pid",
  "prost 0.12.6",
@@ -4678,7 +4689,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber",
  "zbus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,19 @@ members = [
   "hil",
   "mcu-interface",
   "mcu-util",
-  "ui",
-  "ui/cone",
-  "ui/pid",
-  "ui/sound",
-  "ui/uart",
   "qr-link",
   "security-utils",
   "seek-camera/sys",
   "seek-camera/wrapper",
   "slot-ctrl",
   "supervisor",
+  "telemetry",
   "thermal-cam-ctrl",
+  "ui",
+  "ui/cone",
+  "ui/pid",
+  "ui/sound",
+  "ui/uart",
   "update-agent",
   "update-agent/core",
   "update-verifier",
@@ -81,6 +82,7 @@ orb-build-info.path = "build-info"
 orb-const-concat.path = "const-concat"
 orb-security-utils.path = "security-utils"
 orb-slot-ctrl.path = "slot-ctrl"
+orb-telemetry.path = "telemetry"
 orb-update-agent-core.path = "update-agent/core"
 orb-zbus-proxies.path = "zbus-proxies"
 

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "orb-telemetry"
+version = "0.0.0"
+description = "Standardized telemetry setup for the orb"
+authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
+publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+tracing-journald.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true
+
+[target.'cfg(tokio_unstable)'.dependencies]
+console-subscriber.workspace = true
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(tokio_unstable)']

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -1,0 +1,84 @@
+use std::io::IsTerminal as _;
+
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{
+    layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter,
+};
+
+#[derive(Debug)]
+pub struct TelemetryConfig {
+    syslog_identifier: Option<String>,
+    global_filter: EnvFilter,
+}
+
+impl TelemetryConfig {
+    /// Provides all required arguments for telemetry configuration.
+    /// - `log_identifier` will be used for journald, if appropriate.
+    #[expect(clippy::new_without_default, reason = "may add required args later")]
+    pub fn new() -> Self {
+        Self {
+            syslog_identifier: None,
+            global_filter: EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        }
+    }
+
+    /// Enables journald, and uses the provided syslog identifier.
+    ///
+    /// If you run the application in a tty, stderr will be used instead.
+    pub fn with_journald(self, syslog_identifier: &str) -> Self {
+        Self {
+            syslog_identifier: Some(syslog_identifier.to_owned()),
+            ..self
+        }
+    }
+
+    /// Override the global filter to a custom filter.
+    /// Only do this if actually necessary to deviate from the orb's defaults.
+    pub fn with_global_filter(self, filter: EnvFilter) -> Self {
+        Self {
+            global_filter: filter,
+            ..self
+        }
+    }
+
+    /// Initializes the telemetry config. Call this only once, at the beginning of the
+    /// program.
+    ///
+    /// Calling this more than once or when another tracing subscriber is registered
+    /// will cause a panic.
+    pub fn init(self) {
+        let registry = tracing_subscriber::registry();
+        // The type is only there to get it to compile.
+        let tokio_console_layer: Option<tracing_subscriber::layer::Identity> = None;
+        #[cfg(tokio_unstable)]
+        let tokio_console_layer = console_subscriber::spawn();
+        // Checking for a terminal helps detect if we are running under systemd.
+        let journald_layer = if !std::io::stderr().is_terminal() {
+            self.syslog_identifier.and_then(|syslog_identifier| {
+                tracing_journald::layer()
+                    .inspect_err(|err| {
+                        eprintln!(
+                            "failed connecting to journald socket. \
+                        will write to stderr: {err}"
+                        );
+                    })
+                    .map(|layer| layer.with_syslog_identifier(syslog_identifier))
+                    .ok()
+            })
+        } else {
+            None
+        };
+        let stderr_layer = journald_layer
+            .is_none()
+            .then(|| tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
+        assert!(stderr_layer.is_some() || journald_layer.is_some());
+        registry
+            .with(tokio_console_layer)
+            .with(stderr_layer)
+            .with(journald_layer)
+            .with(self.global_filter)
+            .init();
+    }
+}

--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -13,6 +13,7 @@ rust-version.workspace = true
 [dependencies]
 async-trait = "0.1.74"
 clap.workspace = true
+color-eyre.workspace = true
 dashmap = "5.5.3"
 derive_more.workspace = true
 eyre.workspace = true
@@ -21,6 +22,7 @@ orb-build-info.path = "../build-info"
 orb-messages.workspace = true
 orb-rgb.path = "rgb"
 orb-sound.path = "sound"
+orb-telemetry.workspace = true
 orb-uart.path = "uart"
 pid.path = "pid"
 prost = "0.12.3"
@@ -29,12 +31,8 @@ serde.workspace = true
 serde_json = "1.0.108"
 tokio-stream = "0.1.14"
 tokio.workspace = true
-tracing-subscriber.workspace = true
 tracing.workspace = true
 zbus.workspace = true
-
-[target.'cfg(tokio_unstable)'.dependencies]
-console-subscriber.workspace = true
 
 [build-dependencies]
 orb-build-info = { path = "../build-info", features = ["build-script"] }


### PR DESCRIPTION
we should in general be using journald for our logs, not stdout. Also, we should use stderr instead of stdout.

Every one of our crates sets up logging in a different way, but they all do the same thing. I wanted to introduce a single spot that lets us configure our telemetry. If it goes well in orb-ui, we can use it in all the rest too