### PR TITLE
fix: update-agent build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ color-eyre = "0.6.2"
 console-subscriber = "0.4"
 data-encoding = "2.3"
 derive_more = { version = "0.99", default-features = false, features = ["display", "from"] }
-ed25519-dalek = { version = "2.1.1", default-features = false }
+ed25519-dalek = { version = "2.1.1", default-features = false, features = ["std"]}
 eyre = "0.6.12"
 ftdi-embedded-hal = { version = "0.22.0", features = ["libftd2xx", "libftd2xx-static"] }
 futures = "0.3.30"


### PR DESCRIPTION
The build fails with error:

> error[E0599]: the method `as_dyn_error` exists for reference `&Error`, but its trait bounds were not satisfied
>   --> update-agent/core/src/pubkeys.rs:76:21
>    |
> 76 |     InvalidPubKey(#[from] SignatureError),
>    |                     ^^^^ method cannot be called on `&Error` due to unsatisfied trait bounds
>    |
>   ::: /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/signature-2.2.0/src/error.rs:26:1
>    |
> 26 | pub struct Error {
>    | ---------------- doesn't satisfy `ed25519_dalek::ed25519::Error: AsDynError<'_>` or `ed25519_dalek::ed25519::Error: StdError`
>    |
>    = note: the following trait bounds were not satisfied:
>            `ed25519_dalek::ed25519::Error: StdError`
>            which is required by `ed25519_dalek::ed25519::Error: AsDynError<'_>`
>            `&ed25519_dalek::ed25519::Error: StdError`
>            which is required by `&ed25519_dalek::ed25519::Error: AsDynError<'_>`

That happens because `ed25519_dalek::SignatureError` implements `std::error::Error` only if flag `std` is enabled [1]

[1] https://docs.rs/ed25519-dalek/latest/ed25519_dalek/type.SignatureError.html#impl-Error-for-Error