### PR TITLE
feat(nix): build container for cargo tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,3 +9,6 @@ git-fetch-with-cli = true
 # Run cargo with `RUSTFLAGS='--cfg docker_runner'`
 [target.'cfg(docker_runner)']
 runner = "docker/cargo-runner.sh"
+# Run cargo with `RUSTFLAGS='--cfg nix_docker_runner'`
+[target.'cfg(nix_docker_runner)']
+runner = "docker/nix-cargo-runner.sh"

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 # Nix stuff
 /.direnv
-/result
+result
 .envrc
 
 # Used by build.rs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM debian:latest

--- a/docker/nix-cargo-runner.sh
+++ b/docker/nix-cargo-runner.sh
@@ -2,7 +2,6 @@
 # Allows running tests inside docker. Takes care of linux-only dependencies and avoids
 # the need to emulate the architecture.
 
-
 set -Eeuo pipefail
 
 SELF=$0;
@@ -10,16 +9,22 @@ PROGRAM=$1; shift
 
 main() {
 	local -r absolute_path="$(realpath ${PROGRAM})"
-	local -r docker_dir="$(dirname ${SELF})"
 
-	docker build -t cargo-runner ${docker_dir}
+	if [[ "$(uname -m)" == "arm64" ]]; then
+		ARCH="aarch64-linux"
+	else
+		ARCH="x86_64-linux"
+	fi
+	IMAGE_TGZ="$(nix build .#containers.${ARCH}.cargo-runner --print-out-paths)"
+	docker load < "${IMAGE_TGZ}"
 	docker run \
 		--rm \
 		-v "${absolute_path}:/mnt/program" \
 		-w /mnt \
 		-e RUST_BACKTRACE \
-		-it cargo-runner:latest \
+		-it nix-cargo-runner:latest \
 		/mnt/program $@
+		# gdb -ex=run -ex=quit --args /mnt/program $@
 }
 
 main $@

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -23,7 +23,42 @@ host. But not all tests are possible on every target.
 *IF* it is supported, you can run `cargo test -p foobar` like normal. But
 support varies from crate to crate.
 
-## Running the code
+## Running tests locally
+
+You can `cargo test --all-targets -p foobar` for any crate named `foobar`, or
+`cargo test --all-targets --all` to test all crates. But some of our crates only
+can build when targetting linux, so if you are on mac you will need to use the `-p`
+version.
+
+You can also resort to cross compiling to linux and then running your tests in docker.
+There are two ways to do this:
+
+### Using a container based on a Dockerfile
+
+A *limited subset* of tests can use a container built from a `Dockerfile` at
+`docker/Dockerfile`. You can choose to run tests this way with the following command:
+
+```bash
+RUSTFLAGS='--cfg docker_runner' cargo-zigbuild test --target aarch64-unknown-linux-gnu --all-targets --all
+```
+
+### Using a container built from nix directly
+
+More (possibly all) tests can be run by using a container built using
+[docker-tools][docker-tools]. However, this *requires* you to have a linux remote
+builder runner for nix set up. The easiest way to do this is to use the
+[linux-builder][linux-builder] feature of [nix-darwin][nix-darwin]. After
+[setting up nix-darwin][switching to nix-darwin] and enabling the `linux-builder`
+setting in your `configuration.nix`, you can run:
+
+```bash
+RUSTFLAGS='--cfg nix_docker_runner' cargo-zigbuild test --target aarch64-unknown-linux-gnu --all-targets --all
+```
+
+Note that the only difference between this command and the other one is that the
+config flag for cargo is prefixed with `nix_`.
+
+## Running the code on an orb
 
 For binaries that are intended to run on the orb, you can take your
 cross-compiled binary, and scp it onto the orb. You can either use teleport (if
@@ -70,3 +105,7 @@ the readability of debugging.
 
 [first time setup]: ./first-time-setup.md
 [tokio console]: https://github.com/tokio-rs/console?tab=readme-ov-file#extremely-cool-and-amazing-screenshots
+[docker-tools]: https://ryantm.github.io/nixpkgs/builders/images/dockertools/
+[linux-builder]: https://daiderd.com/nix-darwin/manual/index.html#opt-nix.linux-builder.enable
+[nix-darwin]: https://github.com/LnL7/nix-darwin
+[switching to nix-darwin]: https://evantravers.com/articles/2024/02/06/switching-to-nix-darwin-and-flakes/

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,10 @@
       machines = (import nix/machines/flake-outputs.nix { inherit p inputs; });
       # Creates a `nix develop` shell for every host platform.
       devShells = (import nix/shells/flake-outputs.nix { inherit inputs; instantiatedPkgs = p; });
+      containers = (import nix/containers/flake-outputs.nix { inherit inputs; instantiatedPkgs = p; });
     in
 
     # The `//` operators takes the union of its two operands. So we are combining
       # multiple attribute sets into one final, big flake.
-    devShells // machines;
+    (machines // devShells) // containers;
 }

--- a/nix/containers/README.md
+++ b/nix/containers/README.md
@@ -1,0 +1,3 @@
+# Nix Containers
+
+Provides various nix containers, for example for running tests in docker.

--- a/nix/containers/cargo-runner.nix
+++ b/nix/containers/cargo-runner.nix
@@ -1,0 +1,48 @@
+# NixOS configuration common to all HILs. Combined with `nixos-common.nix`
+{ pkgs, lib, system, ... }:
+let
+  bashCmd = "${pkgs.nixpkgs-23_11.bash}/bin/bash";
+  # things needed to be found by linker
+  ldLibPath = lib.makeLibraryPath (with pkgs.nixpkgs-23_11; [
+    alsaLib
+    glib
+    glibc
+    lzma
+    squashfs-tools-ng
+  ]);
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "nix-cargo-runner";
+  tag = "latest";
+  # things needed at runtime
+  contents = with pkgs.nixpkgs-23_11; [
+    alsaLib
+    bash
+    coreutils
+    file
+    gdb
+    glib
+    glibc
+    glibc.bin
+    gst_all_1.gst-plugins-base
+    gst_all_1.gstreamer
+    libsodium
+    lzma
+    nix-ld
+    openssl
+    squashfs-tools-ng
+    squashfsTools
+    udev
+    which
+  ];
+  # See https://github.com/moby/docker-image-spec/blob/f1d00ebd/spec.md#image-json-description
+  config = {
+    Cmd = bashCmd;
+    Env = [
+      "LD_LIBRARY_PATH=${ldLibPath}"
+    ];
+    Volumes = {
+      "/tmp" = { };
+    };
+  };
+}

--- a/nix/containers/flake-outputs.nix
+++ b/nix/containers/flake-outputs.nix
@@ -1,0 +1,24 @@
+# This gets directly combined with the the toplevel flake.nix
+{ inputs, instantiatedPkgs }:
+let
+  inherit (inputs) flake-utils;
+  containerSystems = [ "x86_64-linux" "aarch64-linux" ];
+in
+# This helper function is used to more easily abstract
+  # over the host platform.
+  # See https://github.com/numtide/flake-utils#eachdefaultsystem--system---attrs
+flake-utils.lib.eachSystem containerSystems
+  (system:
+  let
+    nativePkgs = instantiatedPkgs.${system};
+    cargoRunner = import ./cargo-runner.nix
+      {
+        inherit system;
+        pkgs = nativePkgs;
+        lib = inputs.nixpkgs.lib;
+      };
+  in
+  {
+    containers.cargo-runner = cargoRunner;
+  }
+  )

--- a/nix/shells/development.nix
+++ b/nix/shells/development.nix
@@ -27,11 +27,13 @@ let
   # rust's `pkg-config` build script will prioritize env vars
   # suffixed with the target artchitecture.
   makePkgConfigPath = p: p.lib.concatStringsSep ":" ([
-    "${p.nixpkgs-23_11.libsodium.dev}/lib/pkgconfig"
-    "${p.nixpkgs-23_11.openssl.dev}/lib/pkgconfig"
     "${p.nixpkgs-23_11.glib.dev}/lib/pkgconfig"
-    "${p.nixpkgs-23_11.gst_all_1.gstreamer.dev}/lib/pkgconfig"
     "${p.nixpkgs-23_11.gst_all_1.gst-plugins-base.dev}/lib/pkgconfig"
+    "${p.nixpkgs-23_11.gst_all_1.gstreamer.dev}/lib/pkgconfig"
+    "${p.nixpkgs-23_11.libsodium.dev}/lib/pkgconfig"
+    "${p.nixpkgs-23_11.lzma.dev}/lib/pkgconfig"
+    "${p.nixpkgs-23_11.openssl.dev}/lib/pkgconfig"
+    "${p.nixpkgs-23_11.squashfs-tools-ng}/lib/pkgconfig"
   ] ++ p.lib.lists.optionals p.stdenv.isLinux [
     "${p.nixpkgs-23_11.alsaLib.dev}/lib/pkgconfig"
     "${p.nixpkgs-23_11.udev.dev}/lib/pkgconfig"
@@ -58,6 +60,7 @@ in
         cargo-deny # Checks licenses and security advisories
         cargo-expand # Useful for inspecting macros
         cargo-zigbuild # Used to cross compile rust
+        squashfsTools # mksquashfs
         dpkg # Used to test outputs of cargo-deb
         git-cliff # Conventional commit based release notes
         mdbook # Generates site for docs


### PR DESCRIPTION
I don't have a linux machine on me right now so I rely on running cargo tests. We have an existing cargo runner script that runs the tests in a debian docker container. But this is missing most of our actual dependencies. We need instead to actually build a docker image with all the necessary dependencies and use that.
https://linear.app/worldcoin/issue/ORBS-390/get-tests-to-run-in-cargo-runner-via-docker