### PR TITLE
feat(telemetry): add opentelemetry support in orb-telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4903,6 +4903,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.65",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 1.2.0",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.13.3",
+ "thiserror 1.0.65",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.13.3",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror 1.0.65",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5339,9 +5404,16 @@ dependencies = [
 name = "orb-telemetry"
 version = "0.0.0"
 dependencies = [
+ "color-eyre",
  "console-subscriber",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "thiserror 1.0.65",
+ "tokio",
  "tracing",
  "tracing-journald",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -8422,6 +8494,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4928,7 +4928,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.13.3",
+ "prost 0.13.4",
  "thiserror 1.0.65",
  "tokio",
  "tonic",
@@ -4942,7 +4942,7 @@ checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.13.3",
+ "prost 0.13.4",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,9 @@ http = "1.2.0"
 jose-jwk = { version = "0.1.2", default-features = false }
 libc = "0.2.153"
 nix = { version = "0.28", default-features = false, features = [] }
+opentelemetry = { version = "0.27", features = ["trace"] }
+opentelemetry-otlp = { version = "0.27", default-features = false }
+opentelemetry_sdk = "0.27"
 prost = "0.13.4"
 prost-build = "0.13.4"
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls", "stream"] }
@@ -89,6 +92,7 @@ tokio-test = "0.4.4"
 tokio-util = "0.7.11"
 tracing = "0.1"
 tracing-journald = "0.3.0"
+tracing-opentelemetry = { version = "0.28", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 zbus = { version = "4.4.0", default-features = false, features = ["tokio"] }
 zbus_systemd = "0.25600.0"

--- a/attest/src/main.rs
+++ b/attest/src/main.rs
@@ -1,8 +1,10 @@
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new()
+    let telemetry = orb_telemetry::TelemetryConfig::new()
         .with_journald(orb_attest::SYSLOG_IDENTIFIER)
         .init();
-    orb_attest::main().await
+    let result = orb_attest::main().await;
+    telemetry.flush().await;
+    result
 }

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -518,7 +518,7 @@ printf dmFsaWRzaWduYXR1cmU=
     // A happy path
     #[tokio::test]
     async fn get_token() {
-        orb_telemetry::TelemetryConfig::new().init();
+        let _ = orb_telemetry::TelemetryConfig::new().init();
 
         let mock_server = MockServer::start().await;
 

--- a/backend-state/src/main.rs
+++ b/backend-state/src/main.rs
@@ -36,12 +36,18 @@ struct Cli {}
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new()
+    let telemetry = orb_telemetry::TelemetryConfig::new()
         .with_journald(SYSLOG_IDENTIFIER)
         .init();
 
-    let _args = Cli::parse();
+    let args = Cli::parse();
 
+    let result = main_inner(args).await;
+    telemetry.flush().await;
+    result
+}
+
+async fn main_inner(_args: Cli) -> Result<()> {
     let conn = zbus::Connection::session()
         .await
         .wrap_err("failed to connect to zbus session")?;

--- a/experiments/zenoh/src/main.rs
+++ b/experiments/zenoh/src/main.rs
@@ -17,15 +17,17 @@ enum Args {
 
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
-    orb_telemetry::TelemetryConfig::new().init();
+    let telemetry = orb_telemetry::TelemetryConfig::new().init();
     tracing::debug!("debug logging is enabled");
 
     let args = Args::parse();
 
-    match args {
+    let result = match args {
         Args::Alice { .. } => alice(args).await,
         Args::Bob { .. } => bob(args).await,
-    }
+    };
+    telemetry.flush().await;
+    result
 }
 
 async fn alice(args: Args) -> Result<()> {

--- a/fleet-cmdr/src/main.rs
+++ b/fleet-cmdr/src/main.rs
@@ -13,12 +13,14 @@ const SYSLOG_IDENTIFIER: &str = "worldcoin-fleet-cmdr";
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new()
+    let tel_flusher = orb_telemetry::TelemetryConfig::new()
         .with_journald(SYSLOG_IDENTIFIER)
         .init();
 
     let args = Args::parse();
-    run(&args).await
+    let result = run(&args).await;
+    tel_flusher.flush().await;
+    result
 }
 
 async fn run(args: &Args) -> Result<()> {

--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -267,7 +267,7 @@ fn clap_v3_styles() -> Styles {
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new().init();
+    let telemetry = orb_telemetry::TelemetryConfig::new().init();
 
     let args = Args::parse();
 
@@ -277,8 +277,10 @@ async fn main() -> Result<()> {
 
     if let Err(e) = execute(args).await {
         error!("{:#?}", e);
+        telemetry.flush().await;
         std::process::exit(-1);
     } else {
+        telemetry.flush().await;
         std::process::exit(0);
     }
 }

--- a/supervisor/tests/it/helpers.rs
+++ b/supervisor/tests/it/helpers.rs
@@ -11,7 +11,7 @@ use zbus::{
 pub const WORLDCOIN_CORE_SERVICE_OBJECT_PATH: &str =
     "/org/freedesktop/systemd1/unit/worldcoin_2dcore_2eservice";
 static TRACING: Lazy<()> = Lazy::new(|| {
-    orb_telemetry::TelemetryConfig::new().init();
+    let _ = orb_telemetry::TelemetryConfig::new().init();
 });
 
 #[derive(Debug)]

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -10,10 +10,29 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[features]
+default = ["otel"]
+otel = [
+  "dep:opentelemetry",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry_sdk",
+  "dep:tracing-opentelemetry",
+  "dep:tokio",
+]
+
 [dependencies]
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, features = ["trace", "grpc-tonic"], optional = true }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
+thiserror.workspace = true
+tokio = { workspace = true, optional = true }
 tracing-journald.workspace = true
-tracing-subscriber.workspace = true
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 tracing.workspace = true
+
+[dev-dependencies]
+color-eyre.workspace = true
 
 [target.'cfg(tokio_unstable)'.dependencies]
 console-subscriber.workspace = true

--- a/telemetry/examples/async.rs
+++ b/telemetry/examples/async.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use tracing::{debug, error, info, instrument, trace, warn};
+
+const SERVICE_NAME: &str = "my-service";
+const SERVICE_VERSION: &str = "v1.2.3"; // You should use orb-build-info in your code
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+    let telemetry = orb_telemetry::TelemetryConfig::new()
+        .with_opentelemetry(orb_telemetry::OpentelemetryConfig::new(
+            orb_telemetry::OpentelemetryAttributes {
+                service_name: SERVICE_NAME.to_string(),
+                service_version: SERVICE_VERSION.to_string(),
+                additional_otel_attributes: Default::default(),
+            },
+        )?)
+        .with_journald(SERVICE_NAME)
+        .init();
+
+    trace!("TRACE");
+    debug!("DEBUG");
+    info!("INFO");
+    warn!("WARN");
+    error!("ERROR");
+
+    some_longer_task(69).await;
+
+    telemetry.flush().await;
+
+    Ok(())
+}
+
+#[instrument]
+async fn some_longer_task(arg: u8) {
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    info!("got result: {arg}");
+}

--- a/telemetry/examples/custom_filter.rs
+++ b/telemetry/examples/custom_filter.rs
@@ -1,0 +1,59 @@
+use std::time::Duration;
+
+use tracing::{
+    debug, error, info, instrument, level_filters::LevelFilter, trace, warn,
+};
+use tracing_subscriber::{filter::Targets, EnvFilter};
+
+const SERVICE_NAME: &str = "my-service";
+const SERVICE_VERSION: &str = "v1.2.3"; // You should use orb-build-info in your code
+
+#[tokio::main]
+async fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+    let telemetry = orb_telemetry::TelemetryConfig::new()
+        .with_journald(SERVICE_NAME)
+        .with_opentelemetry(
+            orb_telemetry::OpentelemetryConfig::new(
+                orb_telemetry::OpentelemetryAttributes {
+                    service_name: SERVICE_NAME.to_string(),
+                    service_version: SERVICE_VERSION.to_string(),
+                    additional_otel_attributes: Default::default(),
+                },
+            )?
+            .with_filter(
+                "reqwest=WARN,http=WARN" // filter out noisy events and spans
+                    .parse::<Targets>()?
+                    // still send everything else
+                    .with_default(LevelFilter::TRACE),
+            ),
+        )
+        // NOTE: this replaces the default global filter.
+        .with_global_filter(
+            // We still want users to be able to override the filter, so we allow
+            // overriding the defaults with `RUST_LOG`
+            std::env::var("RUST_LOG")
+                // we specify INFO as the fallback/default verbosity. "custom_filter"
+                // is the name of this example crate.
+                .unwrap_or("info,custom_filter=debug".to_owned())
+                .parse::<EnvFilter>()?,
+        )
+        .init();
+
+    trace!("TRACE");
+    debug!("DEBUG");
+    info!("INFO");
+    warn!("WARN");
+    error!("ERROR");
+
+    some_longer_task(69).await;
+
+    telemetry.flush().await;
+    Ok(())
+}
+
+#[instrument]
+async fn some_longer_task(arg: u8) {
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+    info!("got result: {arg}");
+}

--- a/telemetry/examples/simple.rs
+++ b/telemetry/examples/simple.rs
@@ -1,0 +1,12 @@
+use tracing::{debug, error, info, trace, warn};
+
+fn main() {
+    // if you don't care about flushing all logs, you can ignore the return value.
+    let _ = orb_telemetry::TelemetryConfig::new().init();
+
+    trace!("TRACE");
+    debug!("DEBUG");
+    info!("INFO");
+    warn!("WARN");
+    error!("ERROR");
+}

--- a/telemetry/examples/sync.rs
+++ b/telemetry/examples/sync.rs
@@ -1,0 +1,39 @@
+use std::time::Duration;
+
+use tracing::{debug, error, info, instrument, trace, warn};
+
+const SERVICE_NAME: &str = "my-service";
+const SERVICE_VERSION: &str = "v1.2.3"; // get this from orb-build-info instead
+
+fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+
+    let telemetry = orb_telemetry::TelemetryConfig::new()
+        .with_opentelemetry(orb_telemetry::OpentelemetryConfig::new(
+            orb_telemetry::OpentelemetryAttributes {
+                service_name: SERVICE_NAME.to_string(),
+                service_version: SERVICE_VERSION.to_string(),
+                additional_otel_attributes: Default::default(),
+            },
+        )?)
+        .with_journald(SERVICE_NAME)
+        .init();
+
+    trace!("TRACE");
+    debug!("DEBUG");
+    info!("INFO");
+    warn!("WARN");
+    error!("ERROR");
+
+    some_longer_task(69);
+
+    telemetry.flush_blocking();
+
+    Ok(())
+}
+
+#[instrument]
+fn some_longer_task(arg: u8) {
+    std::thread::sleep(Duration::from_millis(1000));
+    info!("got result: {arg}");
+}

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -1,14 +1,110 @@
-use std::io::IsTerminal as _;
+//! Standardized telemetry for the orb.
+//!
+//! See the `examples` dir. Start with [`TelemetryConfig::new()`].
+
+use std::io::{IsTerminal as _, Write as _};
 
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{
     layer::SubscriberExt as _, util::SubscriberInitExt as _, EnvFilter,
 };
 
+#[cfg(feature = "otel")]
+mod _otel_stuff {
+    pub use opentelemetry::trace::TracerProvider;
+    pub use opentelemetry::KeyValue;
+    pub use tokio::io::AsyncWriteExt as _;
+    pub use tracing_subscriber::layer::Layer;
+}
+#[cfg(feature = "otel")]
+use self::_otel_stuff::*;
+
+/// Represents the attributes that will be attached to opentelemetry data for this
+/// service.
+///
+/// This is similar in concept to datadog Tags.
+#[derive(Debug)]
+#[cfg(feature = "otel")]
+pub struct OpentelemetryAttributes {
+    /// Name of the service
+    pub service_name: String,
+    /// Version of the service. We suggest getting this from `orb-build-info`.
+    pub service_version: String,
+    /// Any additional attributes
+    pub additional_otel_attributes: Vec<opentelemetry::KeyValue>,
+}
+
+#[derive(Debug)]
+#[cfg(feature = "otel")]
+pub struct OpentelemetryConfig {
+    /// The tracer that will be used for opentelmetry.
+    pub tracer_provider: opentelemetry_sdk::trace::TracerProvider,
+    /// The name used for the tracer. Should be set to the service name.
+    pub tracer_name: String,
+    /// The layer filter that will be used, might be None.
+    pub filter: Option<tracing_subscriber::filter::Targets>,
+}
+
+#[cfg(feature = "otel")]
+impl OpentelemetryConfig {
+    pub fn new(
+        attrs: OpentelemetryAttributes,
+    ) -> Result<Self, opentelemetry::trace::TraceError> {
+        // The otlp exporter for opentelemetry *requires* that a tokio runtime is
+        // present. To make this easier and less error prone in synchronous use cases,
+        // we create a new single threaded runtime if no runtime is currently present.
+        let rt = tokio::runtime::Handle::try_current().unwrap_or_else(|_| {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            std::thread::spawn(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                tx.send(rt.handle().clone()).ok();
+                rt.block_on(std::future::pending::<()>())
+            });
+            rx.blocking_recv()
+                .expect("failed to create new tokio runtime")
+        });
+        let _tokio_ctx = rt.enter();
+
+        let tracer_provider = opentelemetry_sdk::trace::TracerProvider::builder()
+            .with_resource(opentelemetry_sdk::Resource::new([
+                KeyValue::new("service.name", attrs.service_name.clone()),
+                KeyValue::new("service", attrs.service_name.clone()),
+            ]))
+            .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn)
+            .with_id_generator(opentelemetry_sdk::trace::RandomIdGenerator::default())
+            .with_batch_exporter(
+                opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
+                    .build()?,
+                opentelemetry_sdk::runtime::Tokio,
+            )
+            .build();
+
+        Ok(Self {
+            tracer_provider,
+            tracer_name: attrs.service_name,
+            filter: None,
+        })
+    }
+
+    pub fn with_filter(self, filter: tracing_subscriber::filter::Targets) -> Self {
+        Self {
+            filter: Some(filter),
+            ..self
+        }
+    }
+}
+
+/// The toplevel config for the orb-telemetry crate. Start here.
 #[derive(Debug)]
 pub struct TelemetryConfig {
     syslog_identifier: Option<String>,
     global_filter: EnvFilter,
+    #[cfg(feature = "otel")]
+    otel_cfg: Option<OpentelemetryConfig>,
 }
 
 impl TelemetryConfig {
@@ -22,6 +118,8 @@ impl TelemetryConfig {
             global_filter: EnvFilter::builder()
                 .with_default_directive(LevelFilter::INFO.into())
                 .from_env_lossy(),
+            #[cfg(feature = "otel")]
+            otel_cfg: None,
         }
     }
 
@@ -46,7 +144,18 @@ impl TelemetryConfig {
         }
     }
 
-    pub fn try_init(self) -> Result<(), tracing_subscriber::util::TryInitError> {
+    #[cfg(feature = "otel")]
+    #[must_use]
+    pub fn with_opentelemetry(self, cfg: OpentelemetryConfig) -> Self {
+        Self {
+            otel_cfg: Some(cfg),
+            ..self
+        }
+    }
+
+    pub fn try_init(
+        self,
+    ) -> Result<TelemetryFlusher, tracing_subscriber::util::TryInitError> {
         let registry = tracing_subscriber::registry();
         // The type is only there to get it to compile.
         let tokio_console_layer: Option<tracing_subscriber::layer::Identity> = None;
@@ -72,12 +181,33 @@ impl TelemetryConfig {
             .is_none()
             .then(|| tracing_subscriber::fmt::layer().with_writer(std::io::stderr));
         assert!(stderr_layer.is_some() || journald_layer.is_some());
-        registry
+
+        #[cfg(feature = "otel")]
+        let (otel_layer, otel_provider) = if let Some(otel_cfg) = self.otel_cfg {
+            let tracer = otel_cfg.tracer_provider.tracer(otel_cfg.tracer_name);
+            let layer = tracing_opentelemetry::layer()
+                .with_level(true)
+                .with_location(true)
+                .with_threads(true)
+                .with_tracer(tracer)
+                .with_filter(otel_cfg.filter);
+            (Some(layer), Some(otel_cfg.tracer_provider))
+        } else {
+            (None, None)
+        };
+
+        let registry = registry
             .with(tokio_console_layer)
             .with(stderr_layer)
-            .with(journald_layer)
-            .with(self.global_filter)
-            .try_init()
+            .with(journald_layer);
+        #[cfg(feature = "otel")]
+        let registry = registry.with(otel_layer);
+        registry.with(self.global_filter).try_init()?;
+
+        Ok(TelemetryFlusher {
+            #[cfg(feature = "otel")]
+            otel_provider,
+        })
     }
 
     /// Initializes the telemetry config. Call this only once, at the beginning of the
@@ -85,7 +215,57 @@ impl TelemetryConfig {
     ///
     /// Calling this more than once or when another tracing subscriber is registered
     /// will cause a panic.
-    pub fn init(self) {
+    pub fn init(self) -> TelemetryFlusher {
         self.try_init().expect("failed to initialize orb-telemetry")
+    }
+}
+
+/// Allows flushing all telemetry logs.
+#[must_use = "call .join at the end of the program to flush logs, otherwise they may get lost"]
+pub struct TelemetryFlusher {
+    #[cfg(feature = "otel")]
+    otel_provider: Option<opentelemetry_sdk::trace::TracerProvider>,
+}
+
+impl TelemetryFlusher {
+    /// Call this at the end of the program.
+    pub async fn flush(self) {
+        #[cfg(feature = "otel")]
+        {
+            let task = tokio::task::spawn_blocking(|| self.blocking_work());
+            task.await.unwrap();
+            tokio::io::stderr().flush().await.ok();
+            tokio::io::stdout().flush().await.ok();
+        }
+        #[cfg(not(feature = "otel"))]
+        {
+            // technically blocks, but no one really cares for stderr/out.
+            std::io::stderr().flush().ok();
+            std::io::stdout().flush().ok();
+        }
+    }
+
+    /// Call this at the end of the program.
+    pub fn flush_blocking(self) {
+        self.blocking_work();
+        std::io::stderr().flush().ok();
+        std::io::stdout().flush().ok();
+    }
+
+    #[cfg_attr(not(feature = "otel"), expect(unused_mut))]
+    fn blocking_work(mut self) {
+        #[cfg(feature = "otel")]
+        if let Some(otel_provider) = self.otel_provider.take() {
+            for flush_result in otel_provider.force_flush() {
+                if let Err(err) = flush_result {
+                    // use stderr because tracing is not working
+                    eprintln!("failed to flush opentelemetry tracers, writing to stderr: {err:?}");
+                }
+            }
+            if let Err(err) = otel_provider.shutdown() {
+                // use stderr because tracing is not working
+                eprintln!("failed to shutdown opentelemetry tracers, writing to stderr: {err:?}");
+            }
+        }
     }
 }

--- a/thermal-cam-ctrl/src/main.rs
+++ b/thermal-cam-ctrl/src/main.rs
@@ -110,7 +110,7 @@ enum Flow {
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new()
+    let telemetry = orb_telemetry::TelemetryConfig::new()
         .with_journald(SYSLOG_IDENTIFIER)
         .init();
 
@@ -134,11 +134,13 @@ fn main() -> Result<()> {
         );
     }
 
-    match args.commands {
+    let result = match args.commands {
         Commands::Calibration(c) => c.run(),
         Commands::Capture(c) => c.run(),
         Commands::Log(c) => c.run(),
         Commands::Pairing(c) => c.run(),
         Commands::Cleanup(c) => c.run(),
-    }
+    };
+    telemetry.flush_blocking();
+    result
 }

--- a/ui/examples/ui-replay.rs
+++ b/ui/examples/ui-replay.rs
@@ -65,12 +65,7 @@ impl FromStr for EventRecord {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
-    color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new().init();
-
-    let args = Args::parse();
+async fn main_inner(args: Args) -> Result<()> {
     let connection = Connection::session().await?;
     let proxy = SignupStateProxy::new(&connection).await?;
 
@@ -102,4 +97,15 @@ async fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    let telemetry = orb_telemetry::TelemetryConfig::new().init();
+
+    let args = Args::parse();
+    let result = main_inner(args).await;
+    telemetry.flush().await;
+    result
 }

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -56,16 +56,20 @@ const CFG_ENV_VAR: &str = const_format::concatcp!(ENV_VAR_PREFIX, "CONFIG");
 const SYSLOG_IDENTIFIER: &str = "worldcoin-update-agent";
 
 fn main() -> UpdateAgentResult {
-    orb_telemetry::TelemetryConfig::new()
+    let telemetry = orb_telemetry::TelemetryConfig::new()
         .with_journald(SYSLOG_IDENTIFIER)
         .init();
 
     let args = Args::parse();
 
     match run(&args) {
-        Ok(_) => UpdateAgentResult::Success,
+        Ok(_) => {
+            telemetry.flush_blocking();
+            UpdateAgentResult::Success
+        }
         Err(err) => {
             error!("{err:?}");
+            telemetry.flush_blocking();
             err.into()
         }
     }

--- a/update-agent/tests/main.rs
+++ b/update-agent/tests/main.rs
@@ -6,7 +6,7 @@ use std::{
 #[ignore = "requires specific block device"]
 #[test]
 fn test_blockdevice_size() {
-    orb_telemetry::TelemetryConfig::new().init();
+    let _ = orb_telemetry::TelemetryConfig::new().init();
 
     let mut block_device: File = std::fs::OpenOptions::new()
         .read(true)

--- a/update-verifier/src/main.rs
+++ b/update-verifier/src/main.rs
@@ -27,10 +27,13 @@ fn clap_v3_styles() -> Styles {
 
 fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
-    orb_telemetry::TelemetryConfig::new()
+    let telemetry = orb_telemetry::TelemetryConfig::new()
         .with_journald(SYSLOG_IDENTIFIER)
         .init();
-    run().inspect_err(|error| error!(?error, "failed to run update-verifier"))
+    let result =
+        run().inspect_err(|error| error!(?error, "failed to run update-verifier"));
+    telemetry.flush_blocking();
+    result
 }
 
 fn run() -> eyre::Result<()> {


### PR DESCRIPTION
Adds tracing-opentelemetry as a tracing subscriber and also uses opentelemeyry-otlp to export spans to an opentelemetry collector 