### PR TITLE
orb-ui: operator qr scan

### DIFF
--- a/orb-ui/rgb/src/lib.rs
+++ b/orb-ui/rgb/src/lib.rs
@@ -82,6 +82,8 @@ impl Argb {
     /// Outer-ring color during operator QR scans
     pub const DIAMOND_RING_OPERATOR_QR_SCAN: Argb = Argb(Some(5), 77, 14, 0);
     pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER: Argb = Argb(Some(10), 80, 50, 30);
+    pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER_OPERATOR_BASED: Argb =
+        Argb(Some(10), 100, 88, 20);
     /// Outer-ring color during user QR scans
     pub const DIAMOND_RING_USER_QR_SCAN: Argb = Argb(Some(5), 120, 100, 4); // same as DIAMOND_RING_USER_CAPTURE, lower brightness
     pub const DIAMOND_RING_USER_QR_SCAN_SPINNER: Argb = Argb(Some(10), 80, 60, 40);

--- a/orb-ui/src/engine/diamond.rs
+++ b/orb-ui/src/engine/diamond.rs
@@ -336,8 +336,8 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.set_ring(
                             LEVEL_FOREGROUND,
                             animations::SimpleSpinner::new(
-                                Argb::DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER,
-                                None,
+                                Argb::DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER_OPERATOR_BASED,
+                                Some(Argb::OFF),
                             )
                             .fade_in(1.5),
                         );

--- a/orb-ui/src/engine/mod.rs
+++ b/orb-ui/src/engine/mod.rs
@@ -123,6 +123,8 @@ macro_rules! event_enum {
 pub enum QrScanSchema {
     /// Operator QR-code scanning.
     Operator,
+    /// Operator QR-code scanning, self-serve mode.
+    OperatorSelfServe,
     /// User QR-code scanning.
     User,
     /// WiFi QR-code scanning.

--- a/orb-ui/src/engine/pearl.rs
+++ b/orb-ui/src/engine/pearl.rs
@@ -286,7 +286,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 );
 
                 match schema {
-                    QrScanSchema::Operator => {
+                    QrScanSchema::Operator | QrScanSchema::OperatorSelfServe => {
                         self.operator_signup_phase.operator_qr_code_ok();
                     }
                     QrScanSchema::Wifi => {
@@ -317,7 +317,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     Duration::ZERO,
                 )?;
             }
-            Event::QrScanCompleted { schema } => {
+            Event::QrScanCompleted { schema: _ } => {
                 // stop wave (foreground) & show alert/blinks (notice)
                 self.stop_center(LEVEL_FOREGROUND, Transition::ForceStop);
                 self.set_center(
@@ -329,12 +329,6 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         false,
                     ),
                 );
-
-                match schema {
-                    QrScanSchema::Operator => {}
-                    QrScanSchema::User => {}
-                    QrScanSchema::Wifi => {}
-                }
             }
             Event::QrScanUnexpected { schema, reason } => {
                 match reason {
@@ -357,7 +351,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
                         self.operator_signup_phase.user_qr_code_issue();
                     }
-                    QrScanSchema::Operator => {
+                    QrScanSchema::Operator | QrScanSchema::OperatorSelfServe => {
                         self.operator_signup_phase.operator_qr_code_issue();
                     }
                     QrScanSchema::Wifi => {}
@@ -371,7 +365,9 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     Duration::ZERO,
                 )?;
                 match schema {
-                    QrScanSchema::User | QrScanSchema::Operator => {
+                    QrScanSchema::User
+                    | QrScanSchema::Operator
+                    | QrScanSchema::OperatorSelfServe => {
                         // in case schema is user qr
                         self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
                         self.operator_signup_phase.failure();
@@ -383,7 +379,7 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             }
             Event::QrScanSuccess { schema } => {
                 match schema {
-                    QrScanSchema::Operator => {
+                    QrScanSchema::Operator | QrScanSchema::OperatorSelfServe => {
                         self.sound.queue(
                             sound::Type::Melody(sound::Melody::QrLoadSuccess),
                             Duration::ZERO,
@@ -406,7 +402,9 @@ impl EventHandler for Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 self.sound
                     .queue(sound::Type::Voice(sound::Voice::Timeout), Duration::ZERO)?;
                 match schema {
-                    QrScanSchema::User | QrScanSchema::Operator => {
+                    QrScanSchema::User
+                    | QrScanSchema::Operator
+                    | QrScanSchema::OperatorSelfServe => {
                         // in case schema is user qr
                         self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
                         self.operator_signup_phase.failure();

--- a/orb-ui/src/simulation.rs
+++ b/orb-ui/src/simulation.rs
@@ -72,13 +72,23 @@ pub async fn signup_simulation(
 
     loop {
         if !showcar {
-            // scanning operator QR code
-            ui.qr_scan_start(QrScanSchema::Operator);
-            time::sleep(Duration::from_secs(10)).await;
-            ui.qr_scan_capture();
-            time::sleep(Duration::from_secs(2)).await;
-            ui.qr_scan_completed(QrScanSchema::Operator);
-            ui.qr_scan_success(QrScanSchema::Operator);
+            if self_serve {
+                // scanning operator QR code
+                ui.qr_scan_start(QrScanSchema::OperatorSelfServe);
+                time::sleep(Duration::from_secs(10)).await;
+                ui.qr_scan_capture();
+                time::sleep(Duration::from_secs(2)).await;
+                ui.qr_scan_completed(QrScanSchema::OperatorSelfServe);
+                ui.qr_scan_success(QrScanSchema::OperatorSelfServe);
+            } else {
+                // scanning operator QR code
+                ui.qr_scan_start(QrScanSchema::Operator);
+                time::sleep(Duration::from_secs(10)).await;
+                ui.qr_scan_capture();
+                time::sleep(Duration::from_secs(2)).await;
+                ui.qr_scan_completed(QrScanSchema::Operator);
+                ui.qr_scan_success(QrScanSchema::Operator);
+            }
 
             // scanning user QR code
             time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
differentiate between operator-based (legacy) and self-serve mode.

in operator-based mode, scanning the operator QR code shouldn't look like an error.

see https://github.com/worldcoin/priv-orb-core/pull/1367

fixes O-2903