### PR TITLE
feat(backend-status): FM-405-orbsoft-backend-progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5313,6 +5313,7 @@ dependencies = [
  "thiserror 1.0.65",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
@@ -5451,6 +5452,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "wiremock",
  "zbus",
  "zbus_systemd",
 ]
@@ -5460,6 +5462,7 @@ name = "orb-backend-status-dbus"
 version = "0.0.0"
 dependencies = [
  "derive_more",
+ "orb-telemetry",
  "serde",
  "zbus",
 ]
@@ -5963,6 +5966,7 @@ dependencies = [
  "tracing-journald",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "zbus",
 ]
 
 [[package]]
@@ -7294,9 +7298,11 @@ dependencies = [
  "getrandom",
  "http 1.2.0",
  "matchit 0.8.4",
+ "opentelemetry",
  "reqwest 0.12.12",
  "reqwest-middleware",
  "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -9195,8 +9201,10 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
+ "smallvec",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -10110,9 +10118,9 @@ dependencies = [
 
 [[package]]
 name = "wiremock"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fff469918e7ca034884c7fd8f93fe27bacb7fcb599fd879df6c7b429a29b646"
+checksum = "101681b74cd87b5899e87bcf5a64e83334dd313fcd3053ea72e6dba18928e301"
 dependencies = [
  "assert-json-diff",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,9 +97,6 @@ indicatif = "0.17.9"
 jose-jwk = { version = "0.1.2", default-features = false }
 libc = "0.2.153"
 nix = { version = "0.28", default-features = false, features = [] }
-opentelemetry = { version = "0.27", features = ["trace"] }
-opentelemetry-otlp = { version = "0.27", default-features = false }
-opentelemetry_sdk = "0.27"
 pkg-config = "0.3.32"
 reqwest = { version = "0.12.9", default-features = false, features = ["rustls-tls", "stream"] }
 ring = "0.17.2"

--- a/backend-status/Cargo.toml
+++ b/backend-status/Cargo.toml
@@ -19,14 +19,14 @@ orb-backend-status-dbus = { workspace = true }
 orb-build-info          = { workspace = true }
 orb-endpoints           = { workspace = true }
 orb-info                = { workspace = true, features = ["async", "orb-id", "orb-jabil-id", "orb-name", "orb-token"] }
-orb-telemetry           = { workspace = true }
+orb-telemetry           = { workspace = true, features = ["otel", "zbus-tracing"] }
 orb-update-agent-dbus   = { workspace = true }
 reqwest                 = { workspace = true, features = ["json"] }
-reqwest-middleware      = "0.4.0"
-reqwest-tracing         = "0.5.6"
+reqwest-middleware      = { version = "0.4.1", features = ["json"] }
+reqwest-tracing         = { version = "0.5.6", features = ["opentelemetry_0_27"] }
 serde                   = { workspace = true, features = ["derive"] }
 serde_json              = { workspace = true }
-serde_with              = "3.11.0"
+serde_with              = { version = "3.11.0" }
 thiserror               = { workspace = true }
 tokio                   = { workspace = true, features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }
 tokio-util              = { workspace = true }
@@ -38,6 +38,7 @@ dbus-launch  = { workspace = true }
 eyre         = { workspace = true }
 serial_test  = { workspace = true }
 tokio        = { workspace = true }
+wiremock     = { version = "0.6.3" }
 zbus_systemd = { workspace = true }
 
 [build-dependencies]

--- a/backend-status/dbus/Cargo.toml
+++ b/backend-status/dbus/Cargo.toml
@@ -11,6 +11,7 @@ repository   = { workspace = true }
 rust-version = { workspace = true }
 
 [dependencies]
-zbus        = { workspace = true }
-derive_more = { workspace = true, features = ["deref", "deref_mut", "from"] }
-serde       = { workspace = true }
+derive_more   = { workspace = true, features = ["deref", "deref_mut", "from"] }
+orb-telemetry = { workspace = true, features = ["zbus-tracing"] }
+serde         = { workspace = true }
+zbus          = { workspace = true }

--- a/backend-status/dbus/src/types.rs
+++ b/backend-status/dbus/src/types.rs
@@ -1,0 +1,30 @@
+use zbus::zvariant::{DeserializeDict, SerializeDict, Type};
+
+#[derive(Debug, Clone, SerializeDict, DeserializeDict, Type)]
+pub struct WifiNetwork {
+    #[zvariant(rename = "id")]
+    pub bssid: String,
+    #[zvariant(rename = "fr")]
+    pub frequency: u32,
+    #[zvariant(rename = "sl")]
+    pub signal_level: i32,
+    #[zvariant(rename = "fl")]
+    pub flags: String,
+    #[zvariant(rename = "ss")]
+    pub ssid: String,
+}
+
+#[derive(Debug, Clone, SerializeDict, DeserializeDict, Type)]
+#[zvariant(signature = "a{sv}")]
+pub struct UpdateProgress {
+    #[zvariant(rename = "dp")]
+    pub download_progress: u64,
+    #[zvariant(rename = "pp")]
+    pub processed_progress: u64,
+    #[zvariant(rename = "ip")]
+    pub install_progress: u64,
+    #[zvariant(rename = "tp")]
+    pub total_progress: u64,
+    #[zvariant(rename = "er")]
+    pub error: Option<String>,
+}

--- a/backend-status/src/args.rs
+++ b/backend-status/src/args.rs
@@ -7,7 +7,7 @@ use serde_with::skip_serializing_none;
 
 use crate::BUILD_INFO;
 
-#[derive(Debug, Parser, Serialize, Deserialize)]
+#[derive(Debug, Parser, Serialize, Deserialize, Default)]
 #[clap(
     version = BUILD_INFO.version,
     about,
@@ -15,9 +15,6 @@ use crate::BUILD_INFO;
 )]
 #[skip_serializing_none]
 pub struct Args {
-    /// The path to the config file.
-    #[clap(long)]
-    pub config: Option<String>,
     /// The orb id.
     #[clap(long, env = "ORB_ID", default_value = None)]
     pub orb_id: Option<String>,
@@ -27,8 +24,15 @@ pub struct Args {
     /// The backend to use.
     #[clap(long, env = "ORB_BACKEND", default_value = "stage")]
     pub backend: String,
+    /// status local address
+    #[clap(
+        long,
+        env = "ORB_STATUS_LOCAL_ADDRESS",
+        default_value = "localhost:8080"
+    )]
+    pub status_local_address: String,
     /// status update interval in seconds.
-    #[clap(long, env = "STATUS_UPDATE_INTERVAL", default_value = "10")]
+    #[clap(long, env = "ORB_STATUS_UPDATE_INTERVAL", default_value = "10")]
     pub status_update_interval: u64,
 }
 

--- a/backend-status/src/backend/mod.rs
+++ b/backend-status/src/backend/mod.rs
@@ -1,2 +1,2 @@
-mod models;
 pub mod status;
+mod types;

--- a/backend-status/src/backend/types.rs
+++ b/backend-status/src/backend/types.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 pub struct OrbStatusV2 {
     pub orb_id: Option<String>,
     pub location_data: Option<LocationDataV2>,
+    pub update_progress: Option<UpdateProgressV2>,
     pub timestamp: DateTime<Utc>,
 }
 
@@ -46,4 +47,14 @@ pub struct CellDataV2 {
     pub cell_id: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signal_strength: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateProgressV2 {
+    pub download_progress: u64,
+    pub processed_progress: u64,
+    pub install_progress: u64,
+    pub total_progress: u64,
+    pub error: Option<String>,
 }

--- a/backend-status/src/main.rs
+++ b/backend-status/src/main.rs
@@ -8,10 +8,12 @@ use backend::status::StatusClient;
 use clap::Parser;
 use color_eyre::eyre::Result;
 use dbus::{setup_dbus, BackendStatusImpl};
+use orb_backend_status_dbus::BackendStatusProxy;
 use orb_build_info::{make_build_info, BuildInfo};
+use orb_telemetry::TraceCtx;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 use update_progress::UpdateProgressWatcher;
 use zbus::Connection;
 
@@ -21,13 +23,21 @@ const SYSLOG_IDENTIFIER: &str = "worldcoin-backend-status";
 #[tokio::main]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let tel_flusher = orb_telemetry::TelemetryConfig::new()
+    let telemetry = orb_telemetry::TelemetryConfig::new()
+        .with_opentelemetry(orb_telemetry::OpentelemetryConfig::new(
+            orb_telemetry::OpentelemetryAttributes {
+                service_name: SYSLOG_IDENTIFIER.to_string(),
+                service_version: BUILD_INFO.version.to_string(),
+                additional_otel_attributes: Default::default(),
+            },
+        )?)
         .with_journald(SYSLOG_IDENTIFIER)
         .init();
 
     let args = Args::parse();
     let result = run(&args).await;
-    tel_flusher.flush().await;
+
+    telemetry.flush().await;
     result
 }
 
@@ -41,10 +51,13 @@ async fn run(args: &Args) -> Result<()> {
         shutdown_token.clone(),
     )
     .await;
-    let _dbus_conn = setup_dbus(backend_status_impl.clone()).await?;
 
+    // Setup the server and client DBus connections
+    let _server_conn = setup_dbus(backend_status_impl.clone()).await?;
     let connection = Connection::session().await?;
-    let mut update_progress_watcher = UpdateProgressWatcher::init(connection).await?;
+    let backend_status_proxy = BackendStatusProxy::new(&connection).await?;
+    let mut update_progress_proxy = UpdateProgressWatcher::init(&connection).await?;
+
     loop {
         tokio::select! {
             current_status = backend_status_impl.wait_for_updates() => {
@@ -53,9 +66,14 @@ async fn run(args: &Args) -> Result<()> {
                     backend_status_impl.send_current_status(&current_status).await;
                 }
             }
-            Ok(components) = update_progress_watcher.wait_for_updates() => {
+            Ok(components) = update_progress_proxy.wait_for_updates() => {
                 info!("Updating progress");
-                backend_status_impl.provide_update_progress(components);
+                match backend_status_proxy.provide_update_progress(components, TraceCtx::extract()).await {
+                    Ok(_) => (),
+                    Err(e) => {
+                        error!("failed to send update progress: {e:?}");
+                    }
+                }
             }
             _ = shutdown_token.cancelled() => {
                 info!("Shutting down backend-status initiated");

--- a/endpoints/src/backend.rs
+++ b/endpoints/src/backend.rs
@@ -7,6 +7,7 @@ pub enum Backend {
     Prod,
     Staging,
     Analysis,
+    Local,
 }
 
 impl Backend {
@@ -66,6 +67,7 @@ impl FromStr for Backend {
             "prod" | "production" => Ok(Self::Prod),
             "stage" | "staging" | "dev" | "development" => Ok(Self::Staging),
             "analysis" | "analysis.ml" | "analysis-ml" => Ok(Self::Analysis),
+            "local" | "localhost" | "127.0.0.1" => Ok(Self::Local),
             _ => Err(BackendParseErr),
         }
     }

--- a/endpoints/src/v1.rs
+++ b/endpoints/src/v1.rs
@@ -24,6 +24,7 @@ impl Endpoints {
             Backend::Prod => "orb",
             Backend::Staging => "stage.orb",
             Backend::Analysis => "analysis.ml",
+            Backend::Local => todo!(),
         };
 
         Self {

--- a/endpoints/src/v2.rs
+++ b/endpoints/src/v2.rs
@@ -13,6 +13,7 @@ impl Endpoints {
             Backend::Prod => "orb",
             Backend::Staging => "stage.orb",
             Backend::Analysis => unimplemented!(),
+            Backend::Local => todo!(),
         };
 
         Self {
@@ -50,5 +51,12 @@ mod test {
     fn test_analysis_backend_unimplemented() {
         let orb_id = "ea2ea744".parse().unwrap();
         let _analysis = Endpoints::new(Backend::Analysis, &orb_id);
+    }
+
+    #[test]
+    #[should_panic(expected = "not yet implemented")]
+    fn test_local_backend_unimplemented() {
+        let orb_id = "ea2ea744".parse().unwrap();
+        let _local = Endpoints::new(Backend::Local, &orb_id);
     }
 }

--- a/location/Cargo.toml
+++ b/location/Cargo.toml
@@ -15,7 +15,7 @@ eyre.workspace = true
 color-eyre.workspace = true
 orb-backend-status-dbus.workspace = true
 orb-build-info.workspace = true
-orb-telemetry.workspace = true
+orb-telemetry = { workspace = true, features = ["otel", "zbus-tracing"] }
 serde.workspace = true
 serde_json.workspace = true
 serialport = "4.6.1"

--- a/location/src/dbus.rs
+++ b/location/src/dbus.rs
@@ -1,5 +1,6 @@
 use eyre::Result;
-use orb_backend_status_dbus::{BackendStatusProxy, WifiNetwork};
+use orb_backend_status_dbus::{types::WifiNetwork, BackendStatusProxy};
+use orb_telemetry::TraceCtx;
 use zbus::Connection;
 
 use crate::data::NetworkInfo;
@@ -30,7 +31,7 @@ impl BackendStatus {
             .collect();
 
         self.backend_status_proxy
-            .provide_wifi_networks(dbus_wifi_networks)
+            .provide_wifi_networks(dbus_wifi_networks, TraceCtx::extract())
             .await?;
         Ok(())
     }

--- a/telemetry/Cargo.toml
+++ b/telemetry/Cargo.toml
@@ -19,17 +19,21 @@ otel = [
   "dep:tracing-opentelemetry",
   "dep:tokio",
 ]
+zbus-tracing = [
+  "dep:zbus",
+]
 
 [dependencies]
-opentelemetry = { workspace = true, optional = true }
-opentelemetry-otlp = { workspace = true, features = ["trace", "grpc-tonic"], optional = true }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio"], optional = true }
+opentelemetry = { version = "0.27", features = ["trace"], optional = true }
+opentelemetry-otlp = { version = "0.27", features = ["trace", "grpc-tonic"], optional = true }
+opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"], optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, optional = true }
 tracing-journald.workspace = true
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["registry", "env-filter"] }
 tracing.workspace = true
+zbus = { workspace = true, optional = true }
 
 [dev-dependencies]
 color-eyre.workspace = true


### PR DESCRIPTION
- added dbus proxy to receive UpdateAgent progress messages
- support collecting and sending OrbStatusV2::UpdateProgressV2 to backend


- updated orb-endpoints::backend to support 'local' as an environment
- updated orb-telemetry to define a tracing object compatible with dbus
  - used in orb-location -> orb-backend-status dbus