### PR TITLE
feat(wt_video): implement demo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,9 +245,9 @@ checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -1025,14 +1031,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1043,6 +1049,40 @@ dependencies = [
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1066,6 +1106,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.23.20",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.1",
+ "tower 0.4.13",
+ "tower-service",
+]
+
+[[package]]
 name = "az"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,7 +1165,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
  "object",
  "rustc-demangle",
 ]
@@ -2559,7 +2643,7 @@ dependencies = [
  "flume",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
  "rayon-core",
  "smallvec",
  "zune-inflate",
@@ -2670,7 +2754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -3180,6 +3264,12 @@ name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
+name = "httlib-huffman"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9fcbcc408c5526c3ab80d534e5c86e7967c1fb7aa0a8c76abd1edc27deb877"
 
 [[package]]
 name = "http"
@@ -4332,6 +4422,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4448,6 +4544,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b1c9bd4fe1f0f8b387f6eb9eb3b4a1aa26185e5750efb9140301703f62cd1b"
+dependencies = [
+ "adler2",
  "simd-adler32",
 ]
 
@@ -4796,6 +4901,12 @@ checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "octets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109983a091271ee8916076731ba5fdc9ee22fea871bc7c6ceab9bfd423eb1d99"
 
 [[package]]
 name = "octocrab"
@@ -5787,11 +5898,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -6043,15 +6154,15 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.17.11"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6c3c3e617595665b8ea2ff95a86066be38fb121ff920a9c0eb282abcd1da5a"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.2.1",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.4",
 ]
 
 [[package]]
@@ -6519,9 +6630,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
  "ring 0.17.7",
@@ -8382,7 +8493,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.5",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.6",
@@ -8454,6 +8565,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -9528,6 +9640,62 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wt_video"
+version = "0.0.0"
+dependencies = [
+ "axum 0.8.1",
+ "axum-server",
+ "clap",
+ "color-eyre",
+ "derive_more",
+ "orb-telemetry",
+ "png",
+ "rcgen",
+ "tokio",
+ "tokio-util",
+ "tower 0.5.2",
+ "tracing",
+ "wtransport",
+]
+
+[[package]]
+name = "wtransport"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93a724f65db90b6a1ffa92ea4966cf03cb7e2bcd3ef7135b84dfe4339640d1b9"
+dependencies = [
+ "bytes",
+ "pem",
+ "quinn",
+ "rcgen",
+ "rustls 0.23.20",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "sha2",
+ "socket2",
+ "thiserror 1.0.65",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "wtransport-proto",
+ "x509-parser",
+]
+
+[[package]]
+name = "wtransport-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e4882c24a62f15024609b3688e6e29a4c2129634d27debc849ccd3f9b9690b"
+dependencies = [
+ "httlib-huffman",
+ "octets",
+ "thiserror 1.0.65",
+ "url",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,6 +3334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4940,7 +4946,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tower 0.4.13",
- "tower-http",
+ "tower-http 0.4.4",
  "tracing",
  "url",
 ]
@@ -8580,10 +8586,35 @@ dependencies = [
  "futures-util",
  "http 0.2.11",
  "http-body 0.4.6",
- "http-range-header",
+ "http-range-header 0.3.1",
  "iri-string",
  "pin-project-lite",
  "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags 2.8.0",
+ "bytes",
+ "futures-util",
+ "http 1.2.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "http-range-header 0.4.2",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -9647,6 +9678,7 @@ version = "0.0.0"
 dependencies = [
  "axum 0.8.1",
  "axum-server",
+ "base64 0.22.1",
  "clap",
  "color-eyre",
  "derive_more",
@@ -9656,6 +9688,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower 0.5.2",
+ "tower-http 0.6.2",
  "tracing",
  "wtransport",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
   "zbus-proxies",
   "zbus-proxies/cli",
   "test-utils"
-]
+, "experiments/webtransport_video"]
 
 [workspace.package]
 edition = "2021"

--- a/experiments/webtransport_video/Cargo.toml
+++ b/experiments/webtransport_video/Cargo.toml
@@ -10,14 +10,16 @@ rust-version.workspace = true
 [dependencies]
 axum = "0.8.1"
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+base64.workspace = true
 clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
-derive_more = { workspace = true, features = ["into", "as_ref"] }
+derive_more = { workspace = true, features = ["into", "as_ref", "deref"] }
 orb-telemetry.workspace = true
 png = "0.17.16"
 rcgen = "0.13.2"
 tokio = { workspace = true, features = ["full"] }
 tokio-util.workspace = true
 tower = "0.5.2"
+tower-http = { version = "0.6.2", features = ["fs"] }
 tracing.workspace = true
 wtransport = "0.5.0"

--- a/experiments/webtransport_video/Cargo.toml
+++ b/experiments/webtransport_video/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "wt_video"
+version = "0.0.0"
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+axum = "0.8.1"
+axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
+clap = { workspace = true, features = ["derive"] }
+color-eyre.workspace = true
+derive_more = { workspace = true, features = ["into", "as_ref"] }
+orb-telemetry.workspace = true
+png = "0.17.16"
+rcgen = "0.13.2"
+tokio = { workspace = true, features = ["full"] }
+tokio-util.workspace = true
+tower = "0.5.2"
+tracing.workspace = true
+wtransport = "0.5.0"

--- a/experiments/webtransport_video/index.html
+++ b/experiments/webtransport_video/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>WebTransport Video Frames</title>
+  </head>
+  <body>
+    <h1>WebTransport Video Frames</h1>
+    <img id="videoFrame" alt="Video Frame" width="128" height="128" />
+
+    <script type="module" src="./index.js"></script>
+  </body>
+</html>

--- a/experiments/webtransport_video/index.html
+++ b/experiments/webtransport_video/index.html
@@ -6,8 +6,7 @@
   </head>
   <body>
     <h1>WebTransport Video Frames</h1>
-    <img id="videoFrame" alt="Video Frame" width="128" height="128" />
-
+    <canvas id="videoFrame" width="400" height="300"></canvas>
     <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/experiments/webtransport_video/index.html
+++ b/experiments/webtransport_video/index.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <h1>WebTransport Video Frames</h1>
-    <canvas id="videoFrame" width="400" height="300"></canvas>
+    <canvas id="videoFrame" width="640" height="480"></canvas>
     <script type="module" src="./index.js"></script>
   </body>
 </html>

--- a/experiments/webtransport_video/index.js
+++ b/experiments/webtransport_video/index.js
@@ -1,0 +1,56 @@
+// The URL must be HTTPS (or localhost) for WebTransport
+// e.g., "https://192.168.0.100:443" or the appropriate path
+const transportUrl = "https://localhost:1337";
+const HASH = new Uint8Array([
+  55, 203, 145, 244, 169, 222, 146, 152, 93, 240, 133, 47, 221, 106, 67, 189,
+  151, 7, 215, 109, 57, 85, 104, 13, 222, 239, 103, 117, 226, 30, 50, 101,
+]);
+
+console.log("running script");
+
+async function main() {
+  let transport;
+  try {
+    transport = new WebTransport(transportUrl, {
+      serverCertificateHashes: [{ algorithm: "sha-256", value: HASH.buffer }],
+    });
+    await transport.ready;
+    console.log("WebTransport connection is ready.");
+  } catch (error) {
+    console.error("Failed to create or initialize WebTransport:", error);
+    return;
+  }
+
+  // Get a reader for incoming datagrams.
+  const datagramReader = transport.datagrams.readable.getReader();
+
+  try {
+    // Continuously read from the datagram stream
+    while (true) {
+      const { value, done } = await datagramReader.read();
+      if (done) {
+        console.log("Datagram stream closed.");
+        break;
+      }
+
+      // Convert the datagram (ArrayBuffer) into a Blob.
+      // We assume each datagram is a complete JPEG image.
+      const blob = new Blob([value], { type: "image/png" });
+
+      // Create a temporary Object URL to use as the image source.
+      const imageUrl = URL.createObjectURL(blob);
+
+      // Update the <img> element to display the received frame.
+      const imgElement = document.getElementById("videoFrame");
+      imgElement.src = imageUrl;
+
+      // Optionally, revoke the old Object URL to free memory once the image is displayed.
+      // But be careful with timing (ensure the image is loaded first if you do so).
+      // URL.revokeObjectURL(previousImageUrl);
+    }
+  } catch (readError) {
+    console.error("Error while reading datagrams:", readError);
+  }
+}
+
+await main();

--- a/experiments/webtransport_video/index.js
+++ b/experiments/webtransport_video/index.js
@@ -1,18 +1,27 @@
 // The URL must be HTTPS (or localhost) for WebTransport
 // e.g., "https://192.168.0.100:443" or the appropriate path
 const transportUrl = "https://localhost:1337";
-const HASH = new Uint8Array([
-  55, 203, 145, 244, 169, 222, 146, 152, 93, 240, 133, 47, 221, 106, 67, 189,
-  151, 7, 215, 109, 57, 85, 104, 13, 222, 239, 103, 117, 226, 30, 50, 101,
-]);
 
 console.log("running script");
 
 async function main() {
+  const hash_response = await fetch("/cert_hash");
+  if (!hash_response.ok) {
+    throw new Error(`Response status: ${hash_response.status}`);
+  }
+  const hash = await hash_response.bytes();
+  console.log("hash", hash);
+
+  const https_url = new URL(window.location.origin);
+  console.log(https_url);
+  const wt_url = new URL(https_url);
+  wt_url.port = 1337;
+  console.log(wt_url);
+
   let transport;
   try {
-    transport = new WebTransport(transportUrl, {
-      serverCertificateHashes: [{ algorithm: "sha-256", value: HASH.buffer }],
+    transport = new WebTransport(wt_url, {
+      serverCertificateHashes: [{ algorithm: "sha-256", value: hash.buffer }],
     });
     await transport.ready;
     console.log("WebTransport connection is ready.");
@@ -23,6 +32,9 @@ async function main() {
 
   // Get a reader for incoming datagrams.
   const datagramReader = transport.datagrams.readable.getReader();
+
+  const canvas = document.getElementById("videoFrame");
+  const ctx = canvas.getContext("2d");
 
   try {
     // Continuously read from the datagram stream
@@ -36,17 +48,9 @@ async function main() {
       // Convert the datagram (ArrayBuffer) into a Blob.
       // We assume each datagram is a complete JPEG image.
       const blob = new Blob([value], { type: "image/png" });
-
-      // Create a temporary Object URL to use as the image source.
-      const imageUrl = URL.createObjectURL(blob);
-
-      // Update the <img> element to display the received frame.
-      const imgElement = document.getElementById("videoFrame");
-      imgElement.src = imageUrl;
-
-      // Optionally, revoke the old Object URL to free memory once the image is displayed.
-      // But be careful with timing (ensure the image is loaded first if you do so).
-      // URL.revokeObjectURL(previousImageUrl);
+      // Create an image bitmap from the blob
+      const bitmap = await createImageBitmap(blob);
+      ctx.drawImage(bitmap, 0, 0);
     }
   } catch (readError) {
     console.error("Error while reading datagrams:", readError);

--- a/experiments/webtransport_video/src/main.rs
+++ b/experiments/webtransport_video/src/main.rs
@@ -1,0 +1,86 @@
+mod networking;
+mod video;
+
+use clap::Parser;
+use color_eyre::{eyre::WrapErr as _, Result};
+use networking::run_http_server;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use wtransport::tls::Sha256DigestFmt;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    let args = Args::parse();
+
+    let cancel = CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    tokio::task::spawn(async move {
+        let _cancel_guard = cancel_clone.drop_guard();
+        tokio::signal::ctrl_c().await.expect("failed to get ctrlc");
+    });
+    let flusher = orb_telemetry::TelemetryConfig::new().init();
+    info!("starting server");
+    let result = run(args, cancel).await;
+
+    flusher.flush().await;
+    result
+}
+
+async fn run(args: Args, cancel: CancellationToken) -> Result<()> {
+    let _cancel_guard = cancel.clone().drop_guard();
+
+    let identity = wtransport::Identity::self_signed_builder()
+        .subject_alt_names(["localhost", "127.0.0.1", "::1"])
+        .from_now_utc()
+        .validity_days(7)
+        .build()
+        .unwrap();
+
+    let server_certificate_hashes = identity.certificate_chain().as_slice()[0]
+        .hash()
+        .fmt(Sha256DigestFmt::BytesArray);
+    info!("server certificate hashes: {}", server_certificate_hashes);
+
+    let video_task = crate::video::VideoTaskHandle::spawn(cancel.child_token());
+
+    let wt_fut = async {
+        let cancel = cancel.child_token();
+        cancel
+            .run_until_cancelled(crate::networking::run_wt_server(
+                args.clone(),
+                cancel.clone(),
+                identity.clone_identity(),
+                video_task.frame_rx,
+            ))
+            .await
+            .unwrap_or(Ok(()))
+    };
+
+    let http_fut = async {
+        let cancel = cancel.child_token();
+        cancel
+            .run_until_cancelled(run_http_server(
+                args.clone(),
+                cancel.clone(),
+                identity.clone_identity(),
+            ))
+            .await
+            .unwrap_or(Ok(()))
+    };
+
+    let video_task_fut =
+        async { video_task.task_handle.await.wrap_err("video task panicked") };
+    let ((), (), ()) = tokio::try_join!(wt_fut, http_fut, video_task_fut)?;
+    Ok(())
+}
+
+#[derive(Debug, Parser, Clone)]
+struct Args {
+    /// The port to use for the http server
+    #[clap(long, default_value = "8443")]
+    http_port: u16,
+    /// The port to use for the webtransport server
+    #[clap(long, default_value = "8443")]
+    wt_port: u16,
+}

--- a/experiments/webtransport_video/src/main.rs
+++ b/experiments/webtransport_video/src/main.rs
@@ -81,6 +81,6 @@ struct Args {
     #[clap(long, default_value = "8443")]
     http_port: u16,
     /// The port to use for the webtransport server
-    #[clap(long, default_value = "8443")]
+    #[clap(long, default_value = "1337")]
     wt_port: u16,
 }

--- a/experiments/webtransport_video/src/networking.rs
+++ b/experiments/webtransport_video/src/networking.rs
@@ -1,0 +1,100 @@
+///! All networking related code
+use std::{
+    net::{Ipv6Addr, SocketAddr},
+    sync::{Arc, Mutex},
+};
+
+use axum::{routing::get, Router};
+use axum_server::tls_rustls::RustlsConfig;
+use color_eyre::{eyre::WrapErr as _, Result};
+
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, instrument};
+use wtransport::{endpoint::IncomingSession, tls::Sha256DigestFmt};
+
+use crate::{
+    video::{EncodedPng, Video},
+    Args,
+};
+
+#[instrument(skip_all)]
+pub async fn run_http_server(
+    args: Args,
+    cancel: CancellationToken,
+    identity: wtransport::Identity,
+) -> Result<()> {
+    let _cancel_guard = cancel.drop_guard();
+    let app = Router::new().route("/", get(|| async { "Hello, world!" }));
+
+    let cert = identity.certificate_chain().as_slice()[0]
+        .to_pem()
+        .as_bytes()
+        .to_vec();
+    let key = identity.private_key().to_secret_pem().as_bytes().to_vec();
+    let config = RustlsConfig::from_pem(cert, key).await.unwrap();
+
+    let addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), args.http_port);
+    info!("listening on {}", addr);
+    axum_server::tls_rustls::bind_rustls(addr, config)
+        .serve(app.into_make_service())
+        .await
+        .wrap_err("error in http server")
+}
+
+#[instrument(skip_all)]
+pub async fn run_wt_server(
+    args: Args,
+    cancel: CancellationToken,
+    identity: wtransport::Identity,
+    png_rx: tokio::sync::watch::Receiver<EncodedPng>,
+) -> Result<()> {
+    let _cancel_guard = cancel.drop_guard();
+
+    let server_config = wtransport::ServerConfig::builder()
+        .with_bind_default(args.wt_port)
+        .with_identity(identity)
+        .build();
+    let server = wtransport::Endpoint::server(server_config)
+        .wrap_err("failed to bind webtransport server")?;
+
+    let mut connection_tasks = tokio::task::JoinSet::new();
+    loop {
+        let incoming_session = server.accept().await;
+        let png_rx_clone = png_rx.clone();
+        connection_tasks.spawn(async move {
+            if let Err(err) = conn_task(incoming_session, png_rx_clone).await {
+                error!(?err, "conn task failed");
+            }
+        });
+    }
+}
+
+#[instrument(skip_all, fields(remote_address = format!("{}", incoming_session.remote_address())))]
+async fn conn_task(
+    incoming_session: IncomingSession,
+    mut png_rx: tokio::sync::watch::Receiver<EncodedPng>,
+) -> Result<()> {
+    let session_request = incoming_session
+        .await
+        .wrap_err("failed to accept incoming session")?;
+    info!(
+        headers = ?session_request.headers(),
+        address = ?session_request.remote_address(),
+        user_agent = ?session_request.user_agent(),
+        "incoming session request"
+    );
+    let conn = session_request
+        .accept()
+        .await
+        .wrap_err("failed to accept incoming connection")?;
+
+    while let Ok(()) = png_rx.changed().await {
+        // We use an arc to avoid expensive frame copies.
+        let png = png_rx.borrow_and_update().clone();
+        conn.send_datagram(png.clone_cheap())
+            .wrap_err("failed to send dgram")?;
+    }
+    // Channel cloded, shut down task.
+
+    Ok(())
+}

--- a/experiments/webtransport_video/src/video.rs
+++ b/experiments/webtransport_video/src/video.rs
@@ -1,0 +1,176 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use color_eyre::{eyre::WrapErr as _, Result};
+use derive_more::{AsRef, Into};
+use tokio_util::sync::CancellationToken;
+use tracing::trace;
+
+const WIDTH: usize = 640;
+const HEIGHT: usize = 480;
+const COLOR_TYPE: png::ColorType = png::ColorType::Rgb;
+
+static EMPTY_BUF: &[u8] = &[0; WIDTH * HEIGHT * 3]; // Couldn't use a const :(
+
+pub struct VideoTaskHandle {
+    pub frame_rx: tokio::sync::watch::Receiver<EncodedPng>,
+    pub task_handle: tokio::task::JoinHandle<()>,
+}
+
+impl VideoTaskHandle {
+    pub fn spawn(cancel: CancellationToken) -> Self {
+        let video = Video::new();
+        let initial_empty_frame = {
+            let mut frame = Vec::with_capacity(1024);
+            Video::empty_frame(&mut frame);
+            EncodedPng(Arc::new(frame)).into()
+        };
+
+        let (tx, rx) = tokio::sync::watch::channel(initial_empty_frame);
+        let task_handle =
+            tokio::task::spawn_blocking(move || video_task(tx, cancel, video));
+
+        Self {
+            frame_rx: rx,
+            task_handle,
+        }
+    }
+}
+
+fn video_task(
+    tx: tokio::sync::watch::Sender<EncodedPng>,
+    cancel: CancellationToken,
+    mut video: Video,
+) {
+    let _cancel_guard = cancel.clone().drop_guard();
+
+    // Holds arcs swapped out of the tokio channel. Popped only when strong count
+    // indicates no further references by network tasks.
+    let mut arc_pool: VecDeque<EncodedPng> = VecDeque::with_capacity(4);
+    // Holds arcs that were promoted to vecs after checking their count.
+    let mut vec_pool: Vec<Vec<u8>> = vec![Vec::with_capacity(1024)];
+
+    while !cancel.is_cancelled() {
+        // We bound the maximum number of arcs to scan, to avoid this task slowing
+        // down too much due to too many outstanding connections holding on to arcs.
+        const N_ARC_TO_SCAN: usize = 256;
+        let n_arcs_before_pop = arc_pool.len();
+        pop_arcs(N_ARC_TO_SCAN, &mut arc_pool, &mut vec_pool);
+        trace!("reaped {} arcs", n_arcs_before_pop - arc_pool.len());
+        let mut png_buf: Vec<u8> =
+            vec_pool.pop().unwrap_or_else(|| Vec::with_capacity(1024));
+
+        png_buf.clear();
+        video
+            .next_png(png_buf.as_mut())
+            .expect("error while producing video");
+        let encoded = EncodedPng(Arc::new(png_buf));
+
+        // This could block if anyone is borrowing the channel, so be sure we dont for
+        // long.
+        let swapped = tx.send_replace(encoded);
+        arc_pool.push_back(swapped);
+    }
+}
+
+/// Pops at most `max_num_to_pop` arcs, if their strong counts are low enough.
+/// Places the popped inner values in `out`, calling `popped.into()` in the process.
+fn pop_arcs<T, U>(max_num_to_pop: usize, arcs: &mut VecDeque<T>, out: &mut Vec<U>)
+where
+    T: Into<Arc<U>> + AsRef<Arc<U>>,
+{
+    for _ in 0..max_num_to_pop {
+        let Some(candidate) = arcs.pop_front() else {
+            return;
+        };
+        if Arc::strong_count(candidate.as_ref()) != 1 {
+            // there are other references, return to queue.
+            arcs.push_back(candidate);
+            continue;
+        }
+        // No other references, move to `out`.
+        let inner = Arc::into_inner(candidate.into())
+            .expect("we just checked the reference count, should be infallible");
+        out.push(inner);
+    }
+}
+
+/// Newtype on a vec, to indicate that this contains a png-encoded image.
+#[derive(Debug, Into, AsRef, Clone)]
+pub struct EncodedPng(pub Arc<Vec<u8>>);
+
+impl EncodedPng {
+    /// Equivalent to [`Self::clone`] but is more explicit that this operation is cheap.
+    pub fn clone_cheap(&self) -> Self {
+        EncodedPng(Arc::clone(&self.0))
+    }
+}
+
+impl AsRef<[u8]> for EncodedPng {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+/// Generates a video feed.
+pub struct Video {
+    frame_buffer: Vec<u8>,
+}
+
+impl Video {
+    pub fn new() -> Self {
+        let frame_buffer = vec![0u8; WIDTH * HEIGHT * COLOR_TYPE.samples()];
+        Self { frame_buffer }
+    }
+
+    /// Renders an emtpy frame and encodes it as a png, placing it in `png_out`.
+    /// Using an out-param allows for 1 fewer copy.
+    pub fn empty_frame(png: &mut Vec<u8>) {
+        png.clear();
+        encode_frame(png, EMPTY_BUF).expect("empty frame should always encode");
+    }
+
+    /// Renders the next frame and encodes it as a png, placing it in `png_out`.
+    /// Using an out-param allows for 1 fewer copy.
+    pub fn next_png(&mut self, png_out: &mut Vec<u8>) -> Result<()> {
+        png_out.clear();
+        draw_image(&mut self.frame_buffer);
+        encode_frame(png_out, &self.frame_buffer).wrap_err("failed to encode png")
+    }
+}
+
+fn encode_frame(png_buffer: &mut Vec<u8>, raw_frame: &[u8]) -> Result<()> {
+    let mut encoder = png::Encoder::new(
+        png_buffer,
+        WIDTH.try_into().unwrap(),
+        HEIGHT.try_into().unwrap(),
+    );
+    assert_eq!(raw_frame.len(), WIDTH * HEIGHT * COLOR_TYPE.samples());
+    encoder.set_depth(png::BitDepth::Eight);
+    encoder.set_color(png::ColorType::Rgb);
+    encoder.set_compression(png::Compression::Fast);
+    let mut encoder = encoder
+        .write_header()
+        .wrap_err("failed to write png header")?;
+    encoder
+        .write_image_data(raw_frame)
+        .wrap_err("failed to write png data")?;
+    Ok(())
+}
+
+/// Fills the buffer with a simple pattern
+fn draw_image(raw_frame: &mut [u8]) {
+    for y in 0..HEIGHT {
+        for x in 0..WIDTH {
+            let idx = (y * WIDTH + x) * COLOR_TYPE.samples();
+
+            // Create a gradient pattern
+            let r = (x as f32 / WIDTH as f32 * 255.0) as u8;
+            let g = (y as f32 / HEIGHT as f32 * 255.0) as u8;
+            let b = 0;
+
+            raw_frame[idx] = r;
+            raw_frame[idx + 1] = g;
+            raw_frame[idx + 2] = b;
+        }
+    }
+}

--- a/experiments/webtransport_video/src/video.rs
+++ b/experiments/webtransport_video/src/video.rs
@@ -5,8 +5,8 @@ use derive_more::{AsRef, Deref, Into};
 use tokio_util::sync::CancellationToken;
 use tracing::trace;
 
-const WIDTH: usize = 16;
-const HEIGHT: usize = 16;
+const WIDTH: usize = 1920;
+const HEIGHT: usize = 1080;
 const COLOR_TYPE: png::ColorType = png::ColorType::Rgb;
 
 static EMPTY_BUF: &[u8] = &[0; WIDTH * HEIGHT * 3]; // Couldn't use a const :(
@@ -22,7 +22,7 @@ impl VideoTaskHandle {
         let initial_empty_frame = {
             let mut frame = Vec::with_capacity(1024);
             Video::empty_frame(&mut frame);
-            EncodedPng(Arc::new(frame)).into()
+            EncodedPng(Arc::new(frame))
         };
 
         let (tx, rx) = tokio::sync::watch::channel(initial_empty_frame);
@@ -136,7 +136,7 @@ impl Video {
     /// Renders the next frame and encodes it as a png, placing it in `png_out`.
     /// Using an out-param allows for 1 fewer copy.
     pub fn next_png(&mut self, png_out: &mut Vec<u8>) -> Result<()> {
-        self.i = self.i + Wrapping(1);
+        self.i += Wrapping(1);
         png_out.clear();
         draw_image(&mut self.frame_buffer, self.i.0);
         encode_frame(png_out, &self.frame_buffer).wrap_err("failed to encode png")


### PR DESCRIPTION
This demos using webtransport to perform video streaming from the "orb" to the browser. It also demonstrates some ideas I had for efficient pools of frame buffers, as well as experiments with png encoding.

I think ultimately instead of png encoding, we should use an actual video codec + use the browser [WebCodecs](https://developer.mozilla.org/en-US/docs/Web/API/WebCodecs_API) api, instead of doing the jank png encoding. But even so, this works!