### PR TITLE
chore: SEC-1406: Add .dockerignore

### DIFF
--- a/cellcom/.dockerignore
+++ b/cellcom/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore

--- a/test-utils/.dockerignore
+++ b/test-utils/.dockerignore
@@ -1,0 +1,2 @@
+.git
+.gitignore


### PR DESCRIPTION
Ensure .git and .gitignore are properly ignored
Prevent sensitive files from being included in Docker builds
