### PR TITLE
feat(backend-status): FM-405-orbsoft-backend-status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5405,6 +5405,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "orb-backend-status"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "color-eyre",
+ "dbus-launch",
+ "eyre",
+ "orb-backend-status-dbus",
+ "orb-build-info 0.0.0",
+ "orb-endpoints",
+ "orb-info",
+ "orb-telemetry",
+ "orb-update-agent-dbus",
+ "reqwest 0.12.12",
+ "reqwest-middleware",
+ "reqwest-tracing",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "serial_test 3.2.0",
+ "thiserror 1.0.65",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zbus",
+ "zbus_systemd",
+]
+
+[[package]]
+name = "orb-backend-status-dbus"
+version = "0.0.0"
+dependencies = [
+ "derive_more",
+ "serde",
+ "zbus",
+]
+
+[[package]]
 name = "orb-bidiff-squashfs"
 version = "0.0.0"
 dependencies = [
@@ -7202,6 +7241,37 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.26.7",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http 1.2.0",
+ "reqwest 0.12.12",
+ "serde",
+ "thiserror 1.0.65",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c88a8d9cfe3319b5adc10f3ffc3db75c7346837a1f857f8269f6361f3b2744"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom",
+ "http 1.2.0",
+ "matchit 0.8.4",
+ "reqwest 0.12.12",
+ "reqwest-middleware",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ members = [
   "attest",
   "attest/dbus",
   "backend-state",
+  "backend-status",
+  "backend-status/dbus",
   "bidiff-squashfs/cli",
   "bidiff-squashfs/lib",
   "bidiff-squashfs/shim",
@@ -129,6 +131,7 @@ zenoh = "1.0.3"
 can-rs.path = "can"
 license-stub-libsquashfs1.path = "license-stubs/libsquashfs1"
 orb-attest-dbus.path = "attest/dbus"
+orb-backend-status-dbus.path = "backend-status/dbus"
 orb-bidiff-squashfs-cli.path = "bidiff-squashfs/cli"
 orb-bidiff-squashfs-shim.path = "bidiff-squashfs/shim"
 orb-bidiff-squashfs.path = "bidiff-squashfs/lib"

--- a/backend-status/Cargo.toml
+++ b/backend-status/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+name        = "orb-backend-status"
+version     = "0.0.0"
+description = "Systemd service that receives orb status and periodicallyprovides it to the Orb backend"
+authors     = ["Paul Quinn <paulquinn00@users.noreply.github.com>"]
+publish     = false
+
+edition      = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+chrono                  = { workspace = true, features = ["serde"] }
+clap                    = { workspace = true, features = ["derive", "env"] }
+color-eyre              = { workspace = true }
+eyre                    = { workspace = true }
+orb-backend-status-dbus = { workspace = true }
+orb-build-info          = { workspace = true }
+orb-endpoints           = { workspace = true }
+orb-info                = { workspace = true, features = ["async", "orb-id", "orb-jabil-id", "orb-name", "orb-token"] }
+orb-telemetry           = { workspace = true }
+orb-update-agent-dbus   = { workspace = true }
+reqwest                 = { workspace = true, features = ["json"] }
+reqwest-middleware      = "0.4.0"
+reqwest-tracing         = "0.5.6"
+serde                   = { workspace = true, features = ["derive"] }
+serde_json              = { workspace = true }
+serde_with              = "3.11.0"
+thiserror               = { workspace = true }
+tokio                   = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }
+tokio-util              = { workspace = true }
+tracing                 = { workspace = true, features = ["attributes"] }
+zbus                    = { workspace = true, default-features = false, features = ["tokio"] }
+
+[dev-dependencies]
+dbus-launch  = { workspace = true }
+eyre         = { workspace = true }
+serial_test  = { workspace = true }
+tokio        = { workspace = true }
+zbus_systemd = { workspace = true }
+
+[build-dependencies]
+orb-build-info = { workspace = true, features = ["build-script"] }
+
+[package.metadata.deb]
+assets             = [["target/release/orb-backend-status", "/usr/local/bin/", "755"]]
+maintainer-scripts = "debian/"
+systemd-units      = [{ unit-name = "worldcoin-backend-status" }]

--- a/backend-status/README.md
+++ b/backend-status/README.md
@@ -1,0 +1,5 @@
+# orb-backend-status
+
+This daemon provide a dbus sink to collect status from varous orb systems and periodically provide them to the Orb Fleet Backend.
+
+If you are on mac, be sure that you installed dbus. See the toplevel [README.md]

--- a/backend-status/build.rs
+++ b/backend-status/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    orb_build_info::initialize().expect("failed to initialize build info")
+}

--- a/backend-status/dbus/Cargo.toml
+++ b/backend-status/dbus/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name        = "orb-backend-status-dbus"
+version     = "0.0.0"
+authors     = ["Paul Quinn <paulquinn00@users.noreply.github.com>"]
+description = "Dbus proxy and interface for orb-backend-status"
+publish     = false
+
+edition      = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+zbus        = { workspace = true }
+derive_more = { workspace = true, features = ["deref", "deref_mut", "from"] }
+serde       = { workspace = true }

--- a/backend-status/dbus/src/lib.rs
+++ b/backend-status/dbus/src/lib.rs
@@ -1,0 +1,38 @@
+//! Receives status updates from the orb for the backend service
+
+use serde::{Deserialize, Serialize};
+use zbus::{
+    interface,
+    zvariant::{OwnedValue, Type, Value},
+};
+
+pub trait BackendStatusIface: Send + Sync + 'static {
+    fn provide_wifi_networks(&mut self, wifi_networks: Vec<WifiNetwork>);
+}
+
+#[derive(Debug, derive_more::From)]
+pub struct BackendStatus<T>(pub T);
+
+#[interface(
+    name = "org.worldcoin.BackendStatus1",
+    proxy(
+        default_service = "org.worldcoin.BackendStatus1",
+        default_path = "/org/worldcoin/BackendStatus1",
+    )
+)]
+impl<T: BackendStatusIface> BackendStatusIface for BackendStatus<T> {
+    fn provide_wifi_networks(&mut self, wifi_networks: Vec<WifiNetwork>) {
+        self.0.provide_wifi_networks(wifi_networks)
+    }
+}
+
+#[derive(
+    Debug, Serialize, Deserialize, Type, Clone, Eq, PartialEq, Value, OwnedValue,
+)]
+pub struct WifiNetwork {
+    pub bssid: String,
+    pub frequency: u32,
+    pub signal_level: i32,
+    pub flags: String,
+    pub ssid: String,
+}

--- a/backend-status/debian/orb-backend-status.worldcoin-backend-status.service
+++ b/backend-status/debian/orb-backend-status.worldcoin-backend-status.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Worldcoin Backend Status
+Requires=worldcoin-backend-online.target
+After=wordcoin-backend-online.target
+
+[Service]
+Type=simple
+User=worldcoin
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
+Environment=RUST_BACKTRACE=1
+SyslogIdentifier=worldcoin-backend-status
+ExecStart=/usr/local/bin/orb-backend-status
+
+[Install]
+WantedBy=multi-user.target

--- a/backend-status/src/args.rs
+++ b/backend-status/src/args.rs
@@ -1,0 +1,41 @@
+use clap::{
+    builder::{styling::AnsiColor, Styles},
+    Parser,
+};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::BUILD_INFO;
+
+#[derive(Debug, Parser, Serialize, Deserialize)]
+#[clap(
+    version = BUILD_INFO.version,
+    about,
+    styles = clap_v3_styles(),
+)]
+#[skip_serializing_none]
+pub struct Args {
+    /// The path to the config file.
+    #[clap(long)]
+    pub config: Option<String>,
+    /// The orb id.
+    #[clap(long, env = "ORB_ID", default_value = None)]
+    pub orb_id: Option<String>,
+    /// The orb token.
+    #[clap(long, env = "ORB_TOKEN", default_value = None)]
+    pub orb_token: Option<String>,
+    /// The backend to use.
+    #[clap(long, env = "ORB_BACKEND", default_value = "stage")]
+    pub backend: String,
+    /// status update interval in seconds.
+    #[clap(long, env = "STATUS_UPDATE_INTERVAL", default_value = "10")]
+    pub status_update_interval: u64,
+}
+
+fn clap_v3_styles() -> Styles {
+    Styles::styled()
+        .header(AnsiColor::Yellow.on_default())
+        .usage(AnsiColor::Green.on_default())
+        .literal(AnsiColor::Green.on_default())
+        .placeholder(AnsiColor::Green.on_default())
+}

--- a/backend-status/src/backend/mod.rs
+++ b/backend-status/src/backend/mod.rs
@@ -1,0 +1,2 @@
+mod models;
+pub mod status;

--- a/backend-status/src/backend/models.rs
+++ b/backend-status/src/backend/models.rs
@@ -1,0 +1,49 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OrbStatusV2 {
+    pub orb_id: Option<String>,
+    pub location_data: Option<LocationDataV2>,
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LocationDataV2 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wifi: Option<Vec<WifiDataV2>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cell: Option<Vec<CellDataV2>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WifiDataV2 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ssid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bssid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal_strength: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal_to_noise_ratio: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CellDataV2 {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcc: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mnc: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lac: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signal_strength: Option<i32>,
+}

--- a/backend-status/src/backend/status.rs
+++ b/backend-status/src/backend/status.rs
@@ -1,0 +1,287 @@
+use chrono::Utc;
+use eyre::Result;
+use orb_endpoints::{v2::Endpoints as EndpointsV2, Backend};
+use orb_info::{OrbId, TokenTaskHandle};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
+use reqwest_tracing::{OtelName, TracingMiddleware};
+use std::{str::FromStr, sync::Arc, time::Duration};
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+use zbus::Connection;
+
+use crate::{args::Args, dbus::CurrentStatus};
+
+use super::models::{LocationDataV2, OrbStatusV2, WifiDataV2};
+
+#[derive(Debug, Clone)]
+pub struct StatusClient {
+    client: ClientWithMiddleware,
+    orb_id: OrbId,
+    auth_token: watch::Receiver<String>,
+    _token_task: Option<Arc<TokenTaskHandle>>,
+}
+
+impl StatusClient {
+    pub async fn new(args: &Args, shutdown_token: CancellationToken) -> Result<Self> {
+        let reqwest_client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(60))
+            .user_agent("orb-backend-status")
+            .build()
+            .expect("Failed to build client");
+        let client = ClientBuilder::new(reqwest_client)
+            .with_init(Extension(OtelName(
+                format!("orb_{}", args.orb_id.as_ref().unwrap()).into(),
+            )))
+            .with(TracingMiddleware::default())
+            .build();
+
+        // Get token from args or DBus
+        let mut _token_task: Option<Arc<TokenTaskHandle>> = None;
+        let auth_token = if let Some(token) = args.orb_token.clone() {
+            let (_, receiver) = watch::channel(token);
+            receiver
+        } else {
+            let connection = Connection::session().await?;
+            _token_task = Some(Arc::new(
+                TokenTaskHandle::spawn(&connection, &shutdown_token).await?,
+            ));
+            _token_task.as_ref().unwrap().token_recv.to_owned()
+        };
+
+        let orb_id = OrbId::from_str(args.orb_id.as_ref().unwrap())?;
+
+        Ok(Self {
+            client,
+            orb_id,
+            auth_token,
+            _token_task,
+        })
+    }
+
+    pub async fn send_status(&self, current_status: &CurrentStatus) -> Result<String> {
+        let request = build_status_request_v2(&self.orb_id, current_status)?;
+
+        // Check for ORB_BACKEND environment variable first to provide a better error message
+        let backend = match Backend::from_env() {
+            Ok(backend) => backend,
+            Err(e) => {
+                error!("Error getting backend configuration: {}", e);
+                return Err(eyre::eyre!("Failed to initialize backend from environment: {}. Make sure ORB_BACKEND is set correctly.", e));
+            }
+        };
+
+        let endpoint = EndpointsV2::new(backend, &self.orb_id).status;
+
+        // Try to get auth token
+        let auth_token = self.auth_token.borrow().clone();
+
+        // Build request with optional authentication
+        let request_builder = self
+            .client
+            .post(endpoint)
+            .body(serde_json::to_string(&request).unwrap())
+            .header("Content-Type", "application/json")
+            .basic_auth(self.orb_id.to_string(), Some(auth_token));
+
+        // Send the request with retries
+        let mut response = None;
+        let mut last_error = None;
+
+        match request_builder.try_clone().unwrap().send().await {
+            Ok(resp) => {
+                response = Some(resp);
+            }
+            Err(e) => {
+                error!("Network error while sending status request: {}", e);
+                last_error = Some(e);
+            }
+        }
+
+        let response = match response {
+            Some(resp) => resp,
+            None => {
+                let err = last_error.unwrap();
+                error!("All retry attempts failed: {}", err);
+                return Err(err.into());
+            }
+        };
+
+        // Get status code and log it before checking for errors
+        let status = response.status();
+        info!(status_code = ?status, "Received HTTP status from backend");
+
+        // Get response body, regardless of status code
+        let response_body = match response.text().await {
+            Ok(body) => {
+                if body.is_empty() {
+                    info!("Response body is empty");
+                } else {
+                    info!(body_length = body.len(), "Received response body");
+                }
+                body
+            }
+            Err(e) => {
+                info!("Error reading response body: {}", e);
+                return Err(e.into());
+            }
+        };
+
+        // Check if the status code indicates an error
+        if !status.is_success() {
+            error!(
+                status_code = ?status,
+                response_body = ?response_body,
+                "Error response from status endpoint"
+            );
+
+            // Check for authentication errors specifically
+            if status.as_u16() == 401 || status.as_u16() == 403 {
+                return Err(eyre::eyre!(
+                "Authentication failed: {} - {}. Check that your auth token is valid.",
+                status,
+                response_body
+            ));
+            }
+
+            return Err(eyre::eyre!(
+                "Backend returned error status: {} - {}",
+                status,
+                response_body
+            ));
+        }
+
+        info!(
+            status_code = ?status,
+            body_length = response_body.len(),
+            "Successful response from status endpoint"
+        );
+
+        Ok(response_body)
+    }
+}
+
+fn build_status_request_v2(
+    orb_id: &OrbId,
+    current_status: &CurrentStatus,
+) -> Result<OrbStatusV2> {
+    let location_data = LocationDataV2 {
+        wifi: current_status.wifi_networks.as_ref().map(|wifi_networks| {
+            wifi_networks
+                .iter()
+                .map(|w| WifiDataV2 {
+                    ssid: Some(w.ssid.clone()),
+                    bssid: Some(w.bssid.clone()),
+                    signal_strength: Some(w.signal_level),
+                    channel: freq_to_channel(w.frequency),
+                    signal_to_noise_ratio: None,
+                })
+                .collect()
+        }),
+        cell: None,
+    };
+
+    Ok(OrbStatusV2 {
+        orb_id: Some(orb_id.to_string()),
+        location_data: Some(location_data),
+        timestamp: Utc::now(),
+    })
+}
+
+// Helper function to convert frequency to channel number
+fn freq_to_channel(freq: u32) -> Option<u32> {
+    // For 2.4 GHz: channel = (freq - 2412) / 5 + 1
+    if (2412..=2484).contains(&freq) {
+        if freq == 2484 {
+            // Special case for channel 14
+            return Some(14);
+        }
+        return Some((freq - 2412) / 5 + 1);
+    }
+
+    // For 5 GHz: varies by region, but generally channel = (freq - 5000) / 5
+    if (5170..=5825).contains(&freq) {
+        return Some((freq - 5000) / 5);
+    }
+
+    // For 6 GHz (Wi-Fi 6E): channel = (freq - 5950) / 5 + 1
+    if (5955..=7115).contains(&freq) {
+        return Some((freq - 5950) / 5 + 1);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use orb_backend_status_dbus::WifiNetwork;
+    use orb_info::OrbId;
+
+    #[test]
+    fn test_build_status_request_v2() {
+        let orb_id = OrbId::from_str("abcdef12").unwrap();
+
+        let wifi_networks = vec![WifiNetwork {
+            bssid: "00:11:22:33:44:55".into(),
+            frequency: 2412,
+            signal_level: -45,
+            flags: "[WPA2-PSK-CCMP][ESS]".into(),
+            ssid: "TestAP".into(),
+        }];
+
+        let request = build_status_request_v2(
+            &orb_id,
+            &CurrentStatus {
+                wifi_networks: Some(wifi_networks),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(request.orb_id, Some("abcdef12".to_string()));
+        assert!(request.timestamp <= Utc::now());
+
+        let location_data = request
+            .location_data
+            .expect("Location data should be present");
+
+        assert!(
+            location_data.cell.is_none(),
+            "Cell data should not be present"
+        );
+
+        let wifi_data = location_data.wifi.expect("WiFi data should be present");
+        assert_eq!(wifi_data.len(), 1);
+        let wifi = &wifi_data[0];
+
+        assert_eq!(wifi.bssid, Some("00:11:22:33:44:55".to_string()));
+        assert_eq!(wifi.ssid, Some("TestAP".to_string()));
+        assert_eq!(wifi.signal_strength, Some(-45));
+        assert_eq!(wifi.channel, Some(1)); // 2412 MHz = channel 1
+        assert_eq!(wifi.signal_to_noise_ratio, None);
+    }
+
+    #[test]
+    fn test_freq_to_channel_conversion() {
+        // 2.4 GHz band
+        assert_eq!(freq_to_channel(2412), Some(1));
+        assert_eq!(freq_to_channel(2437), Some(6));
+        assert_eq!(freq_to_channel(2472), Some(13));
+        assert_eq!(freq_to_channel(2484), Some(14));
+
+        // 5 GHz band
+        assert_eq!(freq_to_channel(5180), Some(36));
+        assert_eq!(freq_to_channel(5500), Some(100));
+
+        // 6 GHz band
+        assert_eq!(freq_to_channel(5955), Some(2));
+        assert_eq!(freq_to_channel(6175), Some(46));
+
+        // Invalid frequencies
+        assert_eq!(freq_to_channel(1000), None);
+        assert_eq!(freq_to_channel(9000), None);
+    }
+}

--- a/backend-status/src/dbus.rs
+++ b/backend-status/src/dbus.rs
@@ -1,0 +1,153 @@
+use crate::{args::Args, backend::status::StatusClient};
+use color_eyre::eyre::{Result, WrapErr};
+use orb_backend_status_dbus::{BackendStatus, BackendStatusIface, WifiNetwork};
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tracing::error;
+use zbus::ConnectionBuilder;
+
+#[derive(Debug, Clone)]
+pub struct BackendStatusImpl {
+    last_update: Instant,
+    current_status: Arc<Mutex<Option<CurrentStatus>>>,
+    notify: Arc<Notify>,
+    shutdown_token: CancellationToken,
+    status_client: StatusClient,
+}
+
+#[derive(Debug, Default)]
+pub struct CurrentStatus {
+    pub wifi_networks: Option<Vec<WifiNetwork>>,
+    pub update_progress: Option<UpdateProgress>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct UpdateProgress {
+    pub download_progress: u64,
+    pub install_progress: u64,
+    pub fetched_progress: u64,
+    pub processed_progress: u64,
+    pub total_progress: u64,
+    pub errors: Option<String>,
+}
+
+impl BackendStatusIface for BackendStatusImpl {
+    fn provide_wifi_networks(&mut self, wifi_networks: Vec<WifiNetwork>) {
+        if let Ok(mut current_status) = self.current_status.lock() {
+            if let Some(current_status) = current_status.as_mut() {
+                current_status.wifi_networks = Some(wifi_networks);
+            } else {
+                *current_status = Some(CurrentStatus {
+                    wifi_networks: Some(wifi_networks),
+                    ..Default::default()
+                });
+            }
+            if self.last_update.elapsed() > Duration::from_secs(10) {
+                self.notify.notify_one();
+            }
+        }
+    }
+}
+
+impl BackendStatusImpl {
+    pub async fn new(
+        status_client: StatusClient,
+        shutdown_token: CancellationToken,
+    ) -> Self {
+        Self {
+            last_update: Instant::now(),
+            notify: Arc::new(Notify::new()),
+            shutdown_token,
+            status_client,
+            current_status: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    pub async fn wait_for_updates(
+        &mut self,
+        timeout: Duration,
+    ) -> Option<CurrentStatus> {
+        loop {
+            tokio::select! {
+                _ = self.notify.notified() => {
+                    if let Ok(mut current_status) = self.current_status.lock() {
+                        return current_status.take();
+                    }
+                }
+                _ = tokio::time::sleep(timeout) => {
+                    if let Ok(mut current_status) = self.current_status.lock() {
+                        return current_status.take();
+                    }
+                }
+                _ = self.shutdown_token.cancelled() => {
+                    return None;
+                }
+            }
+        }
+    }
+
+    pub fn provide_update_progress(&mut self, update_progress: UpdateProgress) {
+        if let Ok(mut current_status) = self.current_status.lock() {
+            if let Some(current_status) = current_status.as_mut() {
+                current_status.update_progress = Some(update_progress);
+            } else {
+                *current_status = Some(CurrentStatus {
+                    update_progress: Some(update_progress),
+                    ..Default::default()
+                });
+            }
+            if self.last_update.elapsed() > Duration::from_secs(10) {
+                self.notify.notify_one();
+            }
+        }
+    }
+
+    pub async fn send_current_status(&mut self, current_status: &CurrentStatus) {
+        match self.status_client.send_status(current_status).await {
+            Ok(_) => (),
+            Err(e) => {
+                error!("failed to send status: {e:?}");
+            }
+        };
+        self.last_update = Instant::now();
+    }
+}
+
+pub async fn setup_dbus(
+    args: &Args,
+    shutdown_token: CancellationToken,
+) -> Result<(BackendStatusImpl, zbus::Connection)> {
+    let backend_status_impl = BackendStatusImpl::new(
+        StatusClient::new(args, shutdown_token.clone()).await?,
+        shutdown_token.clone(),
+    )
+    .await;
+
+    let dbus_conn = ConnectionBuilder::session()
+        .wrap_err("failed creating a new session dbus connection")?
+        .name("org.worldcoin.BackendStatus")
+        .wrap_err(
+            "failed to register dbus connection name: `org.worldcoin.BackendStatus1``",
+        )?
+        .serve_at(
+            "/org/worldcoin/BackendStatus1",
+            BackendStatus::from(backend_status_impl.clone()),
+        )
+        .wrap_err("failed to serve dbus interface at `/org/worldcoin/BackendStatus1`")?
+        .build()
+        .await;
+
+    let dbus_conn = match dbus_conn {
+        Ok(conn) => conn,
+        Err(e) => {
+            error!("failed to setup dbus connection: {e:?}");
+            return Err(e.into());
+        }
+    };
+
+    Ok((backend_status_impl, dbus_conn))
+}

--- a/backend-status/src/main.rs
+++ b/backend-status/src/main.rs
@@ -1,0 +1,65 @@
+mod args;
+mod backend;
+mod dbus;
+mod update_progress;
+
+use std::time::Duration;
+
+use args::Args;
+use clap::Parser;
+use color_eyre::eyre::Result;
+use dbus::setup_dbus;
+use orb_build_info::{make_build_info, BuildInfo};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use update_progress::UpdateProgressWatcher;
+use zbus::Connection;
+
+const BUILD_INFO: BuildInfo = make_build_info!();
+
+const SYSLOG_IDENTIFIER: &str = "worldcoin-backend-status";
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+    let tel_flusher = orb_telemetry::TelemetryConfig::new()
+        .with_journald(SYSLOG_IDENTIFIER)
+        .init();
+
+    let args = Args::parse();
+    let result = run(&args).await;
+    tel_flusher.flush().await;
+    result
+}
+
+async fn run(args: &Args) -> Result<()> {
+    info!("Starting backend-status: {:?}", args);
+
+    let shutdown_token = CancellationToken::new();
+    let (mut backend_status_update, _dbus_conn) =
+        setup_dbus(args, shutdown_token.clone()).await?;
+
+    let connection = Connection::session().await?;
+    let mut update_progress_watcher = UpdateProgressWatcher::init(connection).await?;
+    loop {
+        tokio::select! {
+            current_status = backend_status_update.wait_for_updates(Duration::from_secs(args.status_update_interval)) => {
+                if let Some(current_status) = current_status {
+                    info!("Updating backend-status");
+                    backend_status_update.send_current_status(&current_status).await;
+                }
+            }
+            Ok(components) = update_progress_watcher.wait_for_updates() => {
+                info!("Updating progress");
+                backend_status_update.provide_update_progress(components);
+            }
+            _ = shutdown_token.cancelled() => {
+                info!("Shutting down backend-status initiated");
+                break;
+            }
+        }
+    }
+
+    info!("Shutting down backend-status completed");
+    Ok(())
+}

--- a/backend-status/src/update_progress.rs
+++ b/backend-status/src/update_progress.rs
@@ -1,0 +1,212 @@
+use orb_update_agent_dbus::{ComponentState, ComponentStatus};
+use thiserror::Error;
+use zbus::export::futures_util::StreamExt;
+use zbus::proxy::PropertyStream;
+use zbus::{proxy, Connection};
+
+use crate::dbus::UpdateProgress;
+
+#[proxy(
+    default_service = "org.worldcoin.UpdateAgentManager1",
+    default_path = "/org/worldcoin/UpdateAgentManager1",
+    interface = "org.worldcoin.UpdateAgentManager1"
+)]
+trait UpdateAgentManager {
+    #[zbus(property)]
+    fn progress(&self) -> zbus::Result<Vec<ComponentStatus>>;
+}
+
+pub struct UpdateProgressWatcher<'a> {
+    _update_agent_manager_proxy: UpdateAgentManagerProxy<'a>,
+    progress_update_stream: PropertyStream<'a, Vec<ComponentStatus>>,
+}
+
+#[derive(Debug, Error)]
+pub enum UpdateProgressErr {
+    #[error("failed to connect to dbus: {0}")]
+    DbusConnect(zbus::Error),
+    #[error("failed to perform RPC over dbus: {0}")]
+    DbusRPC(zbus::Error),
+}
+
+impl UpdateProgressWatcher<'_> {
+    pub async fn init(connection: Connection) -> Result<Self, UpdateProgressErr> {
+        let update_agent_manager_proxy = UpdateAgentManagerProxy::new(&connection)
+            .await
+            .map_err(UpdateProgressErr::DbusConnect)?;
+        let progress_update_stream =
+            update_agent_manager_proxy.receive_progress_changed().await;
+
+        Ok(Self {
+            _update_agent_manager_proxy: update_agent_manager_proxy,
+            progress_update_stream,
+        })
+    }
+
+    pub async fn wait_for_updates(
+        &mut self,
+    ) -> Result<UpdateProgress, UpdateProgressErr> {
+        if let Some(progress) = self.progress_update_stream.next().await {
+            let progress = progress.get().await.map_err(UpdateProgressErr::DbusRPC)?;
+            Ok(progress.into())
+        } else {
+            Err(UpdateProgressErr::DbusRPC(zbus::Error::Failure(
+                "Disconnected".to_string(),
+            )))
+        }
+    }
+}
+
+impl From<Vec<ComponentStatus>> for UpdateProgress {
+    fn from(components: Vec<ComponentStatus>) -> Self {
+        let total_progress = components.len() as u64 * 100;
+        if total_progress == 0 {
+            return UpdateProgress::default();
+        }
+        let download_progress = components
+            .iter()
+            .filter(|c| c.state == ComponentState::Downloading)
+            .map(|c| c.progress as u64)
+            .sum::<u64>();
+        let install_progress = components
+            .iter()
+            .filter(|c| c.state == ComponentState::Installed)
+            .map(|c| c.progress as u64)
+            .sum::<u64>();
+        let fetched_progress = components
+            .iter()
+            .filter(|c| c.state == ComponentState::Fetched)
+            .map(|c| c.progress as u64)
+            .sum::<u64>();
+        let processed_progress = components
+            .iter()
+            .filter(|c| c.state == ComponentState::Processed)
+            .map(|c| c.progress as u64)
+            .sum::<u64>();
+        UpdateProgress {
+            download_progress: (download_progress * 100) / total_progress,
+            install_progress: (install_progress * 100) / total_progress,
+            fetched_progress: (fetched_progress * 100) / total_progress,
+            processed_progress: (processed_progress * 100) / total_progress,
+            total_progress: (download_progress
+                + install_progress
+                + fetched_progress
+                + processed_progress)
+                * 100
+                / total_progress,
+            errors: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use eyre::{Result, WrapErr};
+    use orb_update_agent_dbus::UpdateAgentManagerT;
+    use std::sync::{Arc, Mutex};
+    use zbus::ConnectionBuilder;
+
+    type UpdateAgentManagerIface = orb_update_agent_dbus::UpdateAgentManager<Mocked>;
+
+    #[derive(Clone, Debug)]
+    struct Mocked {
+        progress: Arc<Mutex<Vec<ComponentStatus>>>,
+    }
+
+    // Note how we are simply implementing a trait from orb-attest-dbus instead of creating an entirely new struct with zbus macros.
+    // This ensures that the function signatures all match up and we get good compile errors and LSP support.
+    impl UpdateAgentManagerT for Mocked {
+        fn progress(&self) -> Vec<ComponentStatus> {
+            self.progress.lock().unwrap().clone()
+        }
+    }
+
+    // using `dbus_launch` ensures that all tests use their own isolated dbus, and that they can't influence each other.
+    async fn start_dbus_daemon() -> dbus_launch::Daemon {
+        tokio::task::spawn_blocking(|| {
+            dbus_launch::Launcher::daemon()
+                .launch()
+                .expect("failed to launch dbus-daemon")
+        })
+        .await
+        .expect("task panicked")
+    }
+
+    async fn setup_test_server(
+        progress: Vec<ComponentStatus>,
+    ) -> Result<(Connection, dbus_launch::Daemon, Mocked)> {
+        let mock_manager = Mocked {
+            progress: Arc::new(Mutex::new(progress)),
+        };
+        let daemon = start_dbus_daemon().await;
+
+        let connection = ConnectionBuilder::address(daemon.address())?
+            .name("org.worldcoin.UpdateAgentManager1")?
+            .serve_at(
+                "/org/worldcoin/UpdateAgentManager1",
+                orb_update_agent_dbus::UpdateAgentManager(mock_manager.clone()),
+            )?
+            .build()
+            .await?;
+
+        Ok((connection, daemon, mock_manager))
+    }
+
+    #[tokio::test]
+    async fn test_progress_update() -> Result<()> {
+        // Set up the test server
+        let (connection, daemon, _mock_manager) =
+            setup_test_server(vec![ComponentStatus {
+                name: "test".to_string(),
+                state: ComponentState::Downloading,
+                progress: 50,
+            }])
+            .await?;
+        let object_server = connection.object_server();
+        let iface_ref = object_server
+            .interface::<_, UpdateAgentManagerIface>(
+                "/org/worldcoin/UpdateAgentManager1",
+            )
+            .await
+            .wrap_err(
+                "failed to get reference to UpdateAgentManager1 from object server",
+            )?;
+
+        // Create a client connection to the same bus
+        let client_connection = ConnectionBuilder::address(daemon.address())?
+            .build()
+            .await
+            .wrap_err("failed to create client connection")?;
+
+        // Initialize the UpdateProgressWatcher
+        let mut watcher = UpdateProgressWatcher::init(client_connection)
+            .await
+            .wrap_err("failed to initialize UpdateProgressWatcher")?;
+
+        // Send the progress update signal
+        iface_ref
+            .get_mut()
+            .await
+            .progress_changed(iface_ref.signal_context())
+            .await
+            .wrap_err("failed to send progress_changed signal")?;
+
+        // Wait for the update to be received
+        let progress = watcher
+            .wait_for_updates()
+            .await
+            .wrap_err("failed to wait for updates")?;
+
+        // Verify the update was received correctly
+        assert_eq!(progress.download_progress, 50);
+        assert_eq!(progress.fetched_progress, 0);
+        assert_eq!(progress.install_progress, 0);
+        assert_eq!(progress.processed_progress, 0);
+        assert_eq!(progress.total_progress, 50);
+        assert_eq!(progress.errors, None);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Orb Backend Status daemon:
- centralized implementation to send status updates to Orb backend
- receives updates over dbus `/org/worldcoin/BackendStatus1`
- listens to Update Agent `/org/worldcoin/UpdateAgentManager1` to send progress updates to backend