### PR TITLE
build: add docker runner for mac users to run tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,7 @@
 [net]
 # libgit2 doesn't handle git credentials well
 git-fetch-with-cli = true
+
+# Run cargo with `RUSTFLAGS='--cfg docker_runner'`
+[target.'cfg(docker_runner)']
+runner = "docker/cargo-runner.sh"

--- a/docker/cargo-runner.sh
+++ b/docker/cargo-runner.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Allows running tests inside docker. Takes care of linux-only dependencies and avoids
+# the need to emulate the architecture.
+
+set -o pipefail -eu
+
+PROGRAM=$1; shift
+
+main() {
+	local -r absolute_path="$(realpath ${PROGRAM})"
+
+	docker run \
+		--rm \
+		-v "${absolute_path}:/mnt/program" \
+		-w /mnt \
+		-e RUST_BACKTRACE \
+		-it debian:latest \
+		/mnt/program $@
+}
+
+main $@


### PR DESCRIPTION
lets mac users run tests that otherwise only run on linux.