### PR TITLE
can: fix ack number with a high pid

### DIFF
--- a/mcu-interface/src/lib.rs
+++ b/mcu-interface/src/lib.rs
@@ -46,20 +46,21 @@ pub trait MessagingInterface {
 }
 
 /// Create a unique ack number
-/// - prefix with process ID
+/// - prefix with process ID (16 bits, the least significant bits)
 /// - suffix with counter
 ///
 /// this added piece of information in the ack number is not strictly necessary
 /// but helps filter out acks that are not for us (e.g. acks for other processes)
 #[inline]
 fn create_ack(counter: u16) -> u32 {
-    process::id() << 16 | counter as u32
+    (process::id() & 0xFFFF) << 16_u32 | counter as u32
 }
 
-/// Check that ack contains the process ID
+/// Check that ack contains 16 least significant bits of the process ID
 #[inline]
 fn is_ack_for_us(ack_number: u32) -> bool {
-    ack_number >> 16 == process::id()
+    // cast looses the upper bits
+    ((ack_number >> 16) as u16) == (process::id() as u16)
 }
 
 /// handle new main mcu message, reference implementation


### PR DESCRIPTION
ack number uses the pid in the 16 most significant bits (and a counter in the lower 16 bits),
this allows us to filter out acks that are not
for the current process.
But, the pid can be encoded over more than 16 bits, so this fix allows the usage of the 16 lsb of the pid in the ack number, the msb of the pid are lost.

fixes that bug where the ack got ignored because the pid is higher than `u16::MAX`
```
2024-10-22T08:07:22.879010Z DEBUG orb_mcu_interface: Ignoring ack # 0xd013002b
2024-10-22T08:07:23.340840Z ERROR orb_mcu_util::orb::main_board: error asking for firmware version: ack not received (isotp)
```