### PR TITLE
update-agent: don't use dbus if run with '--nodbus'

### DIFF
--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -693,8 +693,8 @@ fn shutdown_with_executable() -> eyre::Result<()> {
 /// ⚠️ BUT, we need to send the power-off/shutdown command to the Jetson
 /// because the microcontroller can't detect a Jetson reboot.
 fn reboot(settings: &Settings) -> eyre::Result<()> {
-    debug!("trying to shut down using dbus");
-    if !settings.recovery {
+    if !settings.recovery && !settings.nodbus {
+        debug!("trying to shut down using dbus");
         match shutdown_with_dbus() {
             Ok(()) => return Ok(()),
             Err(e) => {


### PR DESCRIPTION
If update-agent is run with `--nodbus` it should not try to reboot the orb using dbus API, instead it should fallback to calling `systemctl reboot`.