### PR TITLE
update-agent: refactor

### DIFF
--- a/update-agent/core/src/claim.rs
+++ b/update-agent/core/src/claim.rs
@@ -241,7 +241,7 @@ impl Claim {
         }
     }
 
-    pub fn version(&self) -> &String {
+    pub fn version(&self) -> &str {
         &self.version
     }
 
@@ -249,8 +249,8 @@ impl Claim {
         &self.manifest
     }
 
-    pub fn signature(&self) -> &Option<String> {
-        &self.signature
+    pub fn signature(&self) -> Option<&str> {
+        self.signature.as_deref()
     }
 
     pub fn sources(&self) -> &HashMap<String, Source> {

--- a/update-agent/core/src/claim.rs
+++ b/update-agent/core/src/claim.rs
@@ -21,6 +21,14 @@ pub enum Error {
     ManifestSignatureMissing,
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub enum MimeType {
+    #[serde(rename = "application/octet-stream")]
+    OctetStream,
+    #[serde(rename = "application/x-xz")]
+    XZ,
+}
+
 /// The source of a component.
 ///
 /// `Source` includes the name of the component, its location (whether on the local filesystem or
@@ -32,7 +40,7 @@ pub enum Error {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct Source {
     pub hash: String,
-    pub mime_type: String,
+    pub mime_type: MimeType,
     pub name: String,
     pub size: u64,
     pub url: LocalOrRemote,

--- a/update-agent/core/src/lib.rs
+++ b/update-agent/core/src/lib.rs
@@ -12,7 +12,7 @@ pub mod telemetry;
 pub mod version_map;
 pub mod versions;
 
-pub use claim::{Claim, ClaimVerificationContext, Source};
+pub use claim::{Claim, ClaimVerificationContext, MimeType, Source};
 pub use components::{Component, Components};
 pub use file_location::LocalOrRemote;
 pub use manifest::{Manifest, ManifestComponent};

--- a/update-agent/core/src/manifest.rs
+++ b/update-agent/core/src/manifest.rs
@@ -40,7 +40,7 @@ impl Manifest {
         ManifestBuilder::new()
     }
 
-    pub fn magic(&self) -> &String {
+    pub fn magic(&self) -> &str {
         &self.magic
     }
 
@@ -156,15 +156,15 @@ pub struct ManifestComponent {
 }
 
 impl ManifestComponent {
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
-    pub fn version_assert(&self) -> &String {
+    pub fn version_assert(&self) -> &str {
         &self.version_assert
     }
 
-    pub fn version_upgrade(&self) -> &String {
+    pub fn version_upgrade(&self) -> &str {
         &self.version_upgrade
     }
 
@@ -172,7 +172,7 @@ impl ManifestComponent {
         self.size
     }
 
-    pub fn hash(&self) -> &String {
+    pub fn hash(&self) -> &str {
         &self.hash
     }
 

--- a/update-agent/core/src/version_map.rs
+++ b/update-agent/core/src/version_map.rs
@@ -115,10 +115,10 @@ pub struct ComponentIter<'a> {
 }
 
 impl<'a> Iterator for ComponentIter<'a> {
-    type Item = (&'a String, &'a ComponentInfo);
+    type Item = (&'a str, &'a ComponentInfo);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
+        self.inner.next().map(|(n, c)| (n.as_str(), c))
     }
 }
 

--- a/update-agent/core/src/version_map.rs
+++ b/update-agent/core/src/version_map.rs
@@ -121,7 +121,7 @@ impl VersionMap {
         }
     }
 
-    pub fn get_component(&self, name: &str) -> Option<&SlotVersion> {
+    pub fn slot_version(&self, name: &str) -> Option<&SlotVersion> {
         self.components.get(name)
     }
 

--- a/update-agent/core/src/version_map.rs
+++ b/update-agent/core/src/version_map.rs
@@ -211,11 +211,11 @@ impl VersionMap {
         for (name, version) in chain_group(&legacy.singles) {
             if components
                 .insert(
-                    name.clone(),
+                    name.to_owned(),
                     ComponentInfo {
-                        name: name.clone(),
+                        name: name.to_owned(),
                         slot_version: SlotVersion::Single {
-                            version: version.clone(),
+                            version: version.to_owned(),
                         },
                     },
                 )
@@ -231,11 +231,11 @@ impl VersionMap {
         for (name, version) in chain_group(&legacy.slot_a) {
             if components
                 .insert(
-                    name.clone(),
+                    name.to_owned(),
                     ComponentInfo {
-                        name: name.clone(),
+                        name: name.to_owned(),
                         slot_version: SlotVersion::Redundant {
-                            version_a: Some(version.clone()),
+                            version_a: Some(version.to_owned()),
                             version_b: None,
                         },
                     },
@@ -251,7 +251,7 @@ impl VersionMap {
 
         for (name, version) in chain_group(&legacy.slot_b) {
             components
-                .entry(name.clone())
+                .entry(name.to_owned())
                 .and_modify(|info| match &mut info.slot_version {
                     SlotVersion::Single { .. } => warn!(
                         "while copying legacy slot_b component: {name} already present as single \
@@ -259,7 +259,7 @@ impl VersionMap {
                     ),
 
                     SlotVersion::Redundant { version_b, .. } => {
-                        if version_b.replace(version.clone()).is_some() {
+                        if version_b.replace(version.to_owned()).is_some() {
                             warn!(
                                 "while copying legacy slot_b component: `{name}` already had \
                                  version b set"
@@ -268,10 +268,10 @@ impl VersionMap {
                     }
                 })
                 .or_insert_with(|| ComponentInfo {
-                    name: name.clone(),
+                    name: name.to_owned(),
                     slot_version: SlotVersion::Redundant {
                         version_a: None,
-                        version_b: Some(version.clone()),
+                        version_b: Some(version.to_owned()),
                     },
                 });
         }
@@ -326,6 +326,10 @@ fn insert_jetson_or_mcu(group: &mut VersionGroup, name: &str, version: &str) {
     };
 }
 
-fn chain_group(group: &VersionGroup) -> impl Iterator<Item = (&String, &String)> + '_ {
-    group.jetson.iter().chain(group.mcu.iter())
+fn chain_group(group: &VersionGroup) -> impl Iterator<Item = (&str, &str)> + '_ {
+    group
+        .jetson
+        .iter()
+        .chain(group.mcu.iter())
+        .map(|(k, v)| (k.as_str(), v.as_str()))
 }

--- a/update-agent/core/src/version_map.rs
+++ b/update-agent/core/src/version_map.rs
@@ -83,15 +83,10 @@ impl SlotVersion {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComponentInfo {
-    name: String,
     slot_version: SlotVersion,
 }
 
 impl ComponentInfo {
-    pub fn name(&self) -> &str {
-        &self.name
-    }
-
     pub fn slot_version(&self) -> &SlotVersion {
         &self.slot_version
     }
@@ -181,10 +176,7 @@ impl VersionMap {
                 } else {
                     SlotVersion::new_single(new_version)
                 };
-                ComponentInfo {
-                    name: manifest.name().to_owned(),
-                    slot_version,
-                }
+                ComponentInfo { slot_version }
             });
     }
 
@@ -213,7 +205,6 @@ impl VersionMap {
                 .insert(
                     name.to_owned(),
                     ComponentInfo {
-                        name: name.to_owned(),
                         slot_version: SlotVersion::Single {
                             version: version.to_owned(),
                         },
@@ -233,7 +224,6 @@ impl VersionMap {
                 .insert(
                     name.to_owned(),
                     ComponentInfo {
-                        name: name.to_owned(),
                         slot_version: SlotVersion::Redundant {
                             version_a: Some(version.to_owned()),
                             version_b: None,
@@ -268,7 +258,6 @@ impl VersionMap {
                     }
                 })
                 .or_insert_with(|| ComponentInfo {
-                    name: name.to_owned(),
                     slot_version: SlotVersion::Redundant {
                         version_a: None,
                         version_b: Some(version.to_owned()),
@@ -286,8 +275,7 @@ impl VersionMap {
         let mut slot_a = VersionGroup::default();
         let mut slot_b = VersionGroup::default();
         let mut singles = VersionGroup::default();
-        for info in self.components.values() {
-            let name = &info.name;
+        for (name, info) in self.components.iter() {
             match &info.slot_version {
                 SlotVersion::Single { version } => {
                     insert_jetson_or_mcu(&mut singles, name, version)

--- a/update-agent/core/src/version_map.rs
+++ b/update-agent/core/src/version_map.rs
@@ -88,7 +88,7 @@ pub struct ComponentInfo {
 }
 
 impl ComponentInfo {
-    pub fn name(&self) -> &String {
+    pub fn name(&self) -> &str {
         &self.name
     }
 
@@ -123,12 +123,12 @@ impl<'a> Iterator for ComponentIter<'a> {
 }
 
 impl VersionMap {
-    pub fn get_slot_a(&self) -> Option<&String> {
-        self.releases.slot_a.as_ref()
+    pub fn get_slot_a(&self) -> Option<&str> {
+        self.releases.slot_a.as_deref()
     }
 
-    pub fn get_slot_b(&self) -> Option<&String> {
-        self.releases.slot_b.as_ref()
+    pub fn get_slot_b(&self) -> Option<&str> {
+        self.releases.slot_b.as_deref()
     }
 
     pub fn components(&self) -> ComponentIter<'_> {
@@ -160,7 +160,7 @@ impl VersionMap {
     ) {
         let new_version = manifest.version_upgrade();
         self.components
-            .entry(manifest.name().clone())
+            .entry(manifest.name().to_owned())
             .and_modify(|info| {
                 if system_component.is_redundant() {
                     info.slot_version = info
@@ -182,7 +182,7 @@ impl VersionMap {
                     SlotVersion::new_single(new_version)
                 };
                 ComponentInfo {
-                    name: manifest.name().clone(),
+                    name: manifest.name().to_owned(),
                     slot_version,
                 }
             });

--- a/update-agent/core/src/versions.rs
+++ b/update-agent/core/src/versions.rs
@@ -3,10 +3,7 @@ use std::{collections::HashMap, iter::Extend};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    components::{
-        Location::{self, *},
-        Redundancy::{self, *},
-    },
+    components::Location::{self, *},
     slot::Slot,
 };
 

--- a/update-agent/core/src/versions.rs
+++ b/update-agent/core/src/versions.rs
@@ -18,15 +18,6 @@ pub struct SlotReleases {
     pub(crate) slot_b: String,
 }
 
-/// Information of a component inside a `Versions` type. This is the return value of
-/// `Versions::get_component`.
-pub struct ComponentInfo<'a> {
-    pub name: &'a str,
-    pub version: &'a str,
-    pub location: Location,
-    pub redundancy: Redundancy,
-}
-
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct Versions {
     pub(crate) releases: SlotReleases,
@@ -140,37 +131,6 @@ impl Versions {
             .and_then(|(_, src_version, _)| {
                 dst_group.update_component(component, src_version)
             })
-    }
-
-    /// Returns information about a component with `name` on `slot`. If a component is not present
-    /// on `slot` the non-redundant ("single") section is queried instead.
-    ///
-    /// Returns `None` if a component is neither in the redundant nor the single group.
-    pub fn get_component<'a>(
-        &'a self,
-        slot: Slot,
-        name: &str,
-    ) -> Option<ComponentInfo<'a>> {
-        let redundant_group = match slot {
-            Slot::A => &self.slot_a,
-            Slot::B => &self.slot_b,
-        };
-
-        let (name, version, location, redundancy) = redundant_group
-            .get_component(name)
-            .map(|(name, version, location)| (name, version, location, Redundant))
-            .or_else(|| {
-                self.singles
-                    .get_component(name)
-                    .map(|(name, version, location)| (name, version, location, Single))
-            })?;
-
-        Some(ComponentInfo {
-            name,
-            version,
-            location,
-            redundancy,
-        })
     }
 
     pub fn update_release(&mut self, slot: Slot, release: String) {

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -13,7 +13,7 @@ use std::{
 use eyre::{ensure, WrapErr as _};
 use orb_update_agent_core::{
     components, manifest::InstallationPhase, Claim, LocalOrRemote, ManifestComponent,
-    Slot, Source,
+    MimeType, Slot, Source,
 };
 use reqwest::{
     header::{ToStrError, CONTENT_LENGTH, RANGE},
@@ -506,15 +506,9 @@ pub fn fetch<P: AsRef<Path>>(
             download_delay,
         )?,
     };
-    let compressed = match source.mime_type.as_str() {
-        "application/x-xz" => true,
-        "application/octet-stream" => false,
-        other => {
-            return Err(Error::MimeUnknown {
-                name: source.name.clone(),
-                actual_type: other.to_string(),
-            });
-        }
+    let compressed = match source.mime_type {
+        MimeType::XZ => true,
+        MimeType::OctetStream => false,
     };
     info!(
         "checking sha256 hash of downloaded `{}`",

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -67,7 +67,6 @@ pub struct Component {
     source: Source,
     system_component: components::Component,
     on_disk: PathBuf,
-    compressed: bool,
 }
 
 impl Component {
@@ -158,9 +157,9 @@ impl Component {
     }
 
     pub fn process(&mut self) -> eyre::Result<()> {
-        match self.compressed {
-            true => self.process_compressed(),
-            false => Ok(()),
+        match self.source.mime_type {
+            MimeType::XZ => self.process_compressed(),
+            MimeType::OctetStream => Ok(()),
         }
     }
 
@@ -506,10 +505,6 @@ pub fn fetch<P: AsRef<Path>>(
             download_delay,
         )?,
     };
-    let compressed = match source.mime_type {
-        MimeType::XZ => true,
-        MimeType::OctetStream => false,
-    };
     info!(
         "checking sha256 hash of downloaded `{}`",
         manifest_component.name()
@@ -563,6 +558,5 @@ pub fn fetch<P: AsRef<Path>>(
         system_component: system_component.clone(),
         source: source.clone(),
         on_disk: path,
-        compressed,
     })
 }

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -303,11 +303,11 @@ pub fn validate_claim(
 ) -> eyre::Result<()> {
     for component in claim.manifest_components() {
         let name = component.name();
-        let Some(info) = version_map.get_component(component.name()) else {
+        let Some(slot_version) = version_map.get_component(component.name()) else {
             info!("component `{name}` in update manifest is not present in versions on device");
             continue;
         };
-        match info.slot_version() {
+        match slot_version {
             SlotVersion::Single {
                 version: on_disk_version,
             } => {

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -303,7 +303,7 @@ pub fn validate_claim(
 ) -> eyre::Result<()> {
     for component in claim.manifest_components() {
         let name = component.name();
-        let Some(slot_version) = version_map.get_component(component.name()) else {
+        let Some(slot_version) = version_map.slot_version(component.name()) else {
             info!("component `{name}` in update manifest is not present in versions on device");
             continue;
         };


### PR DESCRIPTION
Update agent deviates from conventional rust coding pattern. For example it uses `&String` instead of `&str` and `&Option<String>` instead `Option<&String>`. 

I've also removed some structures like `version_map::ComponentInfo` and `version::ComponentInfo` (isn't it fun to have two different structures with the same name?)

--

I would appreciate comments about rust style/code quality and what else I could have refactored.