### PR TITLE
test(bidiff-squashfs): add tests for different sqfs contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7acc34ff59877422326db7d6f2d845a582b16396b6b08194942bf34c6528ab"
+checksum = "8a8a41e51fda5f7d87152d00f50d08ce24bf5cee8a962facf7f2526a66f8a5fa"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4159dd617a7fbc9be6a692fe69dc2954f8e6bb6bb5e4d7578467441390d77fd0"
+checksum = "6b592add4016ac26ca340298fed5cc2524abe8bacae78ebca3780286da588304"
 dependencies = [
  "darling",
  "ident_case",
@@ -5523,8 +5523,10 @@ version = "0.0.0"
 dependencies = [
  "bidiff",
  "bipatch",
+ "bon",
  "clap",
  "clap-stdin",
+ "cmd_lib",
  "color-eyre",
  "orb-bidiff-squashfs-shim",
  "orb-telemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,12 @@ rust-version = "1.81.0" # See rust-toolchain.toml
 base64 = "0.22.1"
 bidiff = { version = "1.0.0", features = ["enc"] }
 bipatch = "1.0.0"
+bon = "3.4.0"
 bytes = "1.7.1"
 cc = "1.2.16"
 clap = { version = "4.5", features = ["derive", "env"] }
 clap-stdin = { version = "0.6.0", default-features = false }
+cmd_lib = "1.9.3"
 color-eyre = "0.6.2"
 console-subscriber = "0.4"
 data-encoding = "2.3"

--- a/bidiff-squashfs/lib/Cargo.toml
+++ b/bidiff-squashfs/lib/Cargo.toml
@@ -10,12 +10,14 @@ rust-version.workspace = true
 
 [dependencies]
 bidiff = { workspace = true, features = ["enc"] }
+bon.workspace = true
 orb-bidiff-squashfs-shim.workspace = true
 
 [dev-dependencies]
 bipatch.workspace = true
 clap = { workspace = true, features = ["derive"] }
 clap-stdin.workspace = true
+cmd_lib.workspace = true
 color-eyre.workspace = true
 orb-telemetry = { workspace = true, default-features = false }
 tempfile.workspace = true

--- a/hil/Cargo.toml
+++ b/hil/Cargo.toml
@@ -16,7 +16,7 @@ aws-sdk-s3 = "1.46.0"
 bytes.workspace = true
 camino = "1.1.6"
 clap = { workspace = true, features = ["derive"] }
-cmd_lib = "1.9.3"
+cmd_lib.workspace = true
 color-eyre.workspace = true
 ftdi-embedded-hal.workspace = true
 futures.workspace = true


### PR DESCRIPTION
Tests with empty files fail due to segfault in C shim. I am marking these tests as `#[ignore]` so that fixing the offending code isn't a prerequisite for introducing tests.