### PR TITLE
fix(update-agent): increase ack timeout for mcu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4562,7 +4562,7 @@ dependencies = [
 
 [[package]]
 name = "orb-update-agent"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "bytes",
  "can-rs 0.0.0 (git+https://github.com/worldcoin/orb-software?rev=f13df5b723272efc55abf22cacce3625bbd1af04)",

--- a/update-agent/CHANGELOG.md
+++ b/update-agent/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 6.0.1
+
+### Fixed
+
++ Increased ack timeout to 2.5s to accomodate read performance of MCU flash
+  when calculating CRC to confirm update
+
+### Changed
+
++ archived internal repo. All new code should be developed in foss
+  `orb-software` repo.
+
 ## 6.0.0
 
 ### Breaking changes:

--- a/update-agent/Cargo.toml
+++ b/update-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-update-agent"
-version = "6.0.0"
+version = "6.0.1"
 authors = [
 	"Richard Janis Goldschmidt",
 	"Galileo Daras <galileo@getcoffee.io>",

--- a/update-agent/src/update/can.rs
+++ b/update-agent/src/update/can.rs
@@ -84,9 +84,9 @@ const ARBITRARY_EVENT_KEY: usize = 42;
 const MCU_MAX_FW_LEN_BYTES: u64 = 224 * 1024;
 const MCU_BLOCK_LEN_BYTES: u64 = 39;
 const MCU_BLOCK_SEND_ATTEMPTS: usize = 3;
-/// 1.5s timeout for receiving an ack from the MCU
+/// 2.5s timeout for receiving an ack from the MCU
 /// external SPI flash sector is long to erase.
-const MCU_BLOCK_SEND_TIMEOUT_MS: u64 = 1500;
+const MCU_BLOCK_SEND_TIMEOUT_MS: u64 = 2500;
 /// one block takes ~10ms to be sent over ISO-TP (with ack response)
 /// let's use a maximum of 20% of the bandwidth when performing a microcontroller
 /// firmware update so 10ms spaced by 40ms period


### PR DESCRIPTION
Backport changes from the now-archived update-agent repo.