### PR TITLE
feat(ui): white during idle / user scanning (self-serve) 

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,7 @@ ignore = [
   { id = "RUSTSEC-2023-0071", reason = "No patch available yet, we also dont plan to use rsa keys" },
   { id = "RUSTSEC-2024-0429", reason = "We need to update gstreamer in orb-core first"  },
   { id = "RUSTSEC-2024-0436", reason = "paste - no longer maintained"  },
+  { id = "RUSTSEC-2025-0014", reason = "humantime is used cross many crates" }
 ]
 
 [sources]

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -99,7 +99,7 @@ impl Argb {
     pub const PEARL_RING_WIFI_QR_SCAN: Argb = Argb(None, 0, 5, 20);
     pub const PEARL_RING_WIFI_QR_SCAN_SPINNER: Argb = Argb(None, 15, 15, 15);
     /// Outer-ring color during user QR scans
-    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 30, 20, 0);
+    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 40, 40, 40);
     pub const PEARL_RING_USER_QR_SCAN_SPINNER: Argb = Argb(None, 28, 25, 10);
     /// Shroud color to invite user to scan / reposition in front of the orb
     pub const PEARL_CENTER_SUMMON_USER_AMBER: Argb = Argb(None, 30, 20, 0);
@@ -128,12 +128,11 @@ impl Argb {
 
     /// Outer-ring color during operator QR scans
     pub const DIAMOND_RING_OPERATOR_QR_SCAN: Argb = Argb(Some(5), 77, 14, 0);
-    pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER: Argb = Argb(Some(10), 80, 50, 30);
+    pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER: Argb = Argb(Some(10), 100, 88, 70);
     pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER_OPERATOR_BASED: Argb =
         Argb(Some(10), 100, 88, 20);
     /// Outer-ring color during user QR scans
-    pub const DIAMOND_RING_USER_QR_SCAN: Argb = Argb(Some(5), 120, 80, 4);
-    pub const DIAMOND_RING_USER_QR_SCAN_SPINNER: Argb = Argb(Some(10), 100, 90, 35);
+    pub const DIAMOND_RING_USER_QR_SCAN: Argb = Argb(Some(10), 70, 90, 70);
     /// Shroud color to invite user to scan / reposition in front of the orb and capture
     pub const DIAMOND_CENTER_SUMMON_USER_AMBER: Argb = Argb(Some(3), 95, 40, 3);
     /// Outer-ring color during user scan/capture (in progress)

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -104,11 +104,11 @@ impl Argb {
     pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 30, 30, 30);
     pub const PEARL_RING_USER_QR_SCAN_SPINNER: Argb = Argb(None, 28, 25, 10);
     /// Shroud color to invite user to scan / reposition in front of the orb
-    pub const PEARL_CENTER_SUMMON_USER_AMBER: Argb = Argb(None, 30, 20, 0);
+    pub const PEARL_CENTER_SUMMON_USER_AMBER: Argb = Argb(None, 30, 30, 30);
     /// Shroud color during user scan/capture (in progress)
     pub const PEARL_CENTER_USER_CAPTURE: Argb = Argb(None, 30, 20, 0);
     /// Outer-ring color during user scan/capture (in progress)
-    pub const PEARL_RING_USER_CAPTURE: Argb = Argb(None, 30, 20, 0);
+    pub const PEARL_RING_USER_CAPTURE: Argb = Argb(None, 30, 30, 30);
     /// Error color for outer ring
     pub const PEARL_RING_ERROR_SALMON: Argb = Argb(None, 24, 4, 0);
 

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -75,7 +75,7 @@ impl Argb {
     pub const OFF: Argb = Argb(Some(0), 0, 0, 0);
     pub const OPERATOR_DEV: Argb = { Argb(Some(Self::DIMMING_MAX_VALUE), 0, 20, 0) };
 
-    pub const PEARL_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(None, 1, 1, 1);
+    pub const PEARL_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(None, 6, 6, 6);
 
     pub const PEARL_OPERATOR_AMBER: Argb = Argb(None, 20, 16, 0);
     pub const PEARL_OPERATOR_DEFAULT: Argb = { Argb(None, 20, 20, 20) };
@@ -93,12 +93,12 @@ impl Argb {
     /// whiter once wave is over, but darker during the wave.
     ///
     /// Outer-ring color during operator QR scans
-    pub const PEARL_RING_OPERATOR_QR_SCAN: Argb = Argb(None, 30, 30, 30);
+    pub const PEARL_RING_OPERATOR_QR_SCAN: Argb = Argb(None, 25, 25, 25);
     /// Outer-ring color during wifi QR scans
     pub const PEARL_RING_WIFI_QR_SCAN: Argb = Argb(None, 0, 5, 20);
     pub const PEARL_RING_WIFI_QR_SCAN_SPINNER: Argb = Argb(None, 15, 15, 15);
     /// Outer-ring color during user QR scans
-    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 30, 30, 30);
+    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 25, 25, 25);
     pub const PEARL_RING_USER_QR_SCAN_SPINNER: Argb = Argb(None, 28, 25, 10);
     /// Shroud color to invite user to scan / reposition in front of the orb
     pub const PEARL_CENTER_SUMMON_USER_AMBER: Argb = Argb(None, 30, 30, 30);

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -93,10 +93,7 @@ impl Argb {
     /// whiter once wave is over, but darker during the wave.
     ///
     /// Outer-ring color during operator QR scans
-    pub const PEARL_RING_OPERATOR_QR_SCAN: Argb = Argb(None, 20, 6, 0);
-    pub const PEARL_RING_OPERATOR_QR_SCAN_SPINNER: Argb = Argb(None, 25, 15, 9);
-    pub const PEARL_RING_OPERATOR_QR_SCAN_SPINNER_OPERATOR_BASED: Argb =
-        Argb(None, 25, 22, 5);
+    pub const PEARL_RING_OPERATOR_QR_SCAN: Argb = Argb(None, 30, 30, 30);
     /// Outer-ring color during wifi QR scans
     pub const PEARL_RING_WIFI_QR_SCAN: Argb = Argb(None, 0, 5, 20);
     pub const PEARL_RING_WIFI_QR_SCAN_SPINNER: Argb = Argb(None, 15, 15, 15);

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -135,7 +135,7 @@ impl Argb {
         Argb(Some(10), 100, 88, 20);
     pub const DIAMOND_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(Some(1), 1, 1, 1);
     /// Outer-ring color during user QR scans
-    pub const DIAMOND_RING_USER_QR_SCAN: Argb = Argb(Some(10), 70, 90, 70);
+    pub const DIAMOND_RING_USER_QR_SCAN: Argb = Argb(Some(10), 60, 80, 60);
     /// Shroud color to invite user to scan / reposition in front of the orb and capture
     pub const DIAMOND_CENTER_SUMMON_USER_AMBER: Argb = Argb(Some(3), 95, 40, 3);
     /// Outer-ring color during user scan/capture (in progress)

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -75,7 +75,7 @@ impl Argb {
     pub const OFF: Argb = Argb(Some(0), 0, 0, 0);
     pub const OPERATOR_DEV: Argb = { Argb(Some(Self::DIMMING_MAX_VALUE), 0, 20, 0) };
 
-    pub const PEARL_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(None, 6, 6, 6);
+    pub const PEARL_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(None, 4, 4, 4);
 
     pub const PEARL_OPERATOR_AMBER: Argb = Argb(None, 20, 16, 0);
     pub const PEARL_OPERATOR_DEFAULT: Argb = { Argb(None, 20, 20, 20) };
@@ -93,12 +93,12 @@ impl Argb {
     /// whiter once wave is over, but darker during the wave.
     ///
     /// Outer-ring color during operator QR scans
-    pub const PEARL_RING_OPERATOR_QR_SCAN: Argb = Argb(None, 25, 25, 25);
+    pub const PEARL_RING_OPERATOR_QR_SCAN: Argb = Argb(None, 27, 27, 27);
     /// Outer-ring color during wifi QR scans
     pub const PEARL_RING_WIFI_QR_SCAN: Argb = Argb(None, 0, 5, 20);
     pub const PEARL_RING_WIFI_QR_SCAN_SPINNER: Argb = Argb(None, 15, 15, 15);
     /// Outer-ring color during user QR scans
-    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 25, 25, 25);
+    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 27, 27, 27);
     pub const PEARL_RING_USER_QR_SCAN_SPINNER: Argb = Argb(None, 28, 25, 10);
     /// Shroud color to invite user to scan / reposition in front of the orb
     pub const PEARL_CENTER_SUMMON_USER_AMBER: Argb = Argb(None, 30, 30, 30);
@@ -142,7 +142,7 @@ impl Argb {
     pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(4), 127, 20, 0);
 
     pub const FULL_RED: Argb = Argb(None, 255, 0, 0);
-    pub const FULL_GREEN: Argb = Argb(None, 0, 255, 0);
+    pub const FULL_GREEN: Argb = Argb(None, 0, 81, 0);
     pub const FULL_BLUE: Argb = Argb(None, 0, 0, 255);
     pub const FULL_WHITE: Argb = Argb(None, 255, 255, 255);
     pub const FULL_BLACK: Argb = Argb(None, 0, 0, 0);

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -75,6 +75,8 @@ impl Argb {
     pub const OFF: Argb = Argb(Some(0), 0, 0, 0);
     pub const OPERATOR_DEV: Argb = { Argb(Some(Self::DIMMING_MAX_VALUE), 0, 20, 0) };
 
+    pub const PEARL_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(None, 1, 1, 1);
+
     pub const PEARL_OPERATOR_AMBER: Argb = Argb(None, 20, 16, 0);
     pub const PEARL_OPERATOR_DEFAULT: Argb = { Argb(None, 20, 20, 20) };
     pub const PEARL_OPERATOR_VERSIONS_DEPRECATED: Argb = Argb(None, 128, 128, 0);
@@ -99,7 +101,7 @@ impl Argb {
     pub const PEARL_RING_WIFI_QR_SCAN: Argb = Argb(None, 0, 5, 20);
     pub const PEARL_RING_WIFI_QR_SCAN_SPINNER: Argb = Argb(None, 15, 15, 15);
     /// Outer-ring color during user QR scans
-    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 40, 40, 40);
+    pub const PEARL_RING_USER_QR_SCAN: Argb = Argb(None, 30, 30, 30);
     pub const PEARL_RING_USER_QR_SCAN_SPINNER: Argb = Argb(None, 28, 25, 10);
     /// Shroud color to invite user to scan / reposition in front of the orb
     pub const PEARL_CENTER_SUMMON_USER_AMBER: Argb = Argb(None, 30, 20, 0);
@@ -131,6 +133,7 @@ impl Argb {
     pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER: Argb = Argb(Some(10), 100, 88, 70);
     pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER_OPERATOR_BASED: Argb =
         Argb(Some(10), 100, 88, 20);
+    pub const DIAMOND_WAVE_MIN_COLOR_INTENSITY: Argb = Argb(Some(1), 1, 1, 1);
     /// Outer-ring color during user QR scans
     pub const DIAMOND_RING_USER_QR_SCAN: Argb = Argb(Some(10), 70, 90, 70);
     /// Shroud color to invite user to scan / reposition in front of the orb and capture

--- a/ui/src/engine/animations/simple_spinner.rs
+++ b/ui/src/engine/animations/simple_spinner.rs
@@ -1,4 +1,4 @@
-use crate::engine::animations::Static;
+use crate::engine::animations::{Static, Wave};
 use crate::engine::{
     Animation, AnimationState, RingFrame, Transition, TransitionStatus,
     PEARL_RING_LED_COUNT,
@@ -40,6 +40,7 @@ impl<const N: usize> SimpleSpinner<N> {
     }
 
     /// Set the speed of the spinner in radians per second.
+    #[expect(dead_code)]
     pub fn speed(self, speed: f64) -> Self {
         Self { speed, ..self }
     }
@@ -206,8 +207,13 @@ impl<const N: usize> Animation for SimpleSpinner<N> {
             self.transition_time = 0.0;
             TransitionStatus::Smooth
         } else if let Some(static_animation) = superseded.downcast_ref::<Static<N>>() {
-            self.phase = PI / 2.0; // start animation at 12 o'clock
+            self.phase = PI / 2.0; // start with spinner at 12 o'clock
             self.transition_background = Some(static_animation.color());
+            self.transition_time = 0.0;
+            TransitionStatus::Smooth
+        } else if let Some(wave_animation) = superseded.downcast_ref::<Wave<N>>() {
+            self.phase = PI / 2.0; // start with spinner at 12 o'clock
+            self.transition_background = Some(wave_animation.color());
             self.transition_time = 0.0;
             TransitionStatus::Smooth
         } else {

--- a/ui/src/engine/animations/wave.rs
+++ b/ui/src/engine/animations/wave.rs
@@ -194,7 +194,7 @@ impl<const N: usize> Animation for Wave<N> {
                     // pearl's ring or diamond
 
                     // clamp color intensity to self.min_color_intensity
-                    color = color * intensity;
+                    color *= intensity;
                     if let Some(min_color_intensity) = self.min_color_intensity {
                         color.1 = color.1.max(min_color_intensity.1);
                         color.2 = color.2.max(min_color_intensity.2);

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -263,6 +263,7 @@ impl Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 3.0,
                 0.0,
                 true,
+                None,
             )
             .with_delay(alert_duration),
         );
@@ -415,14 +416,11 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.operator_signup_phase.user_qr_code_ok();
                         self.set_ring(
                             LEVEL_FOREGROUND,
-                            animations::Wave::<DIAMOND_RING_LED_COUNT>::new(
+                            animations::Static::new(
                                 Argb::DIAMOND_RING_USER_QR_SCAN,
-                                4.0,
-                                0.0,
-                                false,
-                                Some(Argb::DIAMOND_WAVE_MIN_COLOR_INTENSITY),
+                                None,
                             )
-                            .fade_in(2.0),
+                            .fade_in(1.5),
                         );
                     }
                 };
@@ -441,17 +439,18 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     animations::Static::<DIAMOND_RING_LED_COUNT>::new(Argb::OFF, None),
                 );
 
-                // use previous background color to blink
-                let bg_color = if let Some(wave) = self
+                // use previous color to blink
+                let color = if let Some(static_animation) = self
                     .ring_animations_stack
                     .stack
                     .get_mut(&LEVEL_FOREGROUND)
                     .and_then(|RunningAnimation { animation, .. }| {
                         animation
                             .as_any_mut()
-                            .downcast_mut::<animations::Wave<DIAMOND_RING_LED_COUNT>>()
+                            .downcast_mut::<animations::Static<DIAMOND_RING_LED_COUNT>>(
+                            )
                     }) {
-                    wave.color()
+                    static_animation.color()
                 } else {
                     Argb::OFF
                 };
@@ -459,7 +458,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.set_ring(
                     LEVEL_NOTICE,
                     animations::Alert::<DIAMOND_RING_LED_COUNT>::new(
-                        bg_color,
+                        color,
                         BlinkDurations::from(vec![0.0, 0.4, 0.2, 0.4]),
                         Some(vec![0.2, 0.2, 0.01]),
                         true,
@@ -539,14 +538,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.operator_signup_phase.user_qr_captured();
                     self.set_ring(
                         LEVEL_FOREGROUND,
-                        animations::Wave::<DIAMOND_RING_LED_COUNT>::new(
-                            Argb::DIAMOND_RING_USER_QR_SCAN * 0.5, // dimmed
-                            6.0,
-                            0.0,
-                            false,
-                            Some(Argb::DIAMOND_WAVE_MIN_COLOR_INTENSITY),
-                        )
-                        .fade_in(1.5),
+                        animations::Static::new(Argb::DIAMOND_RING_USER_QR_SCAN, None),
                     );
                 }
                 QrScanSchema::Wifi => {

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -7,7 +7,6 @@ use orb_messages::main::{jetson_to_mcu, JetsonToMcu};
 use orb_messages::mcu_message::Message;
 use orb_rgb::Argb;
 use pid::{InstantTimer, Timer};
-use std::f64::consts::PI;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time;
@@ -416,11 +415,13 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.operator_signup_phase.user_qr_code_ok();
                         self.set_ring(
                             LEVEL_FOREGROUND,
-                            animations::SimpleSpinner::new(
-                                Argb::DIAMOND_RING_USER_QR_SCAN_SPINNER,
-                                Some(Argb::DIAMOND_RING_USER_QR_SCAN),
+                            animations::Wave::<DIAMOND_RING_LED_COUNT>::new(
+                                Argb::DIAMOND_RING_USER_QR_SCAN,
+                                4.0,
+                                0.0,
+                                false,
                             )
-                            .fade_in(1.5),
+                            .fade_in(2.0),
                         );
                     }
                 };
@@ -440,16 +441,16 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 );
 
                 // use previous background color to blink
-                let bg_color = if let Some(spinner) = self
+                let bg_color = if let Some(wave) = self
                     .ring_animations_stack
                     .stack
                     .get_mut(&LEVEL_FOREGROUND)
                     .and_then(|RunningAnimation { animation, .. }| {
                         animation
                             .as_any_mut()
-                            .downcast_mut::<animations::SimpleSpinner<DIAMOND_RING_LED_COUNT>>()
+                            .downcast_mut::<animations::Wave<DIAMOND_RING_LED_COUNT>>()
                     }) {
-                    spinner.background()
+                    wave.color()
                 } else {
                     Argb::OFF
                 };
@@ -537,11 +538,13 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     self.operator_signup_phase.user_qr_captured();
                     self.set_ring(
                         LEVEL_FOREGROUND,
-                        animations::SimpleSpinner::new(
-                            Argb::DIAMOND_RING_USER_QR_SCAN_SPINNER,
-                            Some(Argb::DIAMOND_RING_USER_QR_SCAN),
+                        animations::Wave::<DIAMOND_RING_LED_COUNT>::new(
+                            Argb::DIAMOND_RING_USER_QR_SCAN * 0.5, // dimmed
+                            6.0,
+                            0.0,
+                            false,
                         )
-                        .speed(2.0 * PI / 7.0), // 7 seconds per turn
+                        .fade_in(1.5),
                     );
                 }
                 QrScanSchema::Wifi => {

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -420,6 +420,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                                 4.0,
                                 0.0,
                                 false,
+                                Some(Argb::DIAMOND_WAVE_MIN_COLOR_INTENSITY),
                             )
                             .fade_in(2.0),
                         );
@@ -543,6 +544,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                             6.0,
                             0.0,
                             false,
+                            Some(Argb::DIAMOND_WAVE_MIN_COLOR_INTENSITY),
                         )
                         .fade_in(1.5),
                     );
@@ -611,6 +613,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         3.0,
                         0.0,
                         true,
+                        None,
                     )
                     .with_delay(1.5),
                 );
@@ -879,6 +882,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         3.0,
                         0.0,
                         true,
+                        None,
                     ),
                 );
                 self.set_ring(

--- a/ui/src/engine/pearl/operator_based.rs
+++ b/ui/src/engine/pearl/operator_based.rs
@@ -107,6 +107,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         5.0,
                         0.5,
                         true,
+                        None,
                     ),
                 );
 

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -638,32 +638,19 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             animations::Static::<PEARL_CENTER_LED_COUNT>::new(Argb::OFF, None),
         );
         self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
-        let success_alert_blinks =
-            vec![0.0, fade_out_duration, 0.5, 0.75, 0.5, 1.5, 0.5, 3.0, 0.2];
-        let alert_duration = success_alert_blinks.iter().sum::<f64>();
+        let success_alert_blinks = vec![0.0, fade_out_duration, 0.5, 0.75];
         self.set_ring(
             LEVEL_NOTICE,
             animations::Alert::<PEARL_RING_LED_COUNT>::new(
-                Argb::FULL_GREEN,
-                BlinkDurations::from(success_alert_blinks),
-                Some(vec![0.1, 0.4, 0.4, 0.2, 0.75, 0.2, 0.2, 1.0]),
-                false,
-            )?,
-        );
-        self.set_ring(
-            LEVEL_FOREGROUND,
-            animations::Wave::<PEARL_RING_LED_COUNT>::new(
                 if use_green {
                     Argb::FULL_GREEN
                 } else {
                     Argb::PEARL_RING_USER_CAPTURE
                 },
-                3.0,
-                0.0,
-                true,
-                Some(Argb(None, 3, 2, 1)),
-            )
-            .with_delay(alert_duration),
+                BlinkDurations::from(success_alert_blinks),
+                Some(vec![0.1, 0.4, 0.4]),
+                false,
+            )?,
         );
         self.operator_signup_phase.iris_scan_complete();
         Ok(())

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -247,10 +247,6 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     self.operator_signup_phase.operator_qr_captured();
                 }
                 QrScanSchema::User => {
-                    self.sound.queue(
-                        sound::Type::Melody(sound::Melody::UserQrLoadSuccess),
-                        Duration::ZERO,
-                    )?;
                     self.operator_signup_phase.user_qr_captured();
                     self.set_ring(
                         LEVEL_FOREGROUND,

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -142,11 +142,12 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                             LEVEL_FOREGROUND,
                             animations::Wave::<PEARL_RING_LED_COUNT>::new(
                                 Argb::PEARL_RING_USER_QR_SCAN,
-                                4.0,
+                                8.0,
                                 0.0,
                                 false,
+                                Some(Argb::PEARL_WAVE_MIN_COLOR_INTENSITY),
                             )
-                                .fade_in(2.0),
+                            .fade_in(2.0),
                         );
                     }
                 };
@@ -173,9 +174,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     .and_then(|RunningAnimation { animation, .. }| {
                         animation
                             .as_any_mut()
-                            .downcast_mut::<animations::Wave<
-                                PEARL_RING_LED_COUNT,
-                            >>()
+                            .downcast_mut::<animations::Wave<PEARL_RING_LED_COUNT>>()
                     }) {
                     wave.color()
                 } else {
@@ -266,12 +265,13 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     self.set_ring(
                         LEVEL_FOREGROUND,
                         animations::Wave::<PEARL_RING_LED_COUNT>::new(
-                            Argb::PEARL_RING_USER_QR_SCAN * 0.5, // dimmed
-                            6.0,
+                            Argb::PEARL_RING_USER_QR_SCAN,
+                            4.0,
                             0.0,
                             false,
+                            Some(Argb::PEARL_WAVE_MIN_COLOR_INTENSITY),
                         )
-                            .fade_in(1.5),
+                        .fade_in(1.5),
                     );
                 }
                 QrScanSchema::Wifi => {
@@ -336,6 +336,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         3.0,
                         0.0,
                         false,
+                        Some(Argb(None, 3, 2, 1)),
                     ),
                 );
             }
@@ -674,6 +675,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 3.0,
                 0.0,
                 true,
+                Some(Argb(None, 3, 2, 1)),
             )
             .with_delay(alert_duration),
         );

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -8,7 +8,6 @@ use crate::sound::Player;
 use animations::alert::BlinkDurations;
 use eyre::Result;
 use orb_rgb::Argb;
-use std::f64::consts::PI;
 use std::time::Duration;
 
 impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
@@ -141,11 +140,13 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         self.operator_signup_phase.user_qr_code_ok();
                         self.set_ring(
                             LEVEL_FOREGROUND,
-                            animations::SimpleSpinner::new(
-                                Argb::PEARL_RING_USER_QR_SCAN_SPINNER,
-                                Some(Argb::PEARL_RING_USER_QR_SCAN),
+                            animations::Wave::<PEARL_RING_LED_COUNT>::new(
+                                Argb::PEARL_RING_USER_QR_SCAN,
+                                4.0,
+                                0.0,
+                                false,
                             )
-                            .fade_in(1.5),
+                                .fade_in(2.0),
                         );
                     }
                 };
@@ -165,18 +166,18 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 );
 
                 // use previous background color to blink
-                let bg_color = if let Some(spinner) = self
+                let bg_color = if let Some(wave) = self
                     .ring_animations_stack
                     .stack
                     .get_mut(&LEVEL_FOREGROUND)
                     .and_then(|RunningAnimation { animation, .. }| {
                         animation
                             .as_any_mut()
-                            .downcast_mut::<animations::SimpleSpinner<
+                            .downcast_mut::<animations::Wave<
                                 PEARL_RING_LED_COUNT,
                             >>()
                     }) {
-                    spinner.background()
+                    wave.color()
                 } else {
                     Argb::OFF
                 };
@@ -264,11 +265,13 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     self.operator_signup_phase.user_qr_captured();
                     self.set_ring(
                         LEVEL_FOREGROUND,
-                        animations::SimpleSpinner::new(
-                            Argb::PEARL_RING_USER_QR_SCAN_SPINNER,
-                            Some(Argb::PEARL_RING_USER_QR_SCAN),
+                        animations::Wave::<PEARL_RING_LED_COUNT>::new(
+                            Argb::PEARL_RING_USER_QR_SCAN * 0.5, // dimmed
+                            6.0,
+                            0.0,
+                            false,
                         )
-                        .speed(2.0 * PI / 7.0), // 7 seconds per turn
+                            .fade_in(1.5),
                     );
                 }
                 QrScanSchema::Wifi => {

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -336,7 +336,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         3.0,
                         0.0,
                         false,
-                        Some(Argb(None, 3, 2, 1)),
+                        Some(Argb::PEARL_WAVE_MIN_COLOR_INTENSITY),
                     ),
                 );
             }

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -93,27 +93,17 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
             Event::QrScanStart { schema } => {
                 self.stop_center(LEVEL_FOREGROUND, Transition::ForceStop);
                 match schema {
-                    QrScanSchema::OperatorSelfServe => {
+                    QrScanSchema::OperatorSelfServe | QrScanSchema::Operator => {
                         self.operator_signup_phase.signup_phase_started();
                         self.set_ring(
                             LEVEL_FOREGROUND,
-                            animations::SimpleSpinner::new(
-                                Argb::PEARL_RING_OPERATOR_QR_SCAN_SPINNER,
-                                Some(Argb::PEARL_RING_OPERATOR_QR_SCAN),
-                            )
-                            .fade_in(1.5),
-                        );
-                        self.operator_signup_phase.operator_qr_code_ok();
-                    }
-                    QrScanSchema::Operator => {
-                        self.operator_signup_phase.signup_phase_started();
-                        self.set_ring(
-                            LEVEL_FOREGROUND,
-                            animations::SimpleSpinner::new(
-                                Argb::PEARL_RING_OPERATOR_QR_SCAN_SPINNER_OPERATOR_BASED,
-                                Some(Argb::OFF),
-                            )
-                                .fade_in(1.5),
+                            animations::Wave::<PEARL_RING_LED_COUNT>::new(
+                                Argb::PEARL_RING_OPERATOR_QR_SCAN,
+                                8.0,
+                                0.0,
+                                true,
+                                Some(Argb::PEARL_WAVE_MIN_COLOR_INTENSITY),
+                            ),
                         );
                         self.operator_signup_phase.operator_qr_code_ok();
                     }

--- a/ui/src/simulation.rs
+++ b/ui/src/simulation.rs
@@ -64,7 +64,7 @@ pub async fn signup_simulation(
     ui.good_internet();
     ui.good_wlan();
     ui.idle();
-    if hardware == Hardware::Diamond && self_serve || showcar {
+    if self_serve || showcar {
         // idle state is waiting for user QR code
         ui.qr_scan_start(QrScanSchema::User);
     }
@@ -83,28 +83,28 @@ pub async fn signup_simulation(
 
     loop {
         if !showcar {
-            if self_serve {
-                // scanning operator QR code
-                ui.qr_scan_start(QrScanSchema::OperatorSelfServe);
-                time::sleep(Duration::from_secs(10)).await;
-                ui.qr_scan_capture();
-                time::sleep(Duration::from_secs(2)).await;
-                ui.qr_scan_completed(QrScanSchema::OperatorSelfServe);
-                ui.qr_scan_success(QrScanSchema::OperatorSelfServe);
-            } else {
-                // scanning operator QR code
-                ui.qr_scan_start(QrScanSchema::Operator);
-                time::sleep(Duration::from_secs(10)).await;
-                ui.qr_scan_capture();
-                time::sleep(Duration::from_secs(2)).await;
-                ui.qr_scan_completed(QrScanSchema::Operator);
-                ui.qr_scan_success(QrScanSchema::Operator);
-            }
+            // if self_serve {
+            //     // scanning operator QR code
+            //     ui.qr_scan_start(QrScanSchema::OperatorSelfServe);
+            //     time::sleep(Duration::from_secs(10)).await;
+            //     ui.qr_scan_capture();
+            //     time::sleep(Duration::from_secs(2)).await;
+            //     ui.qr_scan_completed(QrScanSchema::OperatorSelfServe);
+            //     ui.qr_scan_success(QrScanSchema::OperatorSelfServe);
+            // } else {
+            //     // scanning operator QR code
+            //     ui.qr_scan_start(QrScanSchema::Operator);
+            //     time::sleep(Duration::from_secs(10)).await;
+            //     ui.qr_scan_capture();
+            //     time::sleep(Duration::from_secs(2)).await;
+            //     ui.qr_scan_completed(QrScanSchema::Operator);
+            //     ui.qr_scan_success(QrScanSchema::Operator);
+            // }
 
             // scanning user QR code
             time::sleep(Duration::from_secs(1)).await;
             ui.qr_scan_start(QrScanSchema::User);
-            time::sleep(Duration::from_secs(4)).await;
+            time::sleep(Duration::from_secs(10)).await;
             ui.qr_scan_capture();
             time::sleep(Duration::from_secs(2)).await;
             ui.qr_scan_completed(QrScanSchema::User);


### PR DESCRIPTION
TODO

- [x] Thomas comment: Let’s go down in brightness 25%. 
    - @fouge : changed from 40 to 30. **But a problem arises, see below.**
- [ ] Thomas comment: Can we fade in as slow as it fades out?
   - @fouge's comment: same time right now between in and out, but it's not noticeable: on pearl, the intensity is hard to control without bad UX: we notice the intensity **steps** when pulsing, on values close to 0. The animation should be smoother. More details: the current value goes from 1 to 30 using a sine wave. The intensity 29 to 30 is hardly noticeable if noticeable at all by the human eye (looks solid white), while the intensity from 1 to 2 is very noticeable (too much).
    - **Let's use half the LEDs** to decrease general brightness: One idea to make it smooth: switch between which LEDs are on for each new frame. this might help to make sure we don't notice that we use only half the LED, because the light diffusor on Pearl isn't that strong [I would reset half of the LEDs to intensity 0 right before we send the values to the MCU.](https://github.com/worldcoin/orb-software/blob/d50fabfc4419e667f192ff1cdd22fe8f5e41f558/ui/src/engine/pearl/mod.rs#L58) and leave the computation the same. 

March 7th:
@karelispanagiotis now taking over.