### PR TITLE
feat(mcu-util): control front leds

### DIFF
--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -57,6 +57,9 @@ enum SubCommand {
     /// Control optics: gimbal
     #[clap(subcommand)]
     Optics(OpticsOpts),
+    /// Control UI
+    #[clap(subcommand)]
+    Ui(UiOpts),
     /// Control secure element
     #[clap(subcommand)]
     SecureElement(SecureElement),
@@ -145,6 +148,28 @@ enum Camera {
     Eye,
     #[clap(action)]
     Face,
+}
+
+/// Optics tests options
+#[derive(Parser, Debug, Clone, Copy)]
+enum UiOpts {
+    /// Test front leds for 3 seconds
+    #[clap(subcommand)]
+    Front(Leds),
+}
+
+#[derive(Parser, Debug, Clone, Copy)]
+enum Leds {
+    #[clap(action)]
+    Red,
+    #[clap(action)]
+    Green,
+    #[clap(action)]
+    Blue,
+    #[clap(action)]
+    White,
+    #[clap(action)]
+    Booster,
 }
 
 /// Optics position
@@ -254,6 +279,9 @@ async fn execute(args: Args) -> Result<()> {
             SecureElement::PowerCycle => {
                 orb.sec_board_mut().power_cycle_secure_element().await?
             }
+        },
+        SubCommand::Ui(opts) => match opts {
+            UiOpts::Front(leds) => orb.main_board_mut().front_leds(leds).await?,
         },
     }
 

--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -9,7 +9,7 @@ use crate::orb::dfu::BlockIterator;
 use crate::orb::revision::OrbRevision;
 use crate::orb::{dfu, BatteryStatus};
 use crate::orb::{Board, OrbInfo};
-use crate::Camera;
+use crate::{Camera, Leds};
 use orb_mcu_interface::can::canfd::CanRawMessaging;
 use orb_mcu_interface::can::isotp::{CanIsoTpMessaging, IsoTpNodeIdentifier};
 use orb_mcu_interface::orb_messages;
@@ -226,6 +226,120 @@ impl MainBoard {
                     Err(e) => {
                         return Err(eyre!("Error enabling eye camera trigger: {:?}", e));
                     }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn front_leds(&mut self, leds: Leds) -> Result<()> {
+        if let Leds::Booster = leds {
+            match self
+                .isotp_iface
+                .send(McuPayload::ToMain(
+                    main_messaging::jetson_to_mcu::Payload::WhiteLedsBrightness(
+                        main_messaging::WhiteLeDsBrightness { brightness: 5 },
+                    ),
+                ))
+                .await
+            {
+                Ok(_) => {
+                    info!("🚀 Booster LEDs enabled");
+                }
+                Err(e) => {
+                    return Err(eyre!("Error enabling booster LEDs: {:?}", e));
+                }
+            }
+        } else {
+            let pattern = match leds {
+                Leds::Red => {
+                    main_messaging::user_le_ds_pattern::UserRgbLedPattern::AllRed
+                }
+                Leds::Green => {
+                    main_messaging::user_le_ds_pattern::UserRgbLedPattern::AllGreen
+                }
+                Leds::Blue => {
+                    main_messaging::user_le_ds_pattern::UserRgbLedPattern::AllBlue
+                }
+                Leds::White => {
+                    main_messaging::user_le_ds_pattern::UserRgbLedPattern::AllWhite
+                }
+                _ => {
+                    error!("Invalid rgb color");
+                    return Err(eyre!("Invalid LEDs"));
+                }
+            };
+
+            match self
+                .isotp_iface
+                .send(McuPayload::ToMain(
+                    main_messaging::jetson_to_mcu::Payload::UserLedsPattern(
+                        main_messaging::UserLeDsPattern {
+                            pattern: pattern as i32,
+                            custom_color: None,
+                            start_angle: 0,
+                            angle_length: 360,
+                            pulsing_scale: 0.0,
+                            pulsing_period_ms: 0,
+                        },
+                    ),
+                ))
+                .await
+            {
+                Ok(_) => {
+                    info!("🚦 {:?} enabled", pattern);
+                }
+                Err(e) => {
+                    return Err(eyre!("Error enabling green LEDs: {:?}", e));
+                }
+            }
+        }
+
+        // turn off all LEDs after 3 seconds
+        tokio::time::sleep(Duration::from_millis(3000)).await;
+
+        if let Leds::Booster = leds {
+            match self
+                .isotp_iface
+                .send(McuPayload::ToMain(
+                    main_messaging::jetson_to_mcu::Payload::WhiteLedsBrightness(
+                        main_messaging::WhiteLeDsBrightness { brightness: 0 },
+                    ),
+                ))
+                .await
+            {
+                Ok(_) => {
+                    info!("LEDs disabled");
+                }
+                Err(e) => {
+                    return Err(eyre!("Error disabling booster LEDs: {:?}", e));
+                }
+            }
+        } else {
+            match self
+                .isotp_iface
+                .send(McuPayload::ToMain(
+                    main_messaging::jetson_to_mcu::Payload::UserLedsPattern(
+                        main_messaging::UserLeDsPattern {
+                            pattern:
+                            main_messaging::user_le_ds_pattern::UserRgbLedPattern::Off
+                                as i32,
+                            custom_color: None,
+                            start_angle: 0,
+                            angle_length: 360,
+                            pulsing_scale: 0.0,
+                            pulsing_period_ms: 0,
+                        },
+                    ),
+                ))
+                .await
+            {
+                Ok(_) => {
+                    info!("LEDs disabled");
+                }
+                Err(e) => {
+                    return Err(eyre!("Error disabling RGB LEDs: {:?}", e));
                 }
             }
         }


### PR DESCRIPTION
add commands to control rgb and booster leds
all leds are turned on for 3 seconds with the passed color

```
./orb-mcu-util ui front 
Test front leds for 3 seconds

Usage: orb-mcu-util ui front <COMMAND>

Commands:
  red      
  green    
  blue     
  white    
  booster  
  help     Print this message or the help of the given subcommand(s)
```

```
./orb-mcu-util ui front red
2025-03-10T12:12:06.870817Z  INFO orb_mcu_util::orb::main_board: 🚦 AllRed enabled
2025-03-10T12:12:09.874274Z  INFO orb_mcu_util::orb::main_board: LEDs disabled
```