### PR TITLE
fix(bidiff-squashfs): run destructors on ota subcommand

### DIFF
--- a/bidiff-squashfs/cli/src/diff_ota.rs
+++ b/bidiff-squashfs/cli/src/diff_ota.rs
@@ -1,9 +1,17 @@
 use color_eyre::Result;
 use std::path::Path;
 
+use tokio_util::sync::CancellationToken;
+
 /// Preconditions:
 /// - `out_dir` should be an empty directory.
-pub fn diff_ota(_base_dir: &Path, _top_dir: &Path, out_dir: &Path) -> Result<()> {
+pub fn diff_ota(
+    _base_dir: &Path,
+    _top_dir: &Path,
+    out_dir: &Path,
+    cancel: CancellationToken,
+) -> Result<()> {
+    let _cancel_guard = cancel.drop_guard();
     assert!(out_dir.is_dir(), "only directories should be provided");
     assert!(out_dir.exists(), "out_dir should exist");
 


### PR DESCRIPTION
listen for ctrl-c on ota subcommand only. We only do that one because its the only one right now that is actually async. This lets us clean up temp dirs and run destructors.