### PR TITLE
feat(s3-helpers): implement list_prefix

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -126,7 +126,7 @@ jobs:
         uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2
         with:
           key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
-      - name: Install dbus
+      - name: Install DBus
         if: matrix.platform == 'macos-14'
         run: brew install dbus
       - name: Print environment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aed08d3adb6ebe0eff737115056652670ae290f177759aac19c30456135f94c"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
 dependencies = [
  "base64 0.22.1",
  "bollard-stubs",
@@ -1390,13 +1390,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.4.1",
  "hyper-named-pipe",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.3",
  "hyper-util",
- "hyperlocal-next",
+ "hyperlocal",
  "log",
  "pin-project-lite",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.3",
+ "rustls 0.23.20",
+ "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -1404,7 +1404,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror 1.0.65",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -1414,9 +1414,9 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.44.0-rc.2"
+version = "1.47.1-rc.27.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709d9aa1c37abb89d40f19f5d0ad6f0d88cb1581264e571c9350fc5bb89cf1c5"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
 dependencies = [
  "serde",
  "serde_repr",
@@ -2600,18 +2600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
 name = "enum-ordinalize"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +2679,17 @@ checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2833,7 +2832,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -3495,51 +3494,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad3d6d98c648ed628df039541a5577bee1a7c83e9e16fe3dbedeea4cdfeb971"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand",
- "thiserror 1.0.65",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2e2aba9c389ce5267d31cf1e4dace82390ae276b0b364ea55630b1fa1b44b4"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror 1.0.65",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,17 +3509,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
 ]
 
 [[package]]
@@ -3772,25 +3715,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-dependencies = [
- "futures-util",
- "http 1.2.0",
- "hyper 1.4.1",
- "hyper-util",
- "log",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.3",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
@@ -3800,7 +3724,6 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.20",
- "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.1",
@@ -3853,10 +3776,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperlocal-next"
-version = "0.9.0"
+name = "hyperlocal"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
@@ -4174,18 +4097,6 @@ checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
 dependencies = [
  "core-foundation-sys",
  "mach2",
-]
-
-[[package]]
-name = "ipconfig"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
-dependencies = [
- "socket2",
- "widestring",
- "windows-sys 0.48.0",
- "winreg",
 ]
 
 [[package]]
@@ -4647,12 +4558,6 @@ name = "license-stub-libsquashfs1"
 version = "0.0.0"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4713,15 +4618,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4749,12 +4645,6 @@ checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -5727,6 +5617,7 @@ dependencies = [
  "libftd2xx",
  "nusb",
  "orb-build-info 0.0.0",
+ "orb-s3-helpers",
  "orb-security-utils",
  "reqwest 0.12.12",
  "secrecy 0.8.0",
@@ -5927,6 +5818,24 @@ name = "orb-rgb"
 version = "0.0.0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "orb-s3-helpers"
+version = "0.0.0"
+dependencies = [
+ "async-stream",
+ "aws-config",
+ "aws-sdk-s3",
+ "clap",
+ "color-eyre",
+ "futures",
+ "orb-telemetry",
+ "test-with",
+ "testcontainers",
+ "testcontainers-modules",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6309,7 +6218,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -7115,6 +7024,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.2.1",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
@@ -7272,12 +7190,9 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
- "hickory-resolver",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -7294,7 +7209,6 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.20",
- "rustls-native-certs 0.8.0",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -7313,16 +7227,6 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.26.7",
  "windows-registry",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
-dependencies = [
- "hostname",
- "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -7523,20 +7427,6 @@ dependencies = [
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -8589,32 +8479,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "testcontainers"
-version = "0.20.1"
+name = "test-with"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "725cbe485aafddfd8b2d01665937c95498d894c07fabd9c4e06a53c7da4ccc56"
+checksum = "03ed0eeaca420c94c7fbcfd53f425b6ea2ce25e23111523b76bde45ec1c4e2ca"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
 dependencies = [
  "async-trait",
  "bollard",
  "bollard-stubs",
  "bytes",
- "dirs",
  "docker_credential",
  "either",
+ "etcetera",
  "futures",
  "log",
  "memchr",
  "parse-display",
  "pin-project-lite",
- "reqwest 0.12.12",
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 1.0.65",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-stream",
+ "tokio-tar",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -8826,17 +8738,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
@@ -8883,6 +8784,21 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
 ]
 
 [[package]]
@@ -9727,12 +9643,6 @@ dependencies = [
  "once_cell",
  "rustix",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
   "mcu-util",
   "orb-info",
   "qr-link",
+  "s3-helpers",
   "security-utils",
   "seek-camera/sys",
   "seek-camera/wrapper",
@@ -63,6 +64,9 @@ rust-version = "1.81.0" # See rust-toolchain.toml
 # prevent edge cases where CI doesn't catch build errors due to more features
 # being present in a --all vs -p build.
 [workspace.dependencies]
+async-stream = "0.3.6"
+aws-config = "1.5.5"
+aws-sdk-s3 = "1.46.0"
 base64 = "0.22.1"
 bidiff = { version = "1.0.0", features = ["enc"] }
 bipatch = "1.0.0"
@@ -105,7 +109,9 @@ serial_test = "3.2.0"
 serialport = "4.6.1"
 sha2 = "0.10.8"
 tempfile = "3.10.1"
-testcontainers = "0.20.0"
+test-with = { version = "0.14.8", default-features = false } # NOTE: Not hermetic.
+testcontainers = "0.23.3"
+testcontainers-modules = "0.11.6"
 thiserror = "1.0.60"
 tokio = { version = "1", features = ["full"] }
 tokio-serial = "5.4.4"
@@ -135,6 +141,7 @@ orb-header-parsing.path = "header-parsing"
 orb-info = { path = "orb-info", default-features = false }
 orb-location-wifi.path = "location/wifi"
 orb-mcu-interface.path = "mcu-interface"
+orb-s3-helpers.path = "s3-helpers"
 orb-security-utils.path = "security-utils"
 orb-slot-ctrl.path = "slot-ctrl"
 orb-telemetry = { path = "telemetry", default-features = false }

--- a/hil/Cargo.toml
+++ b/hil/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-aws-config = "1.5.5"
-aws-sdk-s3 = "1.46.0"
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
 bytes.workspace = true
 camino = "1.1.6"
 clap = { workspace = true, features = ["derive"] }
@@ -20,13 +20,14 @@ cmd_lib.workspace = true
 color-eyre.workspace = true
 ftdi-embedded-hal.workspace = true
 futures.workspace = true
+humantime = "2.1.0"
 indicatif = { version = "0.17.9", features = ["tokio"] }
 libftd2xx = { version = "0.32.4", features = ["static"] }
 nusb.workspace = true
 orb-build-info.path = "../build-info"
 orb-security-utils = { workspace = true, features = ["reqwest"] }
-humantime = "2.1.0"
 reqwest = { workspace = true, default-features = false, features = ["rustls-tls"] }
+orb-s3-helpers.workspace = true
 secrecy.workspace = true
 tempfile = "3"
 thiserror.workspace = true

--- a/nix/shells/development.nix
+++ b/nix/shells/development.nix
@@ -59,8 +59,8 @@ in
         cargo-deb # Generates .deb packages for orb-os
         cargo-deny # Checks licenses and security advisories
         cargo-expand # Useful for inspecting macros
+        cargo-watch # Useful for repeatedly running tests
         cargo-zigbuild # Used to cross compile rust
-        squashfsTools # mksquashfs
         dpkg # Used to test outputs of cargo-deb
         git-cliff # Conventional commit based release notes
         mdbook # Generates site for docs
@@ -69,6 +69,7 @@ in
         nushell # Cross platform shell for scripts
         protobuf # Needed for orb-messages and other protobuf dependencies
         python3
+        squashfsTools # mksquashfs
         sshpass # Needed for orb-software/scripts 
         zbus-xmlgen # Used by `orb-zbus-proxies`
         zig # Needed for cargo zigbuild

--- a/s3-helpers/Cargo.toml
+++ b/s3-helpers/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "orb-s3-helpers"
+description = "helpers for working with s3"
+version = "0.0.0"
+publish = false
+
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+async-stream.workspace = true
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+color-eyre.workspace = true
+futures.workspace = true
+testcontainers-modules = { workspace = true, features = ["localstack"] }
+testcontainers.workspace = true
+tokio = { workspace = true, features = ["full"] } # TODO: narrow this
+tracing.workspace = true
+
+[dev-dependencies]
+clap = { workspace = true, features = ["derive"] }
+orb-telemetry = { workspace = true, default-features = false }
+test-with.workspace = true

--- a/s3-helpers/README.md
+++ b/s3-helpers/README.md
@@ -1,0 +1,5 @@
+# orb-s3-helpers
+
+Helper crate for common things we need to do with s3
+
+Right now, used by orb-hil and orb-bidiff-squashfs-cli.

--- a/s3-helpers/examples/list.rs
+++ b/s3-helpers/examples/list.rs
@@ -1,0 +1,38 @@
+use clap::Parser;
+use color_eyre::{eyre::Context as _, Result};
+use futures::TryStreamExt as _;
+use orb_s3_helpers::{ClientExt as _, S3Uri};
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    let flusher = orb_telemetry::TelemetryConfig::new().init();
+
+    let args = Command::parse();
+    let result = run(args).await;
+
+    flusher.flush().await;
+
+    result
+}
+
+#[derive(Debug, Parser)]
+struct Command {
+    /// The s3 uri prefix to sync
+    #[clap(long)]
+    prefix: S3Uri,
+}
+
+async fn run(args: Command) -> Result<()> {
+    let client = orb_s3_helpers::client()
+        .await
+        .wrap_err("failed to initialize client")?;
+
+    let mut stream = client.list_prefix(args.prefix);
+    while let Some(obj) = stream.try_next().await? {
+        info!("{obj:?}");
+    }
+
+    Ok(())
+}

--- a/s3-helpers/src/client.rs
+++ b/s3-helpers/src/client.rs
@@ -1,0 +1,65 @@
+use aws_config::{
+    meta::{credentials::CredentialsProviderChain, region::RegionProviderChain},
+    retry::RetryConfig,
+    stalled_stream_protection::StalledStreamProtectionConfig,
+    BehaviorVersion,
+};
+use aws_sdk_s3::{config::ProvideCredentials, types::Object};
+use color_eyre::{eyre::WrapErr as _, Result, Section as _};
+use futures::TryStream;
+use tracing::info;
+
+use crate::s3_url_parts::S3Uri;
+
+const TIMEOUT_RETRY_ATTEMPTS: u32 = 5;
+
+/// Helper function for setting up aws credentials.
+pub async fn client() -> Result<aws_sdk_s3::Client> {
+    let region_provider = RegionProviderChain::default_provider().or_else("us-east-1");
+    let region = region_provider.region().await.expect("infallible");
+    info!("using aws region: {region}");
+    let credentials_provider = CredentialsProviderChain::default_provider().await;
+    let _creds = credentials_provider
+        .provide_credentials()
+        .await
+        .wrap_err("failed to get aws credentials")
+        .with_note(|| {
+            format!("AWS_PROFILE env var was {:?}", std::env::var("AWS_PROFILE"))
+        })
+        .with_suggestion(|| {
+            "make sure that your aws credentials are set. Follow the instructions at
+            https://worldcoin.github.io/orb-software/hil/cli."
+        })
+        .with_suggestion(|| "try running `AWS_PROFILE=hil aws sso login`")?;
+
+    let retry_config =
+        RetryConfig::standard().with_max_attempts(TIMEOUT_RETRY_ATTEMPTS);
+
+    let config = aws_config::defaults(BehaviorVersion::v2024_03_28())
+        .region(region_provider)
+        .credentials_provider(credentials_provider)
+        .retry_config(retry_config)
+        .stalled_stream_protection(StalledStreamProtectionConfig::disabled())
+        .load()
+        .await;
+
+    Ok(aws_sdk_s3::Client::new(&config))
+}
+
+/// Extension trait with several utility helper functions using the aws client.
+pub trait ClientExt {
+    /// Lists all s3 objects under some prefix.
+    fn list_prefix(
+        &self,
+        s3_prefix: S3Uri,
+    ) -> impl TryStream<Ok = Object, Error = color_eyre::Report> + Send + Unpin;
+}
+
+impl ClientExt for aws_sdk_s3::Client {
+    fn list_prefix(
+        &self,
+        s3_prefix: S3Uri,
+    ) -> impl TryStream<Ok = Object, Error = color_eyre::Report> + Send + Unpin {
+        crate::list_prefix::list_prefix(self, s3_prefix)
+    }
+}

--- a/s3-helpers/src/lib.rs
+++ b/s3-helpers/src/lib.rs
@@ -1,0 +1,15 @@
+mod client;
+mod list_prefix;
+mod s3_url_parts;
+
+pub use crate::client::{client, ClientExt};
+pub use crate::s3_url_parts::S3Uri;
+
+/// Whether to overwrite existing files or error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExistingFileBehavior {
+    /// If a file exists, overwrite it
+    Overwrite,
+    /// If a file exists, abort
+    Abort,
+}

--- a/s3-helpers/src/list_prefix.rs
+++ b/s3-helpers/src/list_prefix.rs
@@ -1,0 +1,31 @@
+use aws_sdk_s3::{types::Object, Client};
+use color_eyre::eyre::WrapErr as _;
+use futures::TryStream;
+
+use crate::s3_url_parts::S3Uri;
+
+/// See [`crate::ClientExt::list_prefix`].
+pub(crate) fn list_prefix(
+    client: &Client,
+    s3_prefix: S3Uri,
+) -> impl TryStream<Ok = Object, Error = color_eyre::Report> + Send + Unpin {
+    // List objects in the bucket with the given prefix
+    let mut paginator = client
+        .list_objects_v2()
+        .bucket(&s3_prefix.bucket)
+        .prefix(&s3_prefix.key)
+        .into_paginator()
+        .send();
+
+    // Pin it here just to make people's lives easier elsewhere
+    Box::pin(async_stream::try_stream! {
+        // Process each page of objects
+        while let Some(page) = paginator.next().await {
+            let page = page.wrap_err("error while listing s3 objects")?;
+            for obj in page.contents() {
+                let obj = obj.to_owned();
+                yield obj;
+            }
+        }
+    })
+}

--- a/s3-helpers/src/s3_url_parts.rs
+++ b/s3-helpers/src/s3_url_parts.rs
@@ -1,0 +1,147 @@
+use std::{fmt::Display, str::FromStr};
+
+use color_eyre::eyre::OptionExt as _;
+
+/// A parsed s3 uri
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct S3Uri {
+    pub bucket: String,
+    pub key: String,
+}
+
+impl S3Uri {
+    pub fn is_dir(&self) -> bool {
+        self.key.ends_with('/') || self.key.is_empty()
+    }
+}
+
+impl FromStr for S3Uri {
+    type Err = color_eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (bucket, key) = s
+            .strip_prefix("s3://")
+            .ok_or_eyre("must be a url that starts with `s3://`")?
+            .split_once('/')
+            .ok_or_eyre("expected s3://<bucket>/<key>")?;
+        Ok(Self {
+            bucket: bucket.to_owned(),
+            key: key.to_owned(),
+        })
+    }
+}
+
+impl Display for S3Uri {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "s3://{}/{}", self.bucket, self.key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_prefix_ends_in_slash() {
+        let url = "s3://my-bucket/the/prefix/";
+        let parts = S3Uri::from_str(url).unwrap();
+        assert_eq!(
+            parts,
+            S3Uri {
+                bucket: "my-bucket".to_string(),
+                key: "the/prefix/".to_string(),
+            }
+        );
+        assert!(parts.is_dir());
+        assert_eq!(url, parts.to_string())
+    }
+
+    #[test]
+    fn test_valid_simple_s3_url() {
+        let url = "s3://my-bucket/my-key";
+        let parts = S3Uri::from_str(url).unwrap();
+        assert_eq!(
+            parts,
+            S3Uri {
+                bucket: "my-bucket".to_string(),
+                key: "my-key".to_string(),
+            }
+        );
+        assert!(!parts.is_dir());
+        assert_eq!(url, parts.to_string())
+    }
+
+    #[test]
+    fn test_valid_s3_url_with_complex_key() {
+        let url = "s3://my-bucket/path/to/my/object.json";
+        let parts = S3Uri::from_str(url).unwrap();
+        assert_eq!(
+            parts,
+            S3Uri {
+                bucket: "my-bucket".to_string(),
+                key: "path/to/my/object.json".to_string(),
+            }
+        );
+        assert!(!parts.is_dir());
+        assert_eq!(url, parts.to_string())
+    }
+
+    #[test]
+    fn test_valid_s3_url_with_special_chars() {
+        let url = "s3://my-bucket-123/my_key-123.txt";
+        let parts = S3Uri::from_str(url).unwrap();
+        assert_eq!(
+            parts,
+            S3Uri {
+                bucket: "my-bucket-123".to_string(),
+                key: "my_key-123.txt".to_string(),
+            }
+        );
+        assert!(!parts.is_dir());
+        assert_eq!(url, parts.to_string())
+    }
+
+    #[test]
+    fn test_empty_key() {
+        let url = "s3://my-bucket/";
+        let parts = S3Uri::from_str(url).unwrap();
+        assert_eq!(
+            parts,
+            S3Uri {
+                bucket: "my-bucket".to_string(),
+                key: "".to_string(),
+            }
+        );
+        assert!(parts.is_dir());
+        assert_eq!(url, parts.to_string())
+    }
+
+    #[test]
+    fn test_missing_s3_prefix() {
+        let url = "my-bucket/my-key";
+        let result = S3Uri::from_str(url);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_slash_after_bucket() {
+        let url = "s3://my-bucket";
+        let result = S3Uri::from_str(url);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_string() {
+        let url = "";
+        let result = S3Uri::from_str(url);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_only_s3_prefix() {
+        let url = "s3://";
+        let result = S3Uri::from_str(url);
+        assert!(result.is_err());
+    }
+}

--- a/s3-helpers/tests/common/mod.rs
+++ b/s3-helpers/tests/common/mod.rs
@@ -1,0 +1,95 @@
+//! Helpers for tests.
+//!
+//! A lot of this was adapted from
+//! <https://github.com/testcontainers/testcontainers-rs-modules-community/blob/0b83d15d052f274e84fffaba4f49b5530c550169/examples/localstack.rs>
+
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_s3 as s3;
+use color_eyre::{eyre::Context as _, Result};
+use orb_s3_helpers::S3Uri;
+use testcontainers::{runners::AsyncRunner as _, ContainerAsync, ImageExt as _};
+use testcontainers_modules::localstack::LocalStack;
+
+#[derive(Debug)]
+pub struct TestCtx {
+    client: s3::Client,
+    _localstack: ContainerAsync<LocalStack>,
+}
+
+impl TestCtx {
+    pub async fn new() -> Result<Self> {
+        let request = LocalStack::default().with_env_var("SERVICES", "s3");
+        let container = request
+            .start()
+            .await
+            .wrap_err("failed to start testcontainer for localstack")?;
+
+        let host_ip = container.get_host().await?;
+        let host_port = container.get_host_port_ipv4(4566).await?;
+        // Set up AWS client
+        let endpoint_url = format!("http://{host_ip}:{host_port}");
+
+        // TODO(@thebutlah): See if we can/should use aws_config
+        // TODO(@thebutlah): See if we should instead make a general purpose test
+        // helper for spinning up not just s3 but a variety of clients from a localstack.
+        let creds = s3::config::Credentials::new("fake", "fake", None, None, "test");
+
+        let config = s3::config::Builder::default()
+            .behavior_version(BehaviorVersion::v2024_03_28())
+            .region(Region::new("us-east-1"))
+            .credentials_provider(creds)
+            .endpoint_url(endpoint_url)
+            .force_path_style(true)
+            .build();
+
+        let client = s3::Client::from_conf(config);
+
+        Ok(Self {
+            client,
+            _localstack: container,
+        })
+    }
+
+    pub fn client(&self) -> &s3::Client {
+        &self.client
+    }
+
+    pub async fn mk_bucket(&self, name: &str) -> Result<S3Uri> {
+        let uri = S3Uri {
+            bucket: name.to_owned(),
+            key: String::new(),
+        };
+        self.client
+            .create_bucket()
+            .bucket(name)
+            .send()
+            .await
+            .wrap_err_with(|| format!("failed to create bucket at {uri}"))?;
+
+        Ok(uri)
+    }
+
+    pub async fn mk_object(
+        &self,
+        bucket: &str,
+        key: &str,
+        contents: Option<Vec<u8>>,
+    ) -> Result<S3Uri> {
+        let uri = S3Uri {
+            bucket: bucket.to_owned(),
+            key: key.to_owned(),
+        };
+        let builder = self.client.put_object().bucket(bucket).key(key);
+        let builder = if let Some(contents) = contents {
+            builder.body(contents.into())
+        } else {
+            builder
+        };
+        builder
+            .send()
+            .await
+            .wrap_err_with(|| format!("failed to create object at {uri}"))?;
+
+        Ok(uri)
+    }
+}

--- a/s3-helpers/tests/list_prefix.rs
+++ b/s3-helpers/tests/list_prefix.rs
@@ -1,0 +1,77 @@
+mod common;
+
+use aws_sdk_s3::types::Object;
+use color_eyre::{Report, Result};
+use futures::TryStreamExt as _;
+use orb_s3_helpers::ClientExt;
+
+use common::TestCtx;
+
+// No docker in macos on github
+#[cfg_attr(target_os = "macos", test_with::no_env(GITHUB_ACTIONS))]
+#[tokio::test]
+async fn test_list_prefix() -> Result<()> {
+    color_eyre::install()?;
+    let ctx = TestCtx::new().await?;
+    let client = ctx.client();
+
+    // Assert
+    let _: Report = client
+        .list_prefix("s3://nonexistant/".parse().unwrap())
+        .try_next()
+        .await
+        .expect_err("nonexistant buckets should not list");
+
+    // Act
+    const NEW_BUCKET: &str = "new-bucket";
+    ctx.mk_bucket(NEW_BUCKET).await?;
+    const KEY_A: &str = "A";
+    ctx.mk_object(NEW_BUCKET, KEY_A, None).await?;
+
+    // Assert
+    let objs: Vec<Object> = client
+        .list_prefix(format!("s3://{NEW_BUCKET}/").parse().unwrap())
+        .try_collect()
+        .await
+        .expect("there is a matching bucket");
+    assert_eq!(objs.len(), 1, "only 1 matching object");
+    assert_eq!(objs[0].key.as_deref(), Some(KEY_A), "key should match");
+    let _: Report = client
+        .list_prefix("s3://nonexistant/".parse().unwrap())
+        .try_next()
+        .await
+        .expect_err("nonexistant buckets should not list");
+
+    // Act
+    const KEY_B: &str = "B";
+    ctx.mk_object(NEW_BUCKET, KEY_B, None).await?;
+
+    // Assert
+    let objs: Vec<Object> = client
+        .list_prefix(format!("s3://{NEW_BUCKET}/").parse().unwrap())
+        .try_collect()
+        .await
+        .expect("there is a matching bucket");
+    assert_eq!(objs.len(), 2, "only 2 matching objects");
+    assert_eq!(
+        objs.iter()
+            .filter(|o| o.key.as_deref() == Some(KEY_A))
+            .count(),
+        1,
+        "only one A should match"
+    );
+    assert_eq!(
+        objs.iter()
+            .filter(|o| o.key.as_deref() == Some(KEY_B))
+            .count(),
+        1,
+        "only one B should match"
+    );
+    let _: Report = client
+        .list_prefix("s3://nonexistant/".parse().unwrap())
+        .try_next()
+        .await
+        .expect_err("nonexistant buckets should not list");
+
+    Ok(())
+}


### PR DESCRIPTION
Introduces the orb-s3-helpers crate to consolidate some common s3 related code between orb-hil and orb-bidiff-squashfs-cli.

Also introduces localstack for testing operations against s3, and implements list_prefix which will be used as part of orb-bidiff-squashfs-cli to download directories of s3 objects.