### PR TITLE
feat(ui): Pearl biometric-flow UX

### DIFF
--- a/ui/src/engine/animations/composites/biometric_flow.rs
+++ b/ui/src/engine/animations/composites/biometric_flow.rs
@@ -52,11 +52,8 @@ impl<const N: usize> BiometricFlow<N> {
 
     /// Issues a fast-forward command to the progress bar.
     pub fn progress_fast_forward(&mut self) {
-        match &mut self.phase {
-            Phase::FakeProgress { progress } => {
-                progress.set_completed();
-            }
-            _ => {}
+        if let Phase::FakeProgress { progress } = &mut self.phase {
+            progress.set_completed();
         }
     }
 
@@ -76,21 +73,15 @@ impl<const N: usize> BiometricFlow<N> {
 
     /// Halts the progress bar, if it is active.
     pub fn halt_progress(&mut self) {
-        match &mut self.phase {
-            Phase::FakeProgress { progress } => {
-                progress.halt();
-            }
-            _ => {}
+        if let Phase::FakeProgress { progress } = &mut self.phase {
+            progress.halt();
         }
     }
 
     /// Resumes the progress bar, if it is active.
     pub fn resume_progress(&mut self) {
-        match &mut self.phase {
-            Phase::FakeProgress { progress } => {
-                progress.resume();
-            }
-            _ => {}
+        if let Phase::FakeProgress { progress } = &mut self.phase {
+            progress.resume();
         }
     }
 
@@ -151,7 +142,7 @@ impl<const N: usize> Animation for BiometricFlow<N> {
                         ),
                     }
                 }
-                return AnimationState::Running;
+                AnimationState::Running
             }
             Phase::FakeProgressFadeout { animation } => {
                 if animation.animate(frame, dt, idle) == AnimationState::Finished {
@@ -170,7 +161,7 @@ impl<const N: usize> Animation for BiometricFlow<N> {
                         self.phase = Phase::WaitingForResult;
                     }
                 }
-                return AnimationState::Running;
+                AnimationState::Running
             }
             Phase::WaitingForResult => {
                 if let Some(is_success) = self.is_success {
@@ -186,11 +177,9 @@ impl<const N: usize> Animation for BiometricFlow<N> {
                         },
                     }
                 }
-                return AnimationState::Running;
+                AnimationState::Running
             }
-            Phase::Result { animation } => {
-                return animation.animate(frame, dt, idle);
-            }
+            Phase::Result { animation } => animation.animate(frame, dt, idle),
         }
     }
 

--- a/ui/src/engine/animations/composites/biometric_flow.rs
+++ b/ui/src/engine/animations/composites/biometric_flow.rs
@@ -1,0 +1,187 @@
+use crate::engine::{
+    animations::{
+        alert_v2::{Alert, SquarePulseTrain},
+        fake_progress_v2::FakeProgress,
+    },
+    Animation, AnimationState, RingFrame,
+};
+use orb_rgb::Argb;
+use std::time::Duration;
+
+pub const PROGRESS_BAR_FADE_OUT_DURATION: f64 = 0.3;
+pub const RESULT_ANIMATION_DELAY: f64 = 0.4;
+const WAITING_PERCENTAGE: f64 = 0.9;
+
+/// A composite animation that displays a fake-progress bar followed by success/failure animation.
+/// It's intended to be used on the Orb's ring LEDs.
+pub struct BiometricFlow<const N: usize> {
+    phase: Phase<N>,
+    is_success: Option<bool>,
+    success_color: Argb,
+    failure_color: Argb,
+}
+
+enum Phase<const N: usize> {
+    FakeProgress { progress: FakeProgress<N> },
+    FakeProgressFadeout { animation: Alert<N> },
+    WaitingForResult,
+    Result { animation: Alert<N> },
+}
+
+impl<const N: usize> BiometricFlow<N> {
+    pub fn new(
+        progress_color: Argb,
+        progress_timeout: Duration,
+        min_fast_forward_duration: Duration,
+        max_fast_forward_duration: Duration,
+        success_color: Argb,
+        failure_color: Argb,
+    ) -> Self {
+        let progress = FakeProgress::<N>::new(
+            progress_color,
+            progress_timeout,
+            min_fast_forward_duration,
+            max_fast_forward_duration,
+        );
+        Self {
+            phase: Phase::FakeProgress { progress },
+            is_success: None,
+            success_color,
+            failure_color,
+        }
+    }
+
+    /// Issues a fast-forward commands to the progress bar.
+    pub fn progress_fast_forward(&mut self) {
+        match &mut self.phase {
+            Phase::FakeProgress { progress } => {
+                progress.set_completed();
+            }
+            _ => {}
+        }
+    }
+
+    /// Sets the success state and returns the delay before the result animation starts.
+    pub fn set_success(&mut self, is_success: bool) {
+        self.is_success = Some(is_success);
+    }
+
+    /// Returns the completion time of the progress bar.
+    /// Used for the synchronization of other animations and sounds.
+    pub fn get_progress_completion_time(&self) -> Duration {
+        match &self.phase {
+            Phase::FakeProgress { progress } => progress.get_completion_time(),
+            _ => Duration::from_secs(0),
+        }
+    }
+
+    fn success_animation(&self, delay: f64) -> Alert<N> {
+        Alert::<N>::new(
+            self.success_color,
+            SquarePulseTrain::from(vec![
+                (0.0, 0.1),
+                (0.5, 0.1),
+                (1.0, 0.1),
+                (1.1, 3.5),
+            ]),
+        )
+        .unwrap()
+        .with_delay(delay)
+    }
+
+    fn failure_animation(&self, delay: f64) -> Alert<N> {
+        Alert::<N>::new(
+            self.failure_color,
+            SquarePulseTrain::from(vec![
+                (0.0, 0.1),
+                (0.5, 0.1),
+                (1.0, 0.1),
+                (1.1, 3.5),
+            ]),
+        )
+        .unwrap()
+        .with_delay(delay)
+    }
+
+    fn fake_progress_fadeout(color: Argb) -> Alert<N> {
+        Alert::<N>::new(
+            color,
+            SquarePulseTrain::from(vec![
+                (0.0, 0.0),
+                (0.0, PROGRESS_BAR_FADE_OUT_DURATION),
+            ]),
+        )
+        .unwrap()
+    }
+}
+
+impl<const N: usize> Animation for BiometricFlow<N> {
+    type Frame = RingFrame<N>;
+    fn animate(
+        &mut self,
+        frame: &mut Self::Frame,
+        dt: f64,
+        idle: bool,
+    ) -> AnimationState {
+        match &mut self.phase {
+            Phase::FakeProgress { progress } => {
+                if progress.animate(frame, dt, idle) == AnimationState::Finished {
+                    self.phase = Phase::FakeProgressFadeout {
+                        animation: Self::fake_progress_fadeout(progress.get_color()),
+                    }
+                }
+                return AnimationState::Running;
+            }
+            Phase::FakeProgressFadeout { animation } => {
+                if animation.animate(frame, dt, idle) == AnimationState::Finished {
+                    if let Some(is_success) = self.is_success {
+                        self.phase = Phase::Result {
+                            animation: if is_success {
+                                self.success_animation(RESULT_ANIMATION_DELAY)
+                            } else {
+                                self.failure_animation(RESULT_ANIMATION_DELAY)
+                            },
+                        }
+                    } else {
+                        tracing::warn!(
+                            "Biometric flow progress fadeout without result"
+                        );
+                        self.phase = Phase::WaitingForResult;
+                    }
+                }
+                return AnimationState::Running;
+            }
+            Phase::WaitingForResult => {
+                if let Some(is_success) = self.is_success {
+                    self.phase = Phase::Result {
+                        animation: if is_success {
+                            self.success_animation(
+                                PROGRESS_BAR_FADE_OUT_DURATION + RESULT_ANIMATION_DELAY,
+                            )
+                        } else {
+                            self.failure_animation(
+                                PROGRESS_BAR_FADE_OUT_DURATION + RESULT_ANIMATION_DELAY,
+                            )
+                        },
+                    }
+                }
+                return AnimationState::Running;
+            }
+            Phase::Result { animation } => {
+                return animation.animate(frame, dt, idle);
+            }
+        }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn stop(&mut self, _transition: crate::engine::Transition) -> eyre::Result<()> {
+        Ok(())
+    }
+}

--- a/ui/src/engine/animations/composites/mod.rs
+++ b/ui/src/engine/animations/composites/mod.rs
@@ -1,0 +1,1 @@
+pub mod biometric_flow;

--- a/ui/src/engine/animations/fake_progress_v2.rs
+++ b/ui/src/engine/animations/fake_progress_v2.rs
@@ -76,14 +76,12 @@ impl<const N: usize> FakeProgress<N> {
         self.progress_animation.get_color()
     }
 
-    pub fn get_virtual_progress(&self) -> f64 {
-        self.progress_bar.progress
-    }
-
     pub fn set_completed(&mut self) -> Duration {
+        self.halted = false;
         self.progress_bar.set_completed()
     }
 
+    #[expect(dead_code)]
     pub fn is_in_fast_forward(&self) -> bool {
         self.progress_bar.completed
     }
@@ -91,12 +89,14 @@ impl<const N: usize> FakeProgress<N> {
     pub fn get_completion_time(&self) -> Duration {
         Duration::from_secs_f64(self.progress_bar.completion_time)
     }
-    #[expect(dead_code)]
+
+    /// Halts the progress bar if it is not in fast-forward.
     pub fn halt(&mut self) {
-        self.halted = true;
+        if !self.progress_bar.completed {
+            self.halted = true;
+        }
     }
 
-    #[expect(dead_code)]
     pub fn resume(&mut self) {
         self.halted = false;
     }

--- a/ui/src/engine/animations/mod.rs
+++ b/ui/src/engine/animations/mod.rs
@@ -2,6 +2,7 @@ pub mod alert;
 pub mod alert_v2;
 mod arc_dash;
 pub mod arc_pulse;
+pub mod composites;
 mod fake_progress;
 pub mod fake_progress_v2;
 pub mod idle;

--- a/ui/src/engine/animations/progress.rs
+++ b/ui/src/engine/animations/progress.rs
@@ -73,6 +73,10 @@ impl<const N: usize> Progress<N> {
     pub fn set_pulse_angle(&mut self, pulse_angle: f64) {
         self.pulse_angle = pulse_angle;
     }
+
+    pub fn get_color(&self) -> Argb {
+        self.color
+    }
 }
 
 impl<const N: usize> Animation for Progress<N> {

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -722,6 +722,9 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         .try_queue(sound::Type::Voice(sound::Voice::Silence));
                 }
             }
+            Event::BiometricFlowStart { .. } => {}
+            Event::BiometricFlowProgressFastForward { .. } => {}
+            Event::BiometricFlowResult { .. } => {}
             Event::BiometricCaptureSuccess => {
                 self.biometric_capture_success()?;
             }

--- a/ui/src/engine/mod.rs
+++ b/ui/src/engine/mod.rs
@@ -282,6 +282,21 @@ event_enum! {
             min_fast_forward_duration: Duration,
             max_fast_forward_duration: Duration,
         },
+        /// Biometric flow start.
+        #[event_enum(method = biometric_flow_start)]
+        BiometricFlowStart {
+            timeout: Duration,
+            min_fast_forward_duration: Duration,
+            max_fast_forward_duration: Duration,
+        },
+        /// Biometric flow progress fast forward.
+        #[event_enum(method = biometric_flow_progress_fast_forward)]
+        BiometricFlowProgressFastForward,
+        /// Biometric flow result.
+        #[event_enum(method = biometric_flow_result)]
+        BiometricFlowResult {
+            is_success: bool,
+        },
         /// Biometric capture has finished successfully, command fake-progress to fast-forward
         #[event_enum(method = biometric_capture_success_and_fast_forward_fake_progress)]
         BiometricCaputreSuccessAndFastForwardFakeProgress,

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -472,7 +472,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         animations::Static::<PEARL_CENTER_LED_COUNT>::new(Argb::OFF, None),
                     );
                     self.set_center(
-                        LEVEL_FOREGROUND,
+                        LEVEL_NOTICE,
                         animations::alert_v2::Alert::<PEARL_CENTER_LED_COUNT>::new(
                             if *is_success {Argb::PEARL_CENTER_CAPTURE_SUCCESS} else {Argb::PEARL_RING_ERROR_SALMON},
                             SquarePulseTrain::from(vec![

--- a/ui/src/engine/pearl/self_serve.rs
+++ b/ui/src/engine/pearl/self_serve.rs
@@ -416,6 +416,7 @@ impl Runner<PEARL_RING_LED_COUNT, PEARL_CENTER_LED_COUNT> {
                         Argb::PEARL_RING_USER_CAPTURE,
                     ),
                 );
+                self.stop_ring(LEVEL_FOREGROUND, Transition::ForceStop);
             }
             Event::BiometricFlowProgressFastForward => {
                 if let Some(biometric_flow) = self


### PR DESCRIPTION
1. Adds failure animation in case the processing phase returns an error. (red center LED & error sound).
2. Halting & Resuming the progress bar.
      * Halts the progress bar when the user is not in range (also the music stops playing).
      * Resumes the progress bar when the user enters the range, and the progress bar moves faster to catch-up with the "missed" progress. This is encouraging to the the user, as they did something positive (entered the correct range). (also the music playing resumes).

codebase changes: Introduces a new "composite" animation, which consists of the all the ux events that need to happen in a sequence during the signup (capturing and processing).