### PR TITLE
refactor(info): rework errors, general cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,15 +2725,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ftdi-embedded-hal"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,26 +3736,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
-name = "inotify"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
-dependencies = [
- "bitflags 2.8.0",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,26 +4000,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a3ec39d2dc17953a1540d63906a112088f79b2e46833b4ed65bc9de3904ae34"
 dependencies = [
  "hashbrown 0.14.3",
-]
-
-[[package]]
-name = "kqueue"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.2.1",
- "libc",
 ]
 
 [[package]]
@@ -4520,7 +4471,6 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi",
  "libc",
- "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -4663,31 +4613,6 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "notify"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
-dependencies = [
- "bitflags 2.8.0",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio 1.0.2",
- "notify-types",
- "walkdir",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -5193,7 +5118,6 @@ source = "git+https://github.com/worldcoin/orb-software?rev=832962ad8220bcbe175e
 name = "orb-endpoints"
 version = "0.0.0"
 dependencies = [
- "hex",
  "orb-info",
  "url",
 ]
@@ -5276,12 +5200,9 @@ dependencies = [
 name = "orb-info"
 version = "0.0.0"
 dependencies = [
- "color-eyre",
  "dbus-launch",
- "futures-lite",
+ "eyre",
  "hex",
- "http 1.2.0",
- "notify",
  "orb-attest-dbus",
  "serial_test 3.2.0",
  "thiserror 1.0.65",
@@ -6300,7 +6221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -6320,7 +6241,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,11 +61,14 @@ clap = { version = "4.5", features = ["derive", "env"] }
 color-eyre = "0.6.2"
 console-subscriber = "0.4"
 data-encoding = "2.3"
+dbus-launch = "0.2.0"
 derive_more = { version = "0.99", default-features = false, features = ["display", "from"] }
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["std"]}
 eyre = "0.6.12"
 ftdi-embedded-hal = { version = "0.22.0", features = ["libftd2xx", "libftd2xx-static"] }
 futures = "0.3.30"
+futures-lite = "2.6.0"
+hex = "0.4.3"
 hex-literal = "0.4.1"
 http = "1.2.0"
 jose-jwk = { version = "0.1.2", default-features = false }
@@ -82,9 +85,10 @@ rustix = "0.38.37"
 secrecy = "0.8"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1"
+serial_test = "3.2.0"
 sha2 = "0.10.8"
-testcontainers = "0.20.0"
 tempfile = "3.10.1"
+testcontainers = "0.20.0"
 thiserror = "1.0.60"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5.4.4"
@@ -105,7 +109,7 @@ orb-build-info.path = "build-info"
 orb-const-concat.path = "const-concat"
 orb-endpoints.path = "endpoints"
 orb-header-parsing.path = "header-parsing"
-orb-info.path = "orb-info"
+orb-info = { path = "orb-info", default-features = false }
 orb-mcu-interface.path = "mcu-interface"
 orb-security-utils.path = "security-utils"
 orb-slot-ctrl.path = "slot-ctrl"

--- a/endpoints/Cargo.toml
+++ b/endpoints/Cargo.toml
@@ -11,6 +11,5 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-hex = "0.4.3"
 url = "2.5.0"
-orb-info.workspace = true
+orb-info = { workspace = true, default-features = false, features = ["orb-id"] }

--- a/orb-info/Cargo.toml
+++ b/orb-info/Cargo.toml
@@ -13,25 +13,28 @@ rust-version.workspace = true
 [features]
 default = ["orb-id", "orb-jabil-id", "orb-name", "orb-token", "async"]
 async = ["dep:tokio", "dep:tokio-util"]
-orb-id = []
-orb-name = []
-orb-jabil-id = []
-orb-token = ["dep:zbus", "dep:tokio", "dep:tokio-util"]
+orb-id = ["dep:hex"]
+orb-name = ["dep:hex"]
+orb-jabil-id = ["dep:hex"]
+orb-token = [
+  "dep:orb-attest-dbus",
+  "dep:tokio",
+  "dep:tokio-util",
+  "dep:tracing",
+  "dep:zbus",
+]
 
 [dependencies]
-color-eyre.workspace = true
-futures-lite = "2.6.0"
-hex = "0.4.3"
-http.workspace = true
-notify = "8.0.0"
-orb-attest-dbus.workspace = true
+hex = { workspace = true, optional = true }
+orb-attest-dbus = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true }
-tracing.workspace = true
+tracing = { workspace = true, optional = true }
 thiserror.workspace = true
 zbus = { workspace = true, optional = true }
 
 [dev-dependencies]
-dbus-launch = "0.2.0"
-serial_test = "3.2.0"
+eyre.workspace = true
+dbus-launch.workspace = true
+serial_test.workspace = true
 tokio.workspace = true

--- a/orb-info/src/lib.rs
+++ b/orb-info/src/lib.rs
@@ -7,6 +7,8 @@ pub mod orb_name;
 #[cfg(feature = "orb-token")]
 pub mod orb_token;
 
+use std::io;
+use std::path::Path;
 use std::process::Output;
 
 #[cfg(feature = "orb-id")]
@@ -18,73 +20,39 @@ pub use orb_name::OrbName;
 #[cfg(feature = "orb-token")]
 pub use orb_token::TokenTaskHandle;
 
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum OrbInfoError {
-    #[error("field is not yet available")]
-    Unavailable,
-    #[error(transparent)]
-    IoErr(#[from] std::io::Error),
-    #[error(transparent)]
-    NotifyErr(#[from] notify::Error),
-    #[error(transparent)]
-    Utf8Err(#[from] std::string::FromUtf8Error),
-    #[error(transparent)]
-    OrbIdErr(#[from] hex::FromHexError),
-    #[cfg(feature = "orb-token")]
-    #[error(transparent)]
-    ZbusErr(#[from] zbus::Error),
-}
-
 #[cfg(feature = "async")]
-async fn from_file(path: &str) -> Result<String, OrbInfoError> {
-    match tokio::fs::read_to_string(path).await {
-        Ok(s) => Ok(s.trim().to_string()),
-        Err(e) => Err(OrbInfoError::IoErr(e)),
-    }
-}
-
-#[cfg(feature = "async")]
-async fn from_binary(path: &str) -> Result<String, OrbInfoError> {
-    let output = tokio::process::Command::new(path)
-        .output()
+async fn from_file(path: impl AsRef<Path>) -> io::Result<String> {
+    tokio::fs::read_to_string(path)
         .await
-        .map_err(OrbInfoError::IoErr)?;
+        .map(|s| s.trim().to_owned())
+}
+
+#[cfg_attr(
+    not(any(feature = "orb-name", feature = "orb-jabil-id")),
+    expect(dead_code)
+)]
+fn from_file_blocking(path: impl AsRef<Path>) -> io::Result<String> {
+    std::fs::read_to_string(path).map(|s| s.trim().to_owned())
+}
+
+#[cfg(feature = "async")]
+async fn from_binary(path: impl AsRef<Path>) -> io::Result<String> {
+    let output = tokio::process::Command::new(path.as_ref()).output().await?;
     from_binary_output(output, path)
 }
 
-fn from_env(env_var: &str) -> Result<String, OrbInfoError> {
-    match std::env::var(env_var) {
-        Ok(s) => Ok(s.trim().to_string()),
-        Err(_) => Err(OrbInfoError::Unavailable),
-    }
-}
-
-fn from_file_blocking(path: &str) -> Result<String, OrbInfoError> {
-    match std::fs::read_to_string(path) {
-        Ok(s) => Ok(s.trim().to_string()),
-        Err(e) => Err(OrbInfoError::IoErr(e)),
-    }
-}
-
-fn from_binary_blocking(path: &str) -> Result<String, OrbInfoError> {
-    let output = std::process::Command::new(path)
-        .output()
-        .map_err(OrbInfoError::IoErr)?;
+fn from_binary_blocking(path: impl AsRef<Path>) -> io::Result<String> {
+    let output = std::process::Command::new(path.as_ref()).output()?;
     from_binary_output(output, path)
 }
 
-fn from_binary_output(output: Output, path: &str) -> Result<String, OrbInfoError> {
+fn from_binary_output(output: Output, path: impl AsRef<Path>) -> io::Result<String> {
     if output.status.success() {
-        String::from_utf8(output.stdout)
-            .map(|s| s.trim().to_string())
-            .map_err(OrbInfoError::Utf8Err)
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
     } else {
-        Err(OrbInfoError::IoErr(std::io::Error::new(
+        Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            format!("{} binary failed", path),
-        )))
+            format!("{} binary failed", path.as_ref().display()),
+        ))
     }
 }

--- a/orb-info/src/orb_id.rs
+++ b/orb-info/src/orb_id.rs
@@ -235,31 +235,4 @@ mod test {
 
         std::env::remove_var("ORB_ID");
     }
-
-    #[test]
-    #[serial_test::serial]
-    fn test_sync_get_orb_id_binary_failure() {
-        std::env::remove_var("ORB_ID");
-
-        // TODO(@paulquinn00): Tests should not rely on state from host environment
-        // This should error since orb-id binary likely doesn't exist in test environment
-        let Err(ReadErr::Io(err)) = OrbId::read_blocking() else {
-            panic!("expected io error");
-        };
-        assert_eq!(err.kind(), std::io::ErrorKind::NotFound)
-    }
-
-    #[cfg(feature = "async")]
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn test_async_get_orb_id_binary_failure() {
-        std::env::remove_var("ORB_ID");
-
-        // TODO(@paulquinn00): Tests should not rely on host environment
-        // This should panic since orb-id binary likely doesn't exist in test environment
-        let Err(ReadErr::Io(err)) = OrbId::read().await else {
-            panic!("expected io error");
-        };
-        assert_eq!(err.kind(), std::io::ErrorKind::NotFound)
-    }
 }

--- a/orb-info/src/orb_name.rs
+++ b/orb-info/src/orb_name.rs
@@ -1,35 +1,43 @@
-use color_eyre::Result;
 use std::{fmt::Display, str::FromStr};
+use thiserror::Error;
 
-use crate::{from_env, from_file_blocking, OrbInfoError};
+use crate::from_file_blocking;
 
 #[cfg(test)]
 const ORB_NAME_PATH: &str = "./test_orb_name";
 #[cfg(not(test))]
 const ORB_NAME_PATH: &str = "/usr/persistent/orb-name";
 
+#[derive(Debug, Error)]
+pub enum ReadErr {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct OrbName(pub String);
 
 impl OrbName {
     #[cfg(feature = "async")]
-    pub async fn read() -> Result<Self, OrbInfoError> {
+    pub async fn read() -> Result<Self, ReadErr> {
         use crate::from_file;
 
-        let name = if let Ok(s) = from_env("ORB_NAME") {
+        let name = if let Ok(s) = std::env::var("ORB_NAME") {
             Ok(s.trim().to_string())
         } else {
-            let path = from_env("ORB_NAME_PATH").unwrap_or(ORB_NAME_PATH.to_string());
+            let path =
+                std::env::var("ORB_NAME_PATH").unwrap_or(ORB_NAME_PATH.to_owned());
             from_file(&path).await
         }?;
         Ok(Self(name))
     }
 
-    pub fn read_blocking() -> Result<Self, OrbInfoError> {
-        let name = if let Ok(s) = from_env("ORB_NAME") {
+    pub fn read_blocking() -> Result<Self, ReadErr> {
+        let name = if let Ok(s) = std::env::var("ORB_NAME") {
             Ok(s.trim().to_string())
         } else {
-            let path = from_env("ORB_NAME_PATH").unwrap_or(ORB_NAME_PATH.to_string());
+            let path =
+                std::env::var("ORB_NAME_PATH").unwrap_or(ORB_NAME_PATH.to_string());
             from_file_blocking(&path)
         }?;
         Ok(Self(name))
@@ -45,7 +53,7 @@ impl OrbName {
 }
 
 impl FromStr for OrbName {
-    type Err = OrbInfoError;
+    type Err = hex::FromHexError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(s.to_string()))
@@ -62,7 +70,6 @@ impl Display for OrbName {
 mod tests {
     use super::*;
     use serial_test::serial;
-    use std::fs;
     use std::path::Path;
 
     #[cfg(feature = "async")]
@@ -75,9 +82,9 @@ mod tests {
         std::env::remove_var("ORB_NAME");
     }
 
-    #[tokio::test]
+    #[test]
     #[serial]
-    async fn test_sync_get_from_env() {
+    fn test_sync_get_from_env() {
         std::env::set_var("ORB_NAME", "TEST_ORB");
         let orb_name = OrbName::read_blocking().unwrap();
         assert_eq!(orb_name.as_str(), "TEST_ORB");
@@ -93,50 +100,54 @@ mod tests {
 
         let test_path = Path::new("/tmp/orb-name");
         if !test_path.exists() {
-            fs::create_dir_all("/tmp").unwrap();
-            fs::write(test_path, "FILE_ORB\n").unwrap();
+            tokio::fs::create_dir_all("/tmp").await.unwrap();
+            tokio::fs::write(test_path, "FILE_ORB\n").await.unwrap();
         }
 
         let orb_name = OrbName::read().await.unwrap();
         assert_eq!(orb_name.as_str(), "FILE_ORB");
 
         if test_path.exists() {
-            fs::remove_file(test_path).unwrap();
+            tokio::fs::remove_file(test_path).await.unwrap();
         }
     }
 
-    #[tokio::test]
+    #[test]
     #[serial]
-    async fn test_sync_get_from_file() {
+    fn test_sync_get_from_file() {
         std::env::remove_var("ORB_NAME");
         std::env::set_var("ORB_NAME_PATH", "/tmp/orb-name");
 
         let test_path = Path::new("/tmp/orb-name");
         if !test_path.exists() {
-            fs::create_dir_all("/tmp").unwrap();
-            fs::write(test_path, "FILE_ORB\n").unwrap();
+            std::fs::create_dir_all("/tmp").unwrap();
+            std::fs::write(test_path, "FILE_ORB\n").unwrap();
         }
 
         let orb_name = OrbName::read_blocking().unwrap();
         assert_eq!(orb_name.as_str(), "FILE_ORB");
 
         if test_path.exists() {
-            fs::remove_file(test_path).unwrap();
+            std::fs::remove_file(test_path).unwrap();
         }
     }
 
-    #[tokio::test]
+    #[test]
     #[serial]
-    async fn test_sync_error_when_not_found() {
+    fn test_sync_error_when_not_found() {
         std::env::remove_var("ORB_NAME");
 
+        // TODO(paulquinn00): Use a temporary path, in case we run this on an orb.
         let test_path = Path::new("/usr/persistent/orb-name");
         if test_path.exists() {
-            fs::remove_file(test_path).unwrap();
+            std::fs::remove_file(test_path).unwrap();
         }
 
         let orb_name = OrbName::read_blocking();
-        assert!(matches!(orb_name, Err(OrbInfoError::IoErr(_))));
+        let Err(ReadErr::Io(io_err)) = orb_name else {
+            panic!("expected an IO error");
+        };
+        assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
     }
 
     #[cfg(feature = "async")]
@@ -145,12 +156,16 @@ mod tests {
     async fn test_async_error_when_not_found() {
         std::env::remove_var("ORB_NAME");
 
+        // TODO(paulquinn00): Use a temporary path, in case we run this on an orb.
         let test_path = Path::new("/usr/persistent/orb-name");
         if test_path.exists() {
-            fs::remove_file(test_path).unwrap();
+            tokio::fs::remove_file(test_path).await.unwrap();
         }
 
         let orb_name = OrbName::read().await;
-        assert!(matches!(orb_name, Err(OrbInfoError::IoErr(_))));
+        let Err(ReadErr::Io(io_err)) = orb_name else {
+            panic!("expected an IO error");
+        };
+        assert_eq!(io_err.kind(), std::io::ErrorKind::NotFound);
     }
 }

--- a/update-agent/Cargo.toml
+++ b/update-agent/Cargo.toml
@@ -27,7 +27,7 @@ eyre.workspace = true
 figment = { version = "0.10.8", features = ["env", "toml"] }
 flume = "0.11.0"
 gpt.workspace = true
-hex = "0.4.3"
+hex.workspace = true
 jod-thread = "0.1.2"
 libc.workspace = true
 nix = { workspace = true, default-features = false, features = ["fs"] }


### PR DESCRIPTION
* removed `from_env`, its just a wrapper around existing std library code
* removed `OrbInfoError` in favor of per-function errors. Its not necessary to have one big error type, and furthermore it complicates things since different feature flags result in some variants not being present
* Simplified some naming and removed code stuttering
*  Fixed blocking in async tests
* used Path instead of str when possible.
* removed `.value()`, because it added unecessary data hiding and also obscured potential bugs, since .borrow() does not notify the watcher that it was observed. Could result in much more frequent polling than intentional.
* Removed unnecessary dependencies and fixed a few sneaky spots where things did not have default-features = false

In general, lets be sure that we are not adding unecessary abstraction and data hiding to the code, tokio and std's apis are a known quantity and we should prefer exposing complexity instead of hiding it.