### PR TITLE
CriticalState UI

### DIFF
--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -164,7 +164,7 @@ impl Argb {
     pub const FULL_BLUE: Argb = Argb(None, 0, 0, 255);
     pub const FULL_WHITE: Argb = Argb(None, 255, 255, 255);
     pub const FULL_BLACK: Argb = Argb(None, 0, 0, 0);
-    pub const FULL_PURPLE: Argb = Argb(None, 128, 0, 128);
+    pub const FULL_PURPLE: Argb = Argb(Some(10), 128, 0, 128);
 
     pub fn is_off(&self) -> bool {
         self.0 == Some(0) || (self.1 == 0 && self.2 == 0 && self.3 == 0)

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -164,7 +164,7 @@ impl Argb {
     pub const FULL_BLUE: Argb = Argb(None, 0, 0, 255);
     pub const FULL_WHITE: Argb = Argb(None, 255, 255, 255);
     pub const FULL_BLACK: Argb = Argb(None, 0, 0, 0);
-    pub const FULL_PURPLE: Argb = Argb(Some(10), 128, 0, 128);
+    pub const DIAMOND_FULL_PURPLE: Argb = Argb(Some(10), 128, 0, 128);
 
     pub fn is_off(&self) -> bool {
         self.0 == Some(0) || (self.1 == 0 && self.2 == 0 && self.3 == 0)

--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -164,6 +164,7 @@ impl Argb {
     pub const FULL_BLUE: Argb = Argb(None, 0, 0, 255);
     pub const FULL_WHITE: Argb = Argb(None, 255, 255, 255);
     pub const FULL_BLACK: Argb = Argb(None, 0, 0, 0);
+    pub const FULL_PURPLE: Argb = Argb(None, 128, 0, 128);
 
     pub fn is_off(&self) -> bool {
         self.0 == Some(0) || (self.1 == 0 && self.2 == 0 && self.3 == 0)

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -1071,7 +1071,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.set_ring(
                     LEVEL_FOREGROUND,
                     animations::Static::<DIAMOND_RING_LED_COUNT>::new(
-                        Argb::FULL_PURPLE,
+                        Argb::DIAMOND_FULL_PURPLE,
                         Some(5.0),
                     ),
                 );

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -1072,7 +1072,7 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                     LEVEL_FOREGROUND,
                     animations::Static::<DIAMOND_RING_LED_COUNT>::new(
                         Argb::FULL_PURPLE,
-                        None,
+                        Some(5.0),
                     ),
                 );
             }

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -28,6 +28,7 @@ use super::animations::alert_v2::SquarePulseTrain;
 use super::animations::composites::biometric_flow::{
     PROGRESS_BAR_FADE_OUT_DURATION, RESULT_ANIMATION_DELAY,
 };
+use super::CriticalState;
 
 struct WrappedCenterMessage(Message);
 
@@ -1063,6 +1064,19 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 );
             }
             Event::VoiceOpenEyes => {}
+
+            Event::CriticalState {
+                state: CriticalState::WifiModuleNotInitialized,
+            } => {
+                self.set_ring(
+                    LEVEL_FOREGROUND,
+                    animations::Static::<DIAMOND_RING_LED_COUNT>::new(
+                        Argb::FULL_PURPLE,
+                        None,
+                    ),
+                );
+            }
+
             _ => {}
         }
         Ok(())

--- a/ui/src/engine/mod.rs
+++ b/ui/src/engine/mod.rs
@@ -421,7 +421,18 @@ event_enum! {
         Gimbal {
             x: u32, y: u32
         },
+
+        /// Orb is in a critical state and needs to be power cycled
+        #[event_enum(method = critical_state)]
+        CriticalState {
+            state: CriticalState
+        },
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum CriticalState {
+    WifiModuleNotInitialized,
 }
 
 /// Returned by [`Animation::animate`]


### PR DESCRIPTION
Shines the front ring purple in case of a critical Wifi issue that requires a power cycle.
This will be removed before the next event, just makes it easier to troubleshoot problems in EOL and field testing right now.