### PR TITLE
fix: OTA from local path

### DIFF
--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -82,8 +82,8 @@ impl Component {
         self.manifest_component.name()
     }
 
-    fn process_compressed(&mut self) -> eyre::Result<()> {
-        let uncompressed_path = self.on_disk.with_extension("uncompressed");
+    fn process_compressed(&mut self, dst: &Path) -> eyre::Result<()> {
+        let uncompressed_path = dst.with_extension("uncompressed");
         let uncompressed_path_verified =
             get_verified_component_path(&uncompressed_path);
 
@@ -156,9 +156,9 @@ impl Component {
         Ok(())
     }
 
-    pub fn process(&mut self) -> eyre::Result<()> {
+    pub fn process(&mut self, dst: &Path) -> eyre::Result<()> {
         match self.source.mime_type {
-            MimeType::XZ => self.process_compressed(),
+            MimeType::XZ => self.process_compressed(dst),
             MimeType::OctetStream => Ok(()),
         }
     }

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -353,21 +353,21 @@ pub fn validate_claim(
     Ok(())
 }
 
-fn fetch_update_components<P: AsRef<Path>>(
+fn fetch_update_components(
     claim: &Claim,
-    manifest_dst: P,
-    dst: P,
+    manifest_dst: &Path,
+    dst: &Path,
     supervisor_proxy: Option<&dbus::SupervisorProxyBlocking<'static>>,
     download_delay: Duration,
 ) -> eyre::Result<Vec<Component>> {
-    orb_update_agent::manifest::compare_to_disk(claim.manifest(), &manifest_dst)?;
+    orb_update_agent::manifest::compare_to_disk(claim.manifest(), manifest_dst)?;
     let mut components = Vec::with_capacity(claim.num_components());
     for (component, source) in claim.iter_components_with_location() {
         let component = component::fetch(
             component,
             &claim.system_components()[component.name()],
             source,
-            &dst,
+            dst,
             supervisor_proxy,
             download_delay,
         )
@@ -379,7 +379,7 @@ fn fetch_update_components<P: AsRef<Path>>(
     components
         .iter_mut()
         .try_for_each(|comp| {
-            comp.process().wrap_err_with(|| {
+            comp.process(dst).wrap_err_with(|| {
                 format!(
                     "failed to process update file for component `{}`",
                     comp.name(),


### PR DESCRIPTION
update-agent could download OTA from a local directory. If the images are compress, update-agent tries to decompress files in the same directory where the source image is, instead of /mnt/downloads.

This commit makes update-agent decompress the images in /mnt/downloads.

--

From the patch it is impossible to understand the change, but that is just a nature of update-agent.