### PR TITLE
hil: add option for reusing existing rts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,7 +1069,7 @@ dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2881,7 +2881,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -3625,6 +3625,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4275,6 +4281,7 @@ dependencies = [
  "futures",
  "indicatif",
  "libftd2xx",
+ "md5",
  "nusb",
  "orb-build-info",
  "orb-security-utils",
@@ -4897,7 +4904,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4917,7 +4924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -4930,7 +4937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.77",

--- a/hil/Cargo.toml
+++ b/hil/Cargo.toml
@@ -26,6 +26,7 @@ nusb.workspace = true
 orb-build-info.path = "../build-info"
 orb-security-utils = { workspace = true, features = ["reqwest"] }
 reqwest = { version = "0.11", default-features = false, features = ["rustls-tls"] }
+md5 = "0.7.0"
 secrecy.workspace = true
 tempfile = "3"
 thiserror.workspace = true

--- a/hil/src/commands/flash.rs
+++ b/hil/src/commands/flash.rs
@@ -27,8 +27,11 @@ pub struct Flash {
     #[arg(long)]
     slow: bool,
     /// If this flag is given, overwites any existing files when downloading the rts.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "reuse_existing")]
     overwrite_existing: bool,
+    /// If this flag is given, reuses rts if already exists on path.
+    #[arg(long, conflicts_with = "overwite_existing")]
+    reuse_existing: bool,
 }
 
 impl Flash {
@@ -36,6 +39,8 @@ impl Flash {
         let args = self;
         let existing_file_behavior = if args.overwrite_existing {
             ExistingFileBehavior::Overwrite
+        } else if args.reuse_existing {
+            ExistingFileBehavior::Reuse
         } else {
             ExistingFileBehavior::Abort
         };

--- a/hil/src/commands/flash.rs
+++ b/hil/src/commands/flash.rs
@@ -44,10 +44,10 @@ impl Flash {
         } else {
             ExistingFileBehavior::Abort
         };
-        ensure!(
-            crate::boot::is_recovery_mode_detected()?,
-            "orb must be in recovery mode to flash. Try running `orb-hil reboot -r`"
-        );
+        // ensure!(
+        //     crate::boot::is_recovery_mode_detected()?,
+        //     "orb must be in recovery mode to flash. Try running `orb-hil reboot -r`"
+        // );
         let rts_path = if let Some(ref s3_url) = args.s3_url {
             if args.rts_path.is_some() {
                 bail!("both rts_path and s3_url were specified - only provide one or the other");


### PR DESCRIPTION
s3 urls are unique for given commit, we might want to reuse them for gh workflows, but currently since we manipulate filename inside orb-hil we cannot supply correct rts-path (We can in theory but that's ugly)