### PR TITLE
chore(s3-helpers): switch to minio

### DIFF
--- a/s3-helpers/Cargo.toml
+++ b/s3-helpers/Cargo.toml
@@ -19,7 +19,7 @@ camino.workspace = true
 color-eyre.workspace = true
 futures.workspace = true
 tempfile.workspace = true
-testcontainers-modules = { workspace = true, features = ["localstack"] }
+testcontainers-modules = { workspace = true, features = ["minio"] }
 testcontainers.workspace = true
 tokio = { workspace = true, features = ["full"] } # TODO: narrow this
 tracing.workspace = true


### PR DESCRIPTION
switching from `localstack` to `minio` for testing S3 due to flakyness of localstack