### PR TITLE
refactor(bidiff-squashfs): simplify plan creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,7 +1766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "371c15a3c178d0117091bd84414545309ca979555b1aad573ef591ad58818d41"
 dependencies = [
  "cmd_lib_macros",
- "env_logger",
+ "env_logger 0.10.2",
  "faccess",
  "lazy_static",
  "log",
@@ -2650,6 +2650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2669,18 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -5480,6 +5501,7 @@ dependencies = [
  "orb-update-agent-core",
  "serde_json",
  "tempfile",
+ "test-log",
  "thiserror 1.0.65",
  "tokio",
  "tokio-util",
@@ -8509,6 +8531,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
+dependencies = [
+ "env_logger 0.11.2",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ serial_test = "3.2.0"
 serialport = "4.6.1"
 sha2 = "0.10.8"
 tempfile = "3.10.1"
+test-log = { version = "0.2.17", features = ["trace"] }
 test-with = { version = "0.14.8", default-features = false } # NOTE: Not hermetic.
 testcontainers = "0.23.3"
 testcontainers-modules = "0.11.6"

--- a/bidiff-squashfs/cli/Cargo.toml
+++ b/bidiff-squashfs/cli/Cargo.toml
@@ -31,5 +31,8 @@ tokio = { workspace = true, features = ["full"] } # todo: reduce features
 tokio-util.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+test-log.workspace = true
+
 [build-dependencies]
 orb-build-info = { workspace = true, features = ["build-script"] }

--- a/bidiff-squashfs/cli/src/diff_plan.rs
+++ b/bidiff-squashfs/cli/src/diff_plan.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
     pin::pin,
 };
 
@@ -10,17 +10,19 @@ use color_eyre::{
     eyre::{bail, ensure, WrapErr as _},
     Result,
 };
-use orb_update_agent_core::{LocalOrRemote, Source, UncheckedClaim};
+use orb_update_agent_core::{LocalOrRemote, MimeType, Source, UncheckedClaim};
 use tokio::{
     fs,
     io::{AsyncRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt as _},
 };
+use tracing::debug;
 
 const SQFS_MAGIC: [u8; 4] = *b"hsqs";
 const _: () = {
     // From https://dr-emann.github.io/squashfs/#superblock
     assert!(u32::from_le_bytes(SQFS_MAGIC) == 0x73717368);
 };
+const CLAIM_FILE: &str = "claim.json";
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone, derive_more::From)]
 pub struct ComponentId(pub String);
@@ -31,95 +33,206 @@ impl From<&str> for ComponentId {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Hash, Clone)]
-pub enum Operation {
-    Bidiff(ComponentId),
-    Copy(ComponentId),
-    Delete(ComponentId),
-    Create(ComponentId),
+/// Holds information about different sources.
+#[derive(Debug, Eq, PartialEq, Clone)]
+struct SourceInfo {
+    /// This is always relative to the OTA dir
+    path: PathBuf,
+    is_sqfs: bool,
+    mime: MimeType,
 }
 
+/// Represents a valid populated OTA directory, and information extracted from it.
+///
+/// This is an attempt to reduce the number of times we need to assert certain properties
+/// about directories and instead document these requirements at the type system level.
+/// It helps to consolidate all the complexity in one spot. It also helps to make
+/// plan creation entirely sans-io.
+///
+/// # Invariants enforced
+/// To construct this it must be a valid OTA directory. More concretely, the directory:
+/// - must exist
+/// - must be a directory
+/// - must have a `claim.json` that deserializes
+/// - all paths in the claim must point to files that actually exist.
+/// - all paths in the claim must be local urls that are relative to the claim location.
+// NOTE(@thebutlah): It was getting really confusing keeping track of filesystem state
+// until making this change.
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct DiffPlan(HashSet<Operation>);
+pub struct OtaDir {
+    dir: PathBuf,
+    /// The information extracted and validated about the different sources.
+    sources: HashMap<ComponentId, SourceInfo>,
+}
 
-impl DiffPlan {
-    pub async fn new(old_claim_path: &Path, new_claim_path: &Path) -> Result<Self> {
-        let old_claim =
-            fs::read_to_string(&old_claim_path)
-                .await
-                .wrap_err_with(|| {
-                    format!("missing claim at `{}`", old_claim_path.display())
-                })?;
-        let old_claim: UncheckedClaim = serde_json::from_str(&old_claim)
+impl OtaDir {
+    /// Construct an `OtaDir` from a path.
+    ///
+    /// Inspects the directory and performs IO to extract relevant info.
+    pub async fn new(dir: &Path) -> Result<Self> {
+        let claim_path = dir.join(CLAIM_FILE);
+        let claim_contents = fs::read_to_string(&claim_path)
+            .await
+            .wrap_err_with(|| format!("missing claim at `{}`", claim_path.display()))?;
+        let claim: UncheckedClaim = serde_json::from_str(&claim_contents)
             .wrap_err_with(|| {
-                format!(
-                    "failed to deserialize `{}` as claim",
-                    old_claim_path.display()
-                )
-            })?;
-        let new_claim =
-            fs::read_to_string(&new_claim_path)
-                .await
-                .wrap_err_with(|| {
-                    format!("missing claim at `{}`", new_claim_path.display())
-                })?;
-        let new_claim: UncheckedClaim = serde_json::from_str(&new_claim)
-            .wrap_err_with(|| {
-                format!(
-                    "failed to deserialize `{}` as claim",
-                    new_claim_path.display()
-                )
+                format!("failed to deserialize `{}` as claim", claim_path.display())
             })?;
 
-        let changes = ComponentChanges::new(
-            &old_claim
-                .sources
-                .keys()
-                .map(|id| ComponentId(id.to_owned()))
-                .collect(),
-            &new_claim
-                .sources
-                .keys()
-                .map(|id| ComponentId(id.to_owned()))
-                .collect(),
-        );
+        let mut sources = HashMap::new();
+        for (id, source) in &claim.sources {
+            let source_path_relative_to_ota_dir = relative_path_from_source(source)?;
+            let source_path = dir.join(&source_path_relative_to_ota_dir);
+            ensure!(
+                fs::try_exists(&source_path).await.unwrap_or(false),
+                "source {id} doesn't exist at `{source_path:?}`"
+            );
+            let source_file =
+                tokio::fs::File::open(&source_path)
+                    .await
+                    .wrap_err_with(|| {
+                        format!("failed to open component source at `{source_path:?}`")
+                    })?;
+            let is_sqfs = is_sqfs(source_file).await.wrap_err_with(|| {
+                format!("failed to read component source at `{source_path:?}`")
+            })?;
+            let mime = source.mime_type.clone();
+            let source_info = SourceInfo {
+                path: source_path_relative_to_ota_dir,
+                is_sqfs,
+                mime,
+            };
+            sources.insert(ComponentId(id.to_owned()), source_info);
+        }
 
-        let diffable = detect_bidiffable(
-            &old_claim.sources,
-            old_claim_path,
-            &new_claim.sources,
-            new_claim_path,
-        )
-        .await
-        .wrap_err("error while detecting diffable sources")?;
-        assert!(
-            diffable.is_subset(&changes.kept),
-            "sanity: only components that are kept could ever be diffable"
-        );
-        let copied: HashSet<ComponentId> = changes
-            .kept
-            .difference(&diffable)
-            .map(ToOwned::to_owned)
-            .collect();
-        assert!(
-            copied.is_disjoint(&diffable),
-            "sanity check: any kept component that we dont diff, we copy"
-        );
-
-        let mut result = HashSet::new();
-        result.extend(changes.created.into_iter().map(Operation::Create));
-        result.extend(changes.deleted.into_iter().map(Operation::Delete));
-        result.extend(copied.into_iter().map(Operation::Copy));
-        result.extend(diffable.into_iter().map(Operation::Bidiff));
-
-        Ok(Self(result))
+        Ok(Self {
+            dir: dir.to_path_buf(),
+            sources,
+        })
     }
 }
 
+/// Newtype on a [`PathBuf`]. Represents a desired location on the filesystem that
+/// the results of the final diffed OTA will be placed
+#[derive(Debug, Eq, PartialEq, Clone, Hash)]
+pub struct OutDir(PathBuf);
+
+impl OutDir {
+    pub fn new(dir: &Path) -> Self {
+        Self(dir.to_path_buf())
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+pub enum Operation {
+    Bidiff {
+        id: ComponentId,
+        old_path: PathBuf,
+        new_path: PathBuf,
+        out_path: PathBuf,
+    },
+    Copy {
+        id: ComponentId,
+        from_path: PathBuf,
+        to_path: PathBuf,
+    },
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct DiffPlan {
+    ops: HashSet<Operation>,
+}
+
+impl DiffPlan {
+    #[tracing::instrument(skip_all)]
+    pub fn new(old: &OtaDir, new: &OtaDir, out_dir: &OutDir) -> Self {
+        let changes = ComponentChanges::new(
+            &old.sources.keys().map(ComponentId::to_owned).collect(),
+            &new.sources.keys().map(ComponentId::to_owned).collect(),
+        );
+        debug!("component changes: {changes:?}");
+
+        let diffed = detect_bidiffable(old, new);
+        debug!("diffed: {diffed:?}");
+        assert!(
+            diffed.is_subset(&changes.kept),
+            "sanity: only components that are kept could ever be diffable"
+        );
+        // Copied: (kept - diffed) + created
+        let copied: HashSet<ComponentId> = changes
+            .kept
+            .difference(&diffed)
+            .chain(&changes.created)
+            .map(ToOwned::to_owned)
+            .collect();
+        debug!("copied: {copied:?}");
+        assert!(
+            copied.is_disjoint(&diffed),
+            "sanity check: no diffed component should be copied"
+        );
+        assert!(
+            copied.is_superset(&changes.created),
+            "sanity check: any component that is created will also be copied"
+        );
+
+        let mut ops = HashSet::new();
+        for id in copied {
+            let from_source = new
+                .sources
+                .get(&id)
+                .expect("infallible: `created` will exist in the new dir only");
+            let from_path = new.dir.join(&from_source.path);
+            let to_path = out_dir.0.join(&from_source.path);
+
+            let op = Operation::Copy {
+                id,
+                from_path,
+                to_path,
+            };
+            let inserted = ops.insert(op);
+            assert!(
+                inserted,
+                "infallible: shouldn't be possible for us to create two equivalent operations"
+            );
+        }
+
+        for id in diffed {
+            let old_source = old
+                .sources
+                .get(&id)
+                .expect("infallible: diffed components exist in both old and new");
+            let new_source = new
+                .sources
+                .get(&id)
+                .expect("infallible: diffed components exist in both old and new");
+
+            let old_path = old.dir.join(&old_source.path);
+            let new_path = new.dir.join(&new_source.path);
+            let out_path = out_dir.0.join(&new_source.path);
+
+            let op = Operation::Bidiff {
+                id,
+                old_path,
+                new_path,
+                out_path,
+            };
+            let inserted = ops.insert(op);
+            assert!(
+                inserted,
+                "infallible: shouldn't be possible for us to create two equivalent operations"
+            );
+        }
+
+        Self { ops }
+    }
+}
+
+/// Helper struct using during [`DiffPlan`] to determine how component IDs between two
+/// sets of components
 #[derive(Debug)]
 struct ComponentChanges {
     created: HashSet<ComponentId>,
-    deleted: HashSet<ComponentId>,
+    _deleted: HashSet<ComponentId>,
     kept: HashSet<ComponentId>,
 }
 
@@ -152,71 +265,31 @@ impl ComponentChanges {
 
         Self {
             created,
-            deleted,
+            _deleted: deleted,
             kept,
         }
     }
 }
 
-async fn detect_bidiffable(
-    old: &HashMap<String, Source>,
-    old_claim_path: &Path,
-    new: &HashMap<String, Source>,
-    new_claim_path: &Path,
-) -> Result<HashSet<ComponentId>> {
-    let old_valid = filter_valid_sqfs(old_claim_path, old.iter())
-        .await
-        .wrap_err("failed to filter for squashfs in old claim")?;
-    let new_valid = filter_valid_sqfs(new_claim_path, new.iter())
-        .await
-        .wrap_err("failed to filter for squashfs in new claim")?;
+fn detect_bidiffable(old: &OtaDir, new: &OtaDir) -> HashSet<ComponentId> {
+    let filter_diffable =
+        |sinfo: &SourceInfo| sinfo.mime == MimeType::OctetStream && sinfo.is_sqfs;
+    let old_valid: HashSet<_> = old
+        .sources
+        .iter()
+        .filter_map(|(id, sinfo)| filter_diffable(sinfo).then_some(id))
+        .collect();
 
-    Ok(old_valid
+    let new_valid: HashSet<_> = new
+        .sources
+        .iter()
+        .filter_map(|(id, sinfo)| filter_diffable(sinfo).then_some(id))
+        .collect();
+
+    old_valid
         .intersection(&new_valid)
-        .map(|id| id.to_owned())
-        .collect())
-}
-
-async fn filter_valid_sqfs(
-    claim_path: &Path,
-    sources: impl Iterator<Item = (impl AsRef<str>, &Source)>,
-) -> Result<HashSet<ComponentId>> {
-    ensure!(
-        fs::metadata(claim_path).await?.is_file(),
-        "expected `{claim_path:?}` to be a file"
-    );
-    let base_path = claim_path
-        .parent()
-        .expect("infallible, we already checked its a file");
-    let extract_path = |source: &Source| {
-        let LocalOrRemote::Local(ref path) = source.url else {
-            bail!("claim didn't match expected convention: all sources should be be of form `file://`");
-        };
-        ensure!(path.is_relative(), "claim didn't match expected convention: all sources should be relative file paths");
-
-        Ok(base_path.join(path))
-    };
-
-    let mut sqfs_components = HashSet::new();
-    for (id, source) in sources
-        // We assume sqfs are always OctetStream
-        .filter(|(_id, s)| s.mime_type == orb_update_agent_core::MimeType::OctetStream)
-    {
-        let path = extract_path(source).wrap_err_with(|| {
-            format!("failed to determine path for source {}", source.name)
-        })?;
-        let file = tokio::fs::File::open(&path).await.wrap_err_with(|| {
-            format!("failed to open component source at `{path:?}`")
-        })?;
-        if !is_sqfs(file).await? {
-            continue;
-        }
-
-        let id = ComponentId::from(id.as_ref());
-        sqfs_components.insert(id);
-    }
-
-    Ok(sqfs_components)
+        .map(|id| (*id).to_owned())
+        .collect()
 }
 
 async fn is_sqfs(f: impl AsyncRead + AsyncSeek) -> Result<bool> {
@@ -232,9 +305,368 @@ async fn is_sqfs(f: impl AsyncRead + AsyncSeek) -> Result<bool> {
     Ok(magic.to_be_bytes() == SQFS_MAGIC)
 }
 
+fn relative_path_from_source(source: &Source) -> Result<PathBuf> {
+    let LocalOrRemote::Local(ref path) = source.url else {
+        bail!("claim didn't match expected convention: all sources should be be of form `file://`");
+    };
+    ensure!(path.is_relative(), "source didn't match expected convention: all sources should be relative file paths");
+    Ok(path.to_path_buf())
+}
+
 #[cfg(test)]
 mod test_filter_valid_sqfs {
     // TODO(@thebutlah): write tests
+}
+
+#[cfg(test)]
+mod test_diff_plan {
+    use super::*;
+    use test_log::test;
+
+    fn helper(
+        old_sources: impl IntoIterator<Item = (impl Into<String>, SourceInfo)>,
+        new_sources: impl IntoIterator<Item = (impl Into<String>, SourceInfo)>,
+    ) -> (OtaDir, OtaDir, OutDir) {
+        // Arrange
+        let old_ota_dir = Path::new("old");
+        let old_ota = OtaDir {
+            dir: old_ota_dir.to_path_buf(),
+            sources: old_sources
+                .into_iter()
+                .map(|(id, sinfo)| (ComponentId(id.into()), sinfo))
+                .collect(),
+        };
+        let new_ota_dir = Path::new("new");
+        let new_ota = OtaDir {
+            dir: new_ota_dir.to_path_buf(),
+            sources: new_sources
+                .into_iter()
+                .map(|(id, sinfo)| (ComponentId(id.into()), sinfo))
+                .collect(),
+        };
+        let out_dir = OutDir(PathBuf::from("out"));
+
+        (old_ota, new_ota, out_dir)
+    }
+
+    #[test]
+    fn test_no_components() {
+        // Arrange
+        let empty: HashMap<String, SourceInfo> = HashMap::new();
+        let (old_ota, new_ota, out_dir) = helper(empty.clone(), empty);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert!(plan.ops.is_empty());
+    }
+
+    #[test]
+    fn test_only_created() {
+        // Arrange
+        let empty: HashMap<String, _> = HashMap::new();
+        let a_sinfo = SourceInfo {
+            path: "a.cmp".into(),
+            is_sqfs: false,
+            mime: MimeType::OctetStream,
+        };
+        let created = HashMap::from([("a", a_sinfo.clone())]);
+        let (old_ota, new_ota, out_dir) = helper(empty, created);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert_eq!(
+            plan.ops,
+            HashSet::from([Operation::Copy {
+                id: "a".into(),
+                from_path: new_ota.dir.join("a.cmp"),
+                to_path: out_dir.0.join("a.cmp")
+            }])
+        );
+    }
+
+    #[test]
+    fn test_only_deleted() {
+        // Arrange
+        let empty: HashMap<String, _> = HashMap::new();
+        let a_sinfo = SourceInfo {
+            path: "a.cmp".into(),
+            is_sqfs: false,
+            mime: MimeType::OctetStream,
+        };
+        let initial_sources = HashMap::from([("a", a_sinfo.clone())]);
+        let (old_ota, new_ota, out_dir) = helper(initial_sources, empty);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert!(plan.ops.is_empty());
+    }
+
+    #[test]
+    fn test_keep_1_not_sqfs_will_copy() {
+        // Arrange
+        let a_sinfo = SourceInfo {
+            path: "a.cmp".into(),
+            is_sqfs: false, // this is the important part
+            mime: MimeType::OctetStream,
+        };
+        let sources = HashMap::from([("a", a_sinfo.clone())]);
+        let (old_ota, new_ota, out_dir) = helper(sources.clone(), sources);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert_eq!(
+            plan.ops,
+            HashSet::from([Operation::Copy {
+                id: "a".into(),
+                from_path: new_ota.dir.join("a.cmp"),
+                to_path: out_dir.0.join("a.cmp"),
+            }])
+        );
+    }
+
+    #[test]
+    fn test_keep_1_is_sqfs_will_copy() {
+        // Arrange
+        let a_sinfo = SourceInfo {
+            path: "a.cmp".into(),
+            is_sqfs: true, // this is the important part
+            mime: MimeType::OctetStream,
+        };
+        let sources = HashMap::from([("a", a_sinfo.clone())]);
+        let (old_ota, new_ota, out_dir) = helper(sources.clone(), sources);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert_eq!(
+            plan.ops,
+            HashSet::from([Operation::Bidiff {
+                id: "a".into(),
+                old_path: old_ota.dir.join("a.cmp"),
+                new_path: new_ota.dir.join("a.cmp"),
+                out_path: out_dir.0.join("a.cmp"),
+            }])
+        );
+    }
+
+    #[test]
+    fn test_keep_1_sqfs_and_1_not_sqfs() {
+        // Arrange
+        let sqfs_sinfo = SourceInfo {
+            path: "sqfs.cmp".into(),
+            is_sqfs: true,
+            mime: MimeType::OctetStream,
+        };
+        let non_sqfs_sinfo = SourceInfo {
+            path: "not-sqfs.cmp".into(),
+            is_sqfs: false,
+            mime: MimeType::OctetStream,
+        };
+        let sources = HashMap::from([
+            ("sqfs", sqfs_sinfo.clone()),
+            ("not-sqfs", non_sqfs_sinfo.clone()),
+        ]);
+        let (old_ota, new_ota, out_dir) = helper(sources.clone(), sources);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert_eq!(
+            plan.ops,
+            HashSet::from([
+                Operation::Bidiff {
+                    id: "sqfs".into(),
+                    old_path: old_ota.dir.join("sqfs.cmp"),
+                    new_path: new_ota.dir.join("sqfs.cmp"),
+                    out_path: out_dir.0.join("sqfs.cmp"),
+                },
+                Operation::Copy {
+                    id: "not-sqfs".into(),
+                    from_path: new_ota.dir.join("not-sqfs.cmp"),
+                    to_path: out_dir.0.join("not-sqfs.cmp"),
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn test_only_bidiff_sqfs_when_its_octet() {
+        // Arrange
+        let sqfs_octet_sinfo = SourceInfo {
+            path: "sqfs-octet.cmp".into(),
+            is_sqfs: true,
+            mime: MimeType::OctetStream,
+        };
+        let sqfs_other_mime_sinfo = SourceInfo {
+            path: "sqfs-other.cmp".into(),
+            is_sqfs: true,
+            mime: MimeType::XZ,
+        };
+        let sources = HashMap::from([
+            ("sqfs-octet", sqfs_octet_sinfo.clone()),
+            ("sqfs-other", sqfs_other_mime_sinfo.clone()),
+        ]);
+        let (old_ota, new_ota, out_dir) = helper(sources.clone(), sources);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert_eq!(
+            plan.ops,
+            HashSet::from([
+                // Only the squashfs with OctetStream mime should be bidiffed
+                Operation::Bidiff {
+                    id: "sqfs-octet".into(),
+                    old_path: old_ota.dir.join("sqfs-octet.cmp"),
+                    new_path: new_ota.dir.join("sqfs-octet.cmp"),
+                    out_path: out_dir.0.join("sqfs-octet.cmp"),
+                },
+                // The squashfs with other mime type should be copied
+                Operation::Copy {
+                    id: "sqfs-other".into(),
+                    from_path: new_ota.dir.join("sqfs-other.cmp"),
+                    to_path: out_dir.0.join("sqfs-other.cmp"),
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn test_complicated_setup() {
+        // Arrange
+        let kept_sqfs_sinfo = SourceInfo {
+            path: "kept-sqfs.cmp".into(),
+            is_sqfs: true,
+            mime: MimeType::OctetStream,
+        };
+        let kept_non_sqfs_sinfo = SourceInfo {
+            path: "kept-non-sqfs.cmp".into(),
+            is_sqfs: false,
+            mime: MimeType::OctetStream,
+        };
+        let deleted_sqfs_sinfo = SourceInfo {
+            path: "deleted-sqfs.cmp".into(),
+            is_sqfs: true,
+            mime: MimeType::OctetStream,
+        };
+        let deleted_non_sqfs_sinfo = SourceInfo {
+            path: "deleted-non-sqfs.cmp".into(),
+            is_sqfs: false,
+            mime: MimeType::OctetStream,
+        };
+        let created_sqfs_sinfo = SourceInfo {
+            path: "created-sqfs.cmp".into(),
+            is_sqfs: true,
+            mime: MimeType::OctetStream,
+        };
+        let created_non_sqfs_sinfo = SourceInfo {
+            path: "created-non-sqfs.cmp".into(),
+            is_sqfs: false,
+            mime: MimeType::OctetStream,
+        };
+
+        let old_sources = HashMap::from([
+            ("kept-sqfs", kept_sqfs_sinfo.clone()),
+            ("kept-non-sqfs", kept_non_sqfs_sinfo.clone()),
+            ("deleted-sqfs", deleted_sqfs_sinfo),
+            ("deleted-non-sqfs", deleted_non_sqfs_sinfo),
+        ]);
+
+        let new_sources = HashMap::from([
+            ("kept-sqfs", kept_sqfs_sinfo),
+            ("kept-non-sqfs", kept_non_sqfs_sinfo),
+            ("created-sqfs", created_sqfs_sinfo),
+            ("created-non-sqfs", created_non_sqfs_sinfo),
+        ]);
+
+        let (old_ota, new_ota, out_dir) = helper(old_sources, new_sources);
+
+        // Act
+        let plan = DiffPlan::new(&old_ota, &new_ota, &out_dir);
+
+        // Assert
+        assert_eq!(
+            plan.ops,
+            HashSet::from([
+                // Kept components that are squashfs should be bidiffed
+                Operation::Bidiff {
+                    id: "kept-sqfs".into(),
+                    old_path: old_ota.dir.join("kept-sqfs.cmp"),
+                    new_path: new_ota.dir.join("kept-sqfs.cmp"),
+                    out_path: out_dir.0.join("kept-sqfs.cmp"),
+                },
+                // Kept components that aren't squashfs should be copied
+                Operation::Copy {
+                    id: "kept-non-sqfs".into(),
+                    from_path: new_ota.dir.join("kept-non-sqfs.cmp"),
+                    to_path: out_dir.0.join("kept-non-sqfs.cmp"),
+                },
+                // Created components should be copied regardless of squashfs status
+                Operation::Copy {
+                    id: "created-sqfs".into(),
+                    from_path: new_ota.dir.join("created-sqfs.cmp"),
+                    to_path: out_dir.0.join("created-sqfs.cmp"),
+                },
+                Operation::Copy {
+                    id: "created-non-sqfs".into(),
+                    from_path: new_ota.dir.join("created-non-sqfs.cmp"),
+                    to_path: out_dir.0.join("created-non-sqfs.cmp"),
+                },
+                // Deleted components should not appear in operations at all
+            ])
+        );
+    }
+}
+
+#[cfg(test)]
+mod test_relative_path_from_source {
+    use super::*;
+
+    fn dummy_source(url: LocalOrRemote) -> Source {
+        Source {
+            name: "dummy".into(),
+            url,
+            mime_type: MimeType::OctetStream,
+            size: 0,
+            hash: "".into(),
+        }
+    }
+
+    #[test]
+    fn test_relative_local_url_success() {
+        let path = PathBuf::from("components/foo.sqfs");
+        let source = dummy_source(LocalOrRemote::Local(path.clone()));
+        let result = relative_path_from_source(&source).unwrap();
+        assert_eq!(result, path);
+    }
+
+    #[test]
+    fn test_remote_url_fails() {
+        let url =
+            LocalOrRemote::Remote("https://example.com/foo.sqfs".parse().unwrap());
+        let source = dummy_source(url);
+        let result = relative_path_from_source(&source);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_absolute_local_url_fails() {
+        let path = PathBuf::from("/foo/bar/baz.sqfs");
+        let source = dummy_source(LocalOrRemote::Local(path.clone()));
+        let result = relative_path_from_source(&source);
+        assert!(result.is_err());
+    }
 }
 
 #[cfg(test)]
@@ -277,7 +709,7 @@ mod test_component_changes {
         let same = HashSet::new();
         let changes = ComponentChanges::new(&same, &same);
 
-        assert!(changes.deleted.is_empty());
+        assert!(changes._deleted.is_empty());
         assert!(changes.created.is_empty());
         assert_eq!(changes.kept, same);
     }
@@ -287,7 +719,7 @@ mod test_component_changes {
         let same = HashSet::from(["a"]).into_iter().map(C::from).collect();
         let changes = ComponentChanges::new(&same, &same);
 
-        assert!(changes.deleted.is_empty());
+        assert!(changes._deleted.is_empty());
         assert!(changes.created.is_empty());
         assert_eq!(changes.kept, same);
     }
@@ -297,7 +729,7 @@ mod test_component_changes {
         let same = HashSet::from(["a", "b"]).into_iter().map(C::from).collect();
         let changes = ComponentChanges::new(&same, &same);
 
-        assert!(changes.deleted.is_empty());
+        assert!(changes._deleted.is_empty());
         assert!(changes.created.is_empty());
         assert_eq!(changes.kept, same);
     }
@@ -308,7 +740,7 @@ mod test_component_changes {
         let new = HashSet::from(["a"]).into_iter().map(C::from).collect();
         let changes = ComponentChanges::new(&old, &new);
 
-        assert!(changes.deleted.is_empty());
+        assert!(changes._deleted.is_empty());
         assert_eq!(changes.created, new);
         assert!(changes.kept.is_empty());
     }
@@ -319,7 +751,7 @@ mod test_component_changes {
         let new = HashSet::from(["a", "b"]).into_iter().map(C::from).collect();
         let changes = ComponentChanges::new(&old, &new);
 
-        assert!(changes.deleted.is_empty());
+        assert!(changes._deleted.is_empty());
         assert_eq!(changes.created, new);
         assert!(changes.kept.is_empty());
     }
@@ -330,7 +762,7 @@ mod test_component_changes {
         let new: HashSet<ComponentId> = HashSet::new();
         let changes = ComponentChanges::new(&old, &new);
 
-        assert_eq!(changes.deleted, old);
+        assert_eq!(changes._deleted, old);
         assert!(changes.created.is_empty());
         assert!(changes.kept.is_empty());
     }
@@ -341,7 +773,7 @@ mod test_component_changes {
         let new: HashSet<ComponentId> = HashSet::new();
         let changes = ComponentChanges::new(&old, &new);
 
-        assert_eq!(changes.deleted, old);
+        assert_eq!(changes._deleted, old);
         assert!(changes.created.is_empty());
         assert!(changes.kept.is_empty());
     }
@@ -359,7 +791,7 @@ mod test_component_changes {
         let changes = ComponentChanges::new(&old, &new);
 
         assert_eq!(
-            changes.deleted,
+            changes._deleted,
             HashSet::from(["a"]).into_iter().map(C::from).collect()
         );
         assert_eq!(

--- a/update-agent/core/src/claim.rs
+++ b/update-agent/core/src/claim.rs
@@ -37,7 +37,7 @@ pub enum MimeType {
 ///
 /// The hash is used to verify that the downloaded binary blob is correct, and is not necessarily
 /// the same component as the hash of the final component (as recorded in the manifest).
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Source {
     pub hash: String,
     pub mime_type: MimeType,
@@ -207,7 +207,7 @@ impl<'a> Iterator for ComponentIter<'a> {
     }
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Clone)]
 pub struct Claim {
     version: String,
     manifest: crate::Manifest,

--- a/update-agent/core/src/components.rs
+++ b/update-agent/core/src/components.rs
@@ -7,7 +7,7 @@ use super::Slot;
 
 pub type Components = HashMap<String, Component>;
 
-#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Redundancy {
     #[serde(rename = "single")]
     Single,
@@ -20,7 +20,7 @@ pub enum Location {
     Mcu,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Device {
     #[serde(rename = "emmc")]
     Emmc,
@@ -56,7 +56,7 @@ impl Display for Device {
 
 #[derive(Deserialize, Serialize)]
 #[serde(tag = "type", content = "value")]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Component {
     #[serde(rename = "can")]
     Can(Can),
@@ -108,28 +108,28 @@ macro_rules! impl_is_redundant {
 }
 impl_is_redundant!(Can, Gpt, Raw);
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Can {
     pub address: u32,
     pub bus: String,
     pub redundancy: Redundancy,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Gpt {
     pub device: Device,
     pub label: String,
     pub redundancy: Redundancy,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Raw {
     pub device: Device,
     pub offset: u64,
     pub size: u64,
     pub redundancy: Redundancy,
 }
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Capsule {}
 
 #[derive(Debug, thiserror::Error)]

--- a/update-agent/core/src/file_location.rs
+++ b/update-agent/core/src/file_location.rs
@@ -37,7 +37,7 @@ impl Error {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum LocalOrRemote {
     Local(PathBuf),
     Remote(Url),

--- a/update-agent/core/src/manifest.rs
+++ b/update-agent/core/src/manifest.rs
@@ -9,7 +9,7 @@ pub enum Error {
     DuplicateComponents(Vec<String>),
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum UpdateKind {
     Full,
@@ -164,7 +164,7 @@ impl ManifestBuilder {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum InstallationPhase {
     #[default]
@@ -172,7 +172,7 @@ pub enum InstallationPhase {
     Recovery,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ManifestComponent {
     pub name: String,
     #[serde(rename = "version-assert")]


### PR DESCRIPTION
After [ORBS-407](https://linear.app/worldcoin/issue/ORBS-407/generate-diffing-plan) I realized that to execute the plan we would again need to have the deserialized claims and work with them.

I think a diffing plan is pretty useless if we don't include all the necessary information to actually do the file operations, so this PR reworks it:
* We validate all of the potentially failable operations and disk IO once per OTA dir, and store the extracted information in an `OtaDir` struct.
* The `DiffPlan::new` function then gets to be sans-io and non-failable.
* The operations have been reworked to only expose lower level information, and the actual paths that will be diffed or copied. This ensures that a Claim is not needed later in the plan execution phase.
* Overall due to the three steps (OtaDir parse, Plan creation, Plan execution), its now easier to test each step in isolation.

This PR also adds sans-io tests for the actual plan creation