### PR TITLE
orb-mcu-util: hardware revision

### DIFF
--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -9,6 +9,7 @@ use clap::{
 };
 use color_eyre::eyre::{Context, Result};
 use orb_build_info::{make_build_info, BuildInfo};
+use orb_mcu_interface::orb_messages::mcu_main::hardware::OrbVersion;
 use tokio::fs;
 use tokio::fs::OpenOptions;
 use tokio::io::AsyncWriteExt;
@@ -165,6 +166,12 @@ async fn execute(args: Args) -> Result<()> {
         }
         SubCommand::HardwareRevision { filename } => {
             let hw_rev = orb.get_revision().await?;
+            // discard operation if unknown hardware version
+            if hw_rev.0.version == i32::from(OrbVersion::HwVersionUnknown) {
+                return Err(color_eyre::eyre::eyre!(
+                    "Failed to fetch hardware revision: unknown"
+                ));
+            }
             match filename {
                 None => {
                     println!("{}", hw_rev);

--- a/mcu-util/src/orb/revision.rs
+++ b/mcu-util/src/orb/revision.rs
@@ -7,6 +7,10 @@ pub struct OrbRevision(pub main_messaging::Hardware);
 impl Display for OrbRevision {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if self.0.version
+            == i32::from(main_messaging::hardware::OrbVersion::HwVersionUnknown)
+        {
+            write!(f, "unknown")
+        } else if self.0.version
             < main_messaging::hardware::OrbVersion::HwVersionDiamondPoc1 as i32
         {
             write!(f, "EVT{:?}", self.0.version)


### PR DESCRIPTION
error out on unknown hardware revision,
and don't write into file.

fixes O-2916