### PR TITLE
feat(bidiff-squashfs): Implement new command to diff entire OTAs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,6 +5427,8 @@ dependencies = [
 name = "orb-bidiff-squashfs-cli"
 version = "0.0.0"
 dependencies = [
+ "aws-config",
+ "aws-sdk-s3",
  "bidiff",
  "bipatch",
  "clap",
@@ -5434,11 +5436,15 @@ dependencies = [
  "color-eyre",
  "derive_more",
  "enum_dispatch",
+ "futures",
+ "indicatif",
  "orb-bidiff-squashfs",
+ "orb-build-info 0.0.0",
  "orb-s3-helpers",
  "orb-telemetry",
  "tempfile",
  "thiserror 1.0.65",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ gstreamer-video = "0.22.1"
 hex = "0.4.3"
 hex-literal = "0.4.1"
 http = "1.2.0"
+indicatif = "0.17.9"
 jose-jwk = { version = "0.1.2", default-features = false }
 libc = "0.2.153"
 nix = { version = "0.28", default-features = false, features = [] }

--- a/bidiff-squashfs/cli/Cargo.toml
+++ b/bidiff-squashfs/cli/Cargo.toml
@@ -9,6 +9,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
 bidiff = { workspace = true, features = ["enc"] }
 bipatch.workspace = true
 clap = { workspace = true, features = ["derive"] }
@@ -16,11 +18,16 @@ clap-stdin.workspace = true
 color-eyre.workspace = true
 derive_more = { workspace = true, default-features = false, features = ["from"] }
 enum_dispatch = "0.3.13"
+futures.workspace = true
+indicatif.workspace = true
 orb-bidiff-squashfs.workspace = true
+orb-build-info.workspace = true
 orb-s3-helpers.workspace = true
 orb-telemetry = { workspace = true, default-features = false }
+tempfile.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] } # todo: reduce features
 tracing.workspace = true
 
-[dev-dependencies]
-tempfile.workspace = true
+[build-dependencies]
+orb-build-info = { workspace = true, features = ["build-script"] }

--- a/bidiff-squashfs/cli/build.rs
+++ b/bidiff-squashfs/cli/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    orb_build_info::initialize().expect("failed to initialize")
+}

--- a/bidiff-squashfs/cli/src/fetch.rs
+++ b/bidiff-squashfs/cli/src/fetch.rs
@@ -1,0 +1,54 @@
+use std::{
+    io::IsTerminal as _,
+    path::{Path, PathBuf},
+};
+
+use aws_sdk_s3::Client;
+use color_eyre::{eyre::WrapErr as _, Result};
+use futures::TryStreamExt as _;
+use orb_s3_helpers::{ClientExt as _, S3Uri};
+use tracing::info;
+
+use crate::ota_path::OtaPath;
+
+pub async fn fetch_path(client: &Client, path: &OtaPath) -> Result<PathBuf> {
+    let download_dir = tempfile::tempdir_in(".")
+        .wrap_err("failed to create temporary directory in current directoyr")?;
+
+    match path {
+        OtaPath::S3(s3_uri) => fetch_s3(client, s3_uri, download_dir.path()).await,
+        OtaPath::Version(ota_version) => {
+            fetch_s3(client, &ota_version.to_s3_uri(), download_dir.path()).await
+        }
+        OtaPath::Path(path_buf) => return Ok(path_buf.to_owned()),
+    }
+    .wrap_err("failed to download {path}")?;
+
+    todo!()
+}
+
+/// Preconditions:
+/// - `out_dir` should already exist
+/// - `s3_dir.is_dir()` should be `true`.
+async fn fetch_s3(client: &Client, s3_dir: &S3Uri, out_dir: &Path) -> Result<()> {
+    assert!(s3_dir.is_dir(), "only directories should be provided");
+    assert!(out_dir.exists(), "out_dir should exist");
+
+    let objects: Vec<_> = client
+        .list_prefix(s3_dir)
+        .try_collect()
+        .await
+        .wrap_err("error while listing s3 dir")?;
+    let total_ota_size: u64 = objects
+        .iter()
+        .map(|o| u64::try_from(o.size().unwrap_or_default()).expect("overflow"))
+        .sum();
+
+    let pb = std::io::stderr()
+        .is_terminal()
+        .then(|| indicatif::ProgressBar::new(total_ota_size));
+    for o in objects {
+        info!("key: {}", o.key().unwrap());
+    }
+    todo!()
+}

--- a/bidiff-squashfs/cli/src/lib.rs
+++ b/bidiff-squashfs/cli/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod fetch;
 pub mod file_or_stdout;
-mod ota_path;
+pub mod ota_path;

--- a/bidiff-squashfs/cli/src/main.rs
+++ b/bidiff-squashfs/cli/src/main.rs
@@ -3,22 +3,38 @@ mod file_or_stdout;
 use std::{
     fs,
     io::{self, Write as _},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use bidiff::DiffParams;
-use clap::Parser;
+use clap::{
+    builder::{styling::AnsiColor, Styles},
+    Parser,
+};
 use clap_stdin::FileOrStdin;
-use color_eyre::{eyre::WrapErr as _, Result};
+use color_eyre::{
+    eyre::{ensure, WrapErr as _},
+    Result,
+};
+use orb_bidiff_squashfs_cli::ota_path::OtaPath;
+use orb_build_info::{make_build_info, BuildInfo};
 use tracing::info;
 
 use crate::file_or_stdout::stdout_if_none;
 
+const BUILD_INFO: BuildInfo = make_build_info!();
+
 #[derive(Debug, Parser)]
-#[clap(about, author)]
+#[clap(
+    author,
+    about,
+    version = BUILD_INFO.version,
+    styles = clap_v3_styles(),
+)]
 enum Args {
     Diff(DiffCommand),
     Patch(PatchCommand),
+    Ota(OtaCommand),
 }
 
 #[derive(Debug, Parser)]
@@ -51,16 +67,43 @@ struct PatchCommand {
     force_overwrite_file: bool,
 }
 
-fn main() -> Result<()> {
+#[derive(Debug, Parser)]
+struct OtaCommand {
+    /// The "base" ota, i.e. the state before transition.
+    /// Supports either `s3://...`, `ota://X.Y.Z...`, or a path.
+    #[clap(long, short)]
+    base: OtaPath,
+    /// The "top" ota, i.e. the state after transition.
+    /// Supports either `s3://...`, `ota://X.Y.Z...`, or a path.
+    #[clap(long, short)]
+    top: OtaPath,
+    /// The directory to output the finished OTA
+    #[clap(long, short)]
+    out: PathBuf,
+    /// The location that any downloaded OTAs will be placed. If `None`, they will
+    /// go to a temporary directory in the current working dir.
+    #[clap(long, short)]
+    download_dir: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     let args = Args::parse();
     let telemetry_flusher = orb_telemetry::TelemetryConfig::new().init();
 
     let result = match args {
-        Args::Diff(c) => run_diff(c),
-        Args::Patch(c) => run_patch(c),
+        Args::Diff(c) => tokio::task::spawn_blocking(|| run_diff(c))
+            .await
+            .wrap_err("task panicked")
+            .and_then(|r| r),
+        Args::Patch(c) => tokio::task::spawn_blocking(|| run_patch(c))
+            .await
+            .wrap_err("task panicked")
+            .and_then(|r| r),
+        Args::Ota(c) => run_mk_ota(c).await,
     };
-    telemetry_flusher.flush_blocking();
+    telemetry_flusher.flush().await;
 
     result
 }
@@ -115,4 +158,36 @@ fn run_patch(args: PatchCommand) -> Result<()> {
         .wrap_err("failed to flush writer")?;
 
     Ok(())
+}
+
+async fn run_mk_ota(args: OtaCommand) -> Result<()> {
+    if args.out.exists() {
+        async fn is_empty_dir(d: &Path) -> Result<bool> {
+            Ok(tokio::fs::read_dir(d).await?.next_entry().await?.is_none())
+        }
+        let is_empty = is_empty_dir(&args.out).await.wrap_err_with(|| {
+            format!("out dir {} cannot be read", args.out.display())
+        })?;
+        ensure!(is_empty, "out dir {} must be empty", args.out.display());
+    }
+
+    let client = orb_s3_helpers::client()
+        .await
+        .wrap_err("failed to create s3 client")?;
+    let base_path = orb_bidiff_squashfs_cli::fetch::fetch_path(&client, &args.base)
+        .await
+        .wrap_err("failed to get base ota")?;
+    let top_path = orb_bidiff_squashfs_cli::fetch::fetch_path(&client, &args.top)
+        .await
+        .wrap_err("failed to get base ota")?;
+
+    todo!()
+}
+
+fn clap_v3_styles() -> Styles {
+    Styles::styled()
+        .header(AnsiColor::Yellow.on_default())
+        .usage(AnsiColor::Green.on_default())
+        .literal(AnsiColor::Green.on_default())
+        .placeholder(AnsiColor::Green.on_default())
 }

--- a/bidiff-squashfs/cli/src/ota_path.rs
+++ b/bidiff-squashfs/cli/src/ota_path.rs
@@ -31,13 +31,17 @@ impl OtaVersion {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    pub fn to_s3_uri(&self) -> S3Uri {
+        format!("s3://worldcoin-orb-updates-stage/{}/", self.as_str())
+            .parse()
+            .expect("this should be infallible")
+    }
 }
 
 impl From<OtaVersion> for S3Uri {
     fn from(ota: OtaVersion) -> S3Uri {
-        format!("s3://worldcoin-orb-updates-stage/{}/", ota.as_str())
-            .parse()
-            .expect("this should be infallible")
+        ota.to_s3_uri()
     }
 }
 
@@ -81,7 +85,8 @@ mod tests {
         let s3: S3Uri = "s3://worldcoin-orb-updates-stage/1.2.3/"
             .parse()
             .expect("valid s3");
-        let converted = S3Uri::from(ota);
+        let converted = ota.to_s3_uri();
+        assert_eq!(converted, ota.into());
         assert_eq!(converted, s3);
         assert!(converted.is_dir())
     }
@@ -95,7 +100,8 @@ mod tests {
             "s3://worldcoin-orb-updates-stage/6.0.29+5d20de6.2410071904.dev/"
                 .parse()
                 .expect("valid s3");
-        let converted = S3Uri::from(ota);
+        let converted = ota.to_s3_uri();
+        assert_eq!(converted, ota.into());
         assert_eq!(converted, s3);
         assert!(converted.is_dir())
     }

--- a/hil/Cargo.toml
+++ b/hil/Cargo.toml
@@ -21,7 +21,7 @@ color-eyre.workspace = true
 ftdi-embedded-hal.workspace = true
 futures.workspace = true
 humantime = "2.1.0"
-indicatif = { version = "0.17.9", features = ["tokio"] }
+indicatif = { workspace = true, features = ["tokio"] }
 libftd2xx = { version = "0.32.4", features = ["static"] }
 nusb.workspace = true
 orb-build-info.path = "../build-info"


### PR DESCRIPTION
rebased on #436 

The process of crafting a bidiff ota has proven to be annoying and manual, and is bottle-necking my testing. This new command will automate the process.

In the worst case, we can use this to produce OTAs by hand, instead of in CI. Even if long term we use CI, producing them locally seems useful regardless, for testing and development.