### PR TITLE
chore(ui): diamond wifi qr-scan ux

### DIFF
--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -126,10 +126,6 @@ impl Argb {
     pub const DIAMOND_OPERATOR_VERSIONS_OUTDATED: Argb =
         Argb(Some(Self::DIMMING_MAX_VALUE), 255, 0, 0);
 
-    /// Outer-ring color during wifi QR scans
-    pub const DIAMOND_RING_WIFI_QR_SCAN: Argb = Argb(Some(5), 0, 15, 100);
-    pub const DIAMOND_RING_WIFI_QR_SCAN_SPINNER: Argb = Argb(Some(10), 60, 60, 40);
-
     /// Outer-ring color during operator QR scans
     pub const DIAMOND_RING_OPERATOR_QR_SCAN: Argb = Argb(Some(5), 77, 14, 0);
     pub const DIAMOND_RING_OPERATOR_QR_SCAN_SPINNER: Argb = Argb(Some(10), 100, 88, 70);
@@ -147,6 +143,7 @@ impl Argb {
     pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(4), 127, 20, 0);
 
     /// QR Phase colors - diamond
+    pub const DIAMOND_CENTER_WIFI_QR_SCAN: Argb = Argb(Some(3), 0, 15, 100);
     pub const DIAMOND_CENTER_OPERATOR_QR_SCAN: Argb = Self::DIAMOND_CENTER_USER_QR_SCAN;
     pub const DIAMOND_CENTER_USER_QR_SCAN: Argb = Argb(Some(3), 80, 30, 2);
     pub const DIAMOND_CENTER_USER_QR_SCAN_COMPLETED: Argb = Argb(Some(3), 230, 80, 3);

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -422,11 +422,11 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     }
                     QrScanSchema::Wifi => {
                         self.operator_idle.no_wlan();
-                        self.set_ring(
-                            LEVEL_FOREGROUND,
-                            animations::SimpleSpinner::new(
-                                Argb::DIAMOND_RING_WIFI_QR_SCAN_SPINNER,
-                                Some(Argb::DIAMOND_RING_WIFI_QR_SCAN),
+                        self.set_center(
+                            LEVEL_BACKGROUND,
+                            animations::Static::<DIAMOND_CENTER_LED_COUNT>::new(
+                                Argb::DIAMOND_CENTER_WIFI_QR_SCAN,
+                                None,
                             )
                             .fade_in(1.5),
                         );


### PR DESCRIPTION
Removes the spinner, moves the color from the ring to the shroud (same as all other qr-scans), and makes the blue a bit darker.