### PR TITLE
refactor: orb-ui rework biometric-capture and after-capture animations

### DIFF
--- a/ui/Cargo.toml
+++ b/ui/Cargo.toml
@@ -18,6 +18,7 @@ dashmap = "5.5.3"
 derive_more.workspace = true
 eyre.workspace = true
 futures.workspace = true
+hound = "3.5.1"
 humantime = "2.1.0"
 orb-build-info.path = "../build-info"
 orb-messages.workspace = true

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -106,6 +106,10 @@ impl Argb {
     pub const PEARL_CENTER_USER_CAPTURE: Argb = Argb(None, 30, 20, 0);
     /// Outer-ring color during user scan/capture (in progress)
     pub const PEARL_RING_USER_CAPTURE: Argb = Argb(None, 30, 30, 30);
+    /// Outer-ring color when capture was successful
+    pub const PEARL_RING_CAPTURE_SUCCESS: Argb = Argb(None, 27, 27, 27);
+    /// Shroud color when capture was successful
+    pub const PEARL_CENTER_CAPTURE_SUCCESS: Argb = Argb(None, 0, 81, 0);
     /// Error color for outer ring
     pub const PEARL_RING_ERROR_SALMON: Argb = Argb(None, 24, 4, 0);
 
@@ -142,7 +146,7 @@ impl Argb {
     pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(4), 127, 20, 0);
 
     pub const FULL_RED: Argb = Argb(None, 255, 0, 0);
-    pub const FULL_GREEN: Argb = Argb(None, 0, 81, 0);
+    pub const FULL_GREEN: Argb = Argb(None, 0, 255, 0);
     pub const FULL_BLUE: Argb = Argb(None, 0, 0, 255);
     pub const FULL_WHITE: Argb = Argb(None, 255, 255, 255);
     pub const FULL_BLACK: Argb = Argb(None, 0, 0, 0);

--- a/ui/src/engine/animations/alert_v2.rs
+++ b/ui/src/engine/animations/alert_v2.rs
@@ -1,0 +1,194 @@
+use crate::engine::{Animation, AnimationState};
+use orb_rgb::Argb;
+use std::any::Any;
+use std::f64::consts::PI;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum AlertError {
+    #[error("Edge {} `activation_time` should be later than {}", _0, _1)]
+    InitializationError(usize, f64),
+}
+
+pub struct SquarePulseEdge {
+    activation_time: f64,
+    smooth_duration: f64,
+}
+
+impl From<(f64, f64)> for SquarePulseEdge {
+    fn from(value: (f64, f64)) -> Self {
+        Self {
+            activation_time: value.0,
+            smooth_duration: value.1,
+        }
+    }
+}
+
+pub struct SquarePulseTrain(Vec<SquarePulseEdge>);
+
+impl From<Vec<(f64, f64)>> for SquarePulseTrain {
+    fn from(value: Vec<(f64, f64)>) -> Self {
+        Self(value.into_iter().map(SquarePulseEdge::from).collect())
+    }
+}
+
+/// # Alert
+///
+/// The `Alert` struct creates a flashing LED effect by turning the LEDs on and off
+/// in a timed sequence. It uses a series of pulses (defined in a `SquarePulseTrain`)
+/// to smoothly transition between off and a target color.
+///
+/// ## What It Does
+///
+/// - **Initial Delay:**
+///   The alert can wait for a set time before starting the animation.
+///
+/// - **Pulses:**  
+///   The animation is made up of pulses. Each pulse has two parts:
+///   - A **rising edge** (even-indexed pulse) where the LED brightness increases from off
+///     to the target color.
+///   - A **falling edge** (odd-indexed pulse) where the brightness decreases from the target color back to off.
+///
+/// - **Timing:**
+///   Each pulse is defined by:
+///   - `activation_time`: When the pulse starts.
+///   - `smooth_duration`: How long it takes to complete the fade-in or fade-out.
+///
+/// - **Animation End:**  
+///   Once all pulses have been processed, the animation stops.
+///
+/// ## Example Timeline
+///
+/// ```rust
+/// // Each tuple is (activation_time, smooth_duration)
+/// let pulse_train = SquarePulseTrain::from(vec![(0.0, 0.5), (1.0, 0.5)]);
+/// ```
+/// assuming you use red as the target color:
+///
+/// - **Time 0.0s:**
+///   The animation starts (after any initial delay). The first (rising) pulse begins:
+///   the LED brightness starts at 0 and gradually increases toward red over 0.5 seconds.
+///
+///- **Time 0.5s:**
+///   The rising pulse is complete, and the LED shows full red.
+///
+///- **Time 1.0s:**
+///   The second (falling) pulse starts: the LED brightness begins to decrease from red toward off,
+///   taking another 0.5 seconds.
+///
+///- **Time 1.5s:**
+///   The falling pulse is complete, the LED is off, and the animation finishes.
+///
+pub struct Alert<const N: usize> {
+    current_edge: usize,
+    target_color: Argb,
+    /// Describes the wave-form.
+    square_pulse_train: SquarePulseTrain,
+    /// time in animation
+    phase: f64,
+    /// initial delay, in seconds, before starting the animation
+    initial_delay: f64,
+}
+
+impl<const N: usize> Alert<N> {
+    /// Creates a new [`Alert`].
+    pub fn new(
+        color: Argb,
+        square_pulse_train: SquarePulseTrain,
+    ) -> Result<Self, AlertError> {
+        for (i, window) in square_pulse_train.0.windows(2).enumerate() {
+            let previous = &window[0];
+            let current = &window[1];
+            let required_activation =
+                previous.activation_time + previous.smooth_duration;
+            if current.activation_time < required_activation {
+                return Err(AlertError::InitializationError(
+                    i + 1,
+                    required_activation,
+                ));
+            }
+        }
+        Ok(Self {
+            target_color: color,
+            phase: 0.0,
+            initial_delay: 0.0,
+            square_pulse_train,
+            current_edge: 0,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn with_delay(mut self, delay: f64) -> Self {
+        self.initial_delay = delay;
+        self
+    }
+}
+
+impl<const N: usize> Animation for Alert<N> {
+    type Frame = [Argb; N];
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn animate(
+        &mut self,
+        frame: &mut [Argb; N],
+        dt: f64,
+        idle: bool,
+    ) -> AnimationState {
+        // initial delay
+        if self.initial_delay > 0.0 {
+            self.initial_delay -= dt;
+            return AnimationState::Running;
+        }
+
+        let rising_edge = self.current_edge % 2 == 0;
+        let current_edge = &self.square_pulse_train.0[self.current_edge];
+
+        let color = if self.phase < current_edge.activation_time {
+            // this can only happen if the first edge starts later than 0.0
+            Argb::OFF
+        } else if self.phase
+            < current_edge.activation_time + current_edge.smooth_duration
+        {
+            let t = self.phase - current_edge.activation_time;
+            let intensity = if rising_edge {
+                0.5 * (1.0 - (PI / current_edge.smooth_duration * t).cos())
+            } else {
+                0.5 * (1.0 + (PI / current_edge.smooth_duration * t).cos())
+            };
+            self.target_color * intensity
+        } else if rising_edge {
+            self.target_color
+        } else {
+            Argb::OFF
+        };
+
+        if !idle {
+            for led in frame {
+                *led = color;
+            }
+        }
+
+        if self.current_edge == self.square_pulse_train.0.len() - 1
+            && self.phase > current_edge.activation_time + current_edge.smooth_duration
+        {
+            return AnimationState::Finished;
+        }
+
+        self.phase += dt;
+        while self.current_edge + 1 < self.square_pulse_train.0.len()
+            && self.phase
+                > self.square_pulse_train.0[self.current_edge + 1].activation_time
+        {
+            self.current_edge += 1;
+        }
+
+        AnimationState::Running
+    }
+}

--- a/ui/src/engine/animations/fake_progress_v2.rs
+++ b/ui/src/engine/animations/fake_progress_v2.rs
@@ -1,0 +1,116 @@
+use super::Progress;
+use crate::engine::{Animation, AnimationState, RingFrame};
+use orb_rgb::Argb;
+use std::{any::Any, time::Duration};
+
+/// Exponentially decaying progress bar.
+/// The bar keeps progressing until a given timeout.
+/// If all of the tasks complete before the timeout,
+/// the bar smoothly progresses towards the end in `fast_forward_duration` time.
+struct ProgressBar {
+    progress: f64,
+    rate: f64,
+    completed: bool,
+    min_fast_forward_duration: Duration,
+    max_fast_forward_duration: Duration,
+}
+
+pub struct FakeProgress<const N: usize> {
+    progress_bar: ProgressBar,
+    progress_animation: Progress<N>,
+}
+
+impl<const N: usize> Animation for FakeProgress<N> {
+    type Frame = RingFrame<N>;
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn animate(
+        &mut self,
+        frame: &mut Self::Frame,
+        dt: f64,
+        idle: bool,
+    ) -> crate::engine::AnimationState {
+        self.progress_animation
+            .set_progress(self.progress_bar.update(dt), None);
+        if self.progress_bar.is_complete() {
+            AnimationState::Finished
+        } else {
+            self.progress_animation.animate(frame, dt, idle)
+        }
+    }
+}
+
+impl<const N: usize> FakeProgress<N> {
+    pub fn new(
+        color: Argb,
+        timeout: Duration,
+        min_fast_forward_duration: Duration,
+        max_fast_forward_duration: Duration,
+    ) -> Self {
+        Self {
+            progress_bar: ProgressBar::new(
+                timeout,
+                min_fast_forward_duration,
+                max_fast_forward_duration,
+            ),
+            progress_animation: Progress::<N>::new(0.0, None, color),
+        }
+    }
+
+    pub fn set_completed(&mut self) -> Duration {
+        self.progress_bar.set_completed()
+    }
+}
+
+impl ProgressBar {
+    // higher than 1.0, so that the `displayed_progress` can reach 1.0.
+    const TARGET_PROGRESS: f64 = 1.1;
+
+    pub fn new(
+        timeout: Duration,
+        min_fast_forward_duration: Duration,
+        max_fast_forward_duration: Duration,
+    ) -> Self {
+        let rate = -f64::ln((Self::TARGET_PROGRESS - 1.0) / Self::TARGET_PROGRESS)
+            / timeout.as_secs_f64();
+        Self {
+            progress: 0.0,
+            rate,
+            completed: false,
+            min_fast_forward_duration,
+            max_fast_forward_duration,
+        }
+    }
+
+    pub fn update(&mut self, dt: f64) -> f64 {
+        // Use exponential smoothing to move displayed_progress toward effective_target.
+        self.progress +=
+            (Self::TARGET_PROGRESS - self.progress) * (1.0 - (-self.rate * dt).exp());
+        self.progress
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.progress >= 1.0
+    }
+
+    pub fn set_completed(&mut self) -> Duration {
+        self.completed = true;
+        // linear interpolation of max..min fast-forward duration based on current progress.
+        let fast_forward_duration = self.max_fast_forward_duration.as_secs_f64()
+            + self.progress
+                * (self.min_fast_forward_duration.as_secs_f64()
+                    - self.max_fast_forward_duration.as_secs_f64());
+        self.rate = -f64::ln(
+            (Self::TARGET_PROGRESS - 1.0) / (Self::TARGET_PROGRESS - self.progress),
+        ) / fast_forward_duration;
+
+        Duration::from_secs_f64(fast_forward_duration)
+    }
+}

--- a/ui/src/engine/animations/mod.rs
+++ b/ui/src/engine/animations/mod.rs
@@ -1,4 +1,5 @@
 pub mod alert;
+pub mod alert_v2;
 mod arc_dash;
 pub mod arc_pulse;
 mod fake_progress;

--- a/ui/src/engine/animations/mod.rs
+++ b/ui/src/engine/animations/mod.rs
@@ -3,6 +3,7 @@ pub mod alert_v2;
 mod arc_dash;
 pub mod arc_pulse;
 mod fake_progress;
+pub mod fake_progress_v2;
 pub mod idle;
 pub mod milky_way;
 pub mod progress;

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -666,6 +666,11 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     }
                 }
             }
+            Event::BiometricCaptureFakeProgressStart {
+                timeout: _,
+                min_fast_forward_duration: _,
+                max_fast_forward_duration: _,
+            } => {}
             Event::BiometricCaptureOcclusion { occlusion_detected } => {
                 if *occlusion_detected {
                     self.operator_signup_phase.capture_occlusion_issue();
@@ -723,6 +728,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
             Event::BiometricCaptureSuccessGreen => {
                 self.biometric_capture_success()?;
             }
+            Event::BiometricCaputreSuccessAndFastForwardFakeProgress => {}
             Event::BiometricPipelineProgress { progress } => {
                 // operator LED to show pipeline progress
                 if *progress <= 0.5 {

--- a/ui/src/engine/mod.rs
+++ b/ui/src/engine/mod.rs
@@ -9,6 +9,7 @@ use orb_messages::mcu_message::Message;
 use orb_rgb::Argb;
 use pid::InstantTimer;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use std::{any::Any, collections::BTreeMap};
 use tokio::sync::mpsc;
 
@@ -272,6 +273,16 @@ event_enum! {
         BiometricCaptureProgress {
             progress: f64,
         },
+        /// Biometric capture start fake progress.
+        #[event_enum(method = biometric_capture_fake_progress_start)]
+        BiometricCaptureFakeProgressStart {
+            timeout: Duration,
+            min_fast_forward_duration: Duration,
+            max_fast_forward_duration: Duration,
+        },
+        /// Biometric capture has finished successfully, command fake-progress to fast-forward
+        #[event_enum(method = biometric_capture_success_and_fast_forward_fake_progress)]
+        BiometricCaputreSuccessAndFastForwardFakeProgress,
         #[event_enum(method = biometric_capture_progress_with_notch)]
         BiometricCaptureProgressWithNotch {
             progress: f64,

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -474,10 +474,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 }
             }
             Event::BiometricCaptureSuccess => {
-                self.biometric_capture_success(false)?;
-            }
-            Event::BiometricCaptureSuccessGreen => {
-                self.biometric_capture_success(true)?;
+                self.biometric_capture_success()?;
             }
             Event::BiometricPipelineProgress { progress } => {
                 // operator LED to show pipeline progress
@@ -618,8 +615,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
         Ok(())
     }
 
-    fn biometric_capture_success(&mut self, use_green: bool) -> Result<()> {
-        // fade out duration + sound delay
+    fn biometric_capture_success(&mut self) -> Result<()> {
         // delaying the sound allows resynchronizing in case another
         // sound is played at the same time, as the delay start
         // when the sound is queued.
@@ -642,11 +638,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
         self.set_ring(
             LEVEL_NOTICE,
             animations::Alert::<PEARL_RING_LED_COUNT>::new(
-                if use_green {
-                    Argb::FULL_GREEN
-                } else {
-                    Argb::PEARL_RING_USER_CAPTURE
-                },
+                Argb::PEARL_RING_USER_CAPTURE,
                 BlinkDurations::from(success_alert_blinks),
                 Some(vec![0.1, 0.4, 0.4]),
                 false,

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -654,27 +654,12 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                 );
             }
             Event::SignupSuccess => {
-                self.sound.queue(
-                    sound::Type::Melody(sound::Melody::SignupSuccess),
-                    Duration::ZERO,
-                )?;
-
                 self.operator_signup_phase.signup_successful();
-
                 self.set_ring(
                     LEVEL_BACKGROUND,
                     animations::Static::<PEARL_RING_LED_COUNT>::new(Argb::OFF, None),
                 );
                 self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
-                self.set_ring(
-                    LEVEL_NOTICE,
-                    animations::Alert::<PEARL_RING_LED_COUNT>::new(
-                        Argb::PEARL_RING_USER_CAPTURE,
-                        BlinkDurations::from(vec![0.0, 0.6, 3.6]),
-                        None,
-                        false,
-                    )?,
-                );
             }
             Event::Idle => {
                 self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -1,3 +1,4 @@
+use crate::engine::animations::alert_v2::SquarePulseTrain;
 use crate::engine::{
     animations, Animation, Event, QrScanSchema, QrScanUnexpectedReason, Runner,
     RunningAnimation, SignupFailReason, Transition, LEVEL_BACKGROUND, LEVEL_FOREGROUND,
@@ -381,6 +382,99 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     }
                 }
             }
+            Event::BiometricCaptureFakeProgressStart {
+                timeout,
+                min_fast_forward_duration,
+                max_fast_forward_duration,
+            } => {
+                self.set_ring(
+                    LEVEL_NOTICE,
+                    animations::fake_progress_v2::FakeProgress::<PEARL_RING_LED_COUNT>::new(
+                        Argb::PEARL_RING_USER_CAPTURE,
+                        *timeout,
+                        *min_fast_forward_duration,
+                        *max_fast_forward_duration,
+                    ),
+                );
+            }
+            Event::BiometricCaputreSuccessAndFastForwardFakeProgress => {
+                let ring_completion_time = self
+                    .ring_animations_stack
+                    .stack
+                    .get_mut(&LEVEL_NOTICE)
+                    .and_then(|RunningAnimation { animation, .. }| {
+                        animation
+                            .as_any_mut()
+                            .downcast_mut::<animations::fake_progress_v2::FakeProgress<
+                                PEARL_RING_LED_COUNT,
+                            >>()
+                    })
+                    .map(|fake_progress| fake_progress.set_completed())
+                    .unwrap_or_default()
+                    .as_secs_f64();
+
+                let mut total_duration = 0.0;
+                while let Some(melody) = self.capture_sound.peekable().peek() {
+                    let melody = sound::Type::Melody(*melody);
+                    let melody_duration =
+                        self.sound.get_duration(melody).unwrap().as_secs_f64();
+                    if total_duration + melody_duration < ring_completion_time {
+                        self.sound.queue(melody, Duration::ZERO)?;
+                        self.capture_sound.next();
+                        total_duration += melody_duration;
+                    } else {
+                        break;
+                    }
+                }
+                // Sync biometric capture success animation + sounds, with the fake progress.
+                // Since the ring is ON after the fake progress, we turn it off smoothly in `fade_out_duration`,
+                // and then we do a double blink after `success_delay`.
+                let fade_out_duration = 0.3;
+                let success_delay = 0.4;
+                self.sound.queue(
+                    sound::Type::Melody(sound::Melody::IrisScanSuccess),
+                    Duration::from_millis(
+                        ((ring_completion_time + fade_out_duration + success_delay)
+                            * 1000.0) as u64,
+                    ),
+                )?;
+                self.stop_center(
+                    LEVEL_FOREGROUND,
+                    Transition::FadeOut(ring_completion_time),
+                );
+                // in case nothing is running on center, make sure we set the background to off
+                self.set_center(
+                    LEVEL_BACKGROUND,
+                    animations::Static::<PEARL_CENTER_LED_COUNT>::new(Argb::OFF, None),
+                );
+                self.set_center(
+                    LEVEL_FOREGROUND,
+                    animations::alert_v2::Alert::<PEARL_CENTER_LED_COUNT>::new(
+                        Argb::PEARL_CENTER_CAPTURE_SUCCESS,
+                        SquarePulseTrain::from(vec![
+                            (fade_out_duration + success_delay, 1.1),
+                            (fade_out_duration + success_delay + 1.1, 3.4),
+                        ]),
+                    )?
+                    .with_delay(ring_completion_time),
+                );
+                self.set_ring(
+                    LEVEL_FOREGROUND,
+                    animations::alert_v2::Alert::<PEARL_RING_LED_COUNT>::new(
+                        Argb::PEARL_RING_CAPTURE_SUCCESS,
+                        SquarePulseTrain::from(vec![
+                            (0.0, 0.0),
+                            (0.0, fade_out_duration),
+                            (fade_out_duration + success_delay, 0.1),
+                            (fade_out_duration + success_delay + 0.5, 0.1),
+                            (fade_out_duration + success_delay + 1.0, 0.1),
+                            (fade_out_duration + success_delay + 1.1, 3.5),
+                        ]),
+                    )?
+                    .with_delay(ring_completion_time),
+                );
+                self.operator_signup_phase.iris_scan_complete();
+            }
             Event::BiometricCaptureProgressWithNotch { progress } => {
                 // set progress but wait for wave to finish breathing
                 let breathing = self
@@ -445,22 +539,20 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                     self.operator_signup_phase.capture_distance_issue();
                 }
 
-                // show correct position to user by playing sounds but
-                // only once we stop breathing
-                let breathing = self
+                // play the sound only once we start the progress bar.
+                let progressing = self
                     .ring_animations_stack
                     .stack
-                    .get_mut(&LEVEL_FOREGROUND)
+                    .get_mut(&LEVEL_NOTICE)
                     .and_then(|RunningAnimation { animation, .. }| {
                         animation
                             .as_any_mut()
-                            .downcast_mut::<animations::Wave<PEARL_RING_LED_COUNT>>()
+                            .downcast_mut::<animations::fake_progress_v2::FakeProgress<
+                                PEARL_RING_LED_COUNT,
+                            >>()
                     })
                     .is_some();
-                if breathing && *in_range {
-                    // stop any ongoing breathing animation
-                    self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
-                } else if *in_range {
+                if progressing && *in_range {
                     if let Some(melody) = self.capture_sound.peekable().peek() {
                         if self.sound.try_queue(sound::Type::Melody(*melody))? {
                             self.capture_sound.next();


### PR DESCRIPTION
UX changes:
* biometric capture uses a fake progress animation coupled to finish (go to 100%) with the plan's timeout. If the capture is successful, `orb-core` issues a "fast-forward" command that also drives the progress to 100%.
* new biometric capture success animation:
    * blink led ring twice and fade-out
    * center led becomes green and fades-out in sync with the ring.
* after the capture, the orb remains blank until the next operator/user qr-scan.
    * removed `SignupSuccess` animations
    * removed `SignupFail` animations that come after biometric capture (pcp-upload/verification etc).

Codebase additions:
* new `alert_v2::Alert` animation for constructing pulse-train signals with (optionally) smooth transitions.
* new `fake_progress_v2::Progress` animation that gets configured by the timeout-period and the fast-forward min & max durations.