### PR TITLE
feat: extend update-agent reporting

### DIFF
--- a/update-agent/src/claim.rs
+++ b/update-agent/src/claim.rs
@@ -53,6 +53,8 @@ pub enum Error {
         status_code: StatusCode,
         msg: String,
     },
+    #[error("no new version available - system is up to date")]
+    NoNewVersion,
 }
 
 impl Error {
@@ -143,7 +145,12 @@ fn from_remote(
                 Cow::Borrowed("")
             }
         };
-        Err(Error::status_code(status, msg))
+
+        if status == StatusCode::NOT_FOUND && msg.contains("no new version") {
+            Err(Error::NoNewVersion)
+        } else {
+            Err(Error::status_code(status, msg))
+        }
     } else {
         let resp_txt = resp.text().map_err(Error::ResponseAsText)?;
         debug!("server sent raw claim: {resp_txt}");

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -18,7 +18,9 @@ use orb_update_agent_core::{
     manifest::InstallationPhase,
     Claim, LocalOrRemote, ManifestComponent, MimeType, Slot, Source,
 };
-use orb_update_agent_dbus::{ComponentState, UpdateAgentManager};
+use orb_update_agent_dbus::{
+    ComponentState, ComponentStatus, UpdateAgentManager, UpdateAgentState,
+};
 use reqwest::{
     header::{ToStrError, CONTENT_LENGTH, RANGE},
     Url,
@@ -618,10 +620,13 @@ pub fn download<P: AsRef<Path>>(
 
         info!("downloading component `{name}`: {progress_percent}%");
         if let Some(iface) = update_iface {
-            if let Err(e) = interfaces::update_dbus_properties(
-                name,
-                ComponentState::Downloading,
-                progress_percent as u8,
+            if let Err(e) = interfaces::update_dbus_progress(
+                Some(ComponentStatus {
+                    name: name.to_string(),
+                    state: ComponentState::Downloading,
+                    progress: progress_percent as u8,
+                }),
+                Some(UpdateAgentState::Downloading),
                 iface,
             ) {
                 warn!("{e:?}");

--- a/update-agent/src/dbus/interfaces.rs
+++ b/update-agent/src/dbus/interfaces.rs
@@ -2,17 +2,41 @@ use eyre::WrapErr;
 use orb_update_agent_core::ManifestComponent;
 use orb_update_agent_dbus::{
     ComponentState, ComponentStatus, UpdateAgentManager, UpdateAgentManagerT,
+    UpdateAgentState,
 };
 use zbus::blocking::object_server::InterfaceRef;
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateProgress {
     pub components: Vec<ComponentStatus>,
+    pub overall_status: UpdateAgentState,
+}
+
+impl UpdateProgress {
+    pub fn set_overall_status(&mut self, status: UpdateAgentState) {
+        self.overall_status = status;
+    }
 }
 
 impl UpdateAgentManagerT for UpdateProgress {
     fn progress(&self) -> Vec<ComponentStatus> {
         self.components.clone()
+    }
+
+    fn overall_status(&self) -> UpdateAgentState {
+        self.overall_status
+    }
+
+    fn overall_progress(&self) -> u8 {
+        // TODO do a weighted average based on actual size of the components
+        if self.components.is_empty() {
+            return 0;
+        }
+
+        let total_progress: u32 =
+            self.components.iter().map(|c| c.progress as u32).sum();
+
+        (total_progress / self.components.len() as u32) as u8
     }
 }
 
@@ -30,24 +54,42 @@ pub fn init_dbus_properties(
         .collect();
 }
 
-pub fn update_dbus_properties(
-    name: &str,
-    state: ComponentState,
-    progress: u8,
+pub fn update_dbus_progress(
+    component_update: Option<ComponentStatus>,
+    overall_status: Option<UpdateAgentState>,
     iface: &InterfaceRef<UpdateAgentManager<UpdateProgress>>,
 ) -> eyre::Result<()> {
-    if let Some(component) = iface
-        .get_mut()
-        .0
-        .components
-        .iter_mut()
-        .find(|c| c.name == name)
-    {
-        component.state = state;
-        component.progress = progress;
+    if let Some(update) = component_update {
+        if let Some(component) = iface
+            .get_mut()
+            .0
+            .components
+            .iter_mut()
+            .find(|c| c.name == update.name)
+        {
+            component.state = update.state;
+            component.progress = update.progress;
+        }
     }
+
+    if let Some(status) = overall_status {
+        iface.get_mut().0.set_overall_status(status);
+    }
+
     zbus::block_on(iface.get_mut().progress_changed(iface.signal_context()))
         .wrap_err("Failed to emit progress_changed signal")?;
+    zbus::block_on(
+        iface
+            .get_mut()
+            .overall_status_changed(iface.signal_context()),
+    )
+    .wrap_err("Failed to emit overall_status_changed signal")?;
+    zbus::block_on(
+        iface
+            .get_mut()
+            .overall_progress_changed(iface.signal_context()),
+    )
+    .wrap_err("Failed to emit overall_progress_changed signal")?;
 
     Ok(())
 }

--- a/update-agent/src/dbus/interfaces.rs
+++ b/update-agent/src/dbus/interfaces.rs
@@ -1,15 +1,17 @@
 use eyre::WrapErr;
-use orb_update_agent_core::ManifestComponent;
+use orb_update_agent_core::Claim;
 use orb_update_agent_dbus::{
     ComponentState, ComponentStatus, UpdateAgentManager, UpdateAgentManagerT,
     UpdateAgentState,
 };
+use std::collections::HashMap;
 use zbus::blocking::object_server::InterfaceRef;
 
 #[derive(Debug, Clone, Default)]
 pub struct UpdateProgress {
     pub components: Vec<ComponentStatus>,
     pub overall_status: UpdateAgentState,
+    pub component_download_sizes: HashMap<String, u64>, // component_name -> download_size
 }
 
 impl UpdateProgress {
@@ -28,29 +30,52 @@ impl UpdateAgentManagerT for UpdateProgress {
     }
 
     fn overall_progress(&self) -> u8 {
-        // TODO do a weighted average based on actual size of the components
         if self.components.is_empty() {
             return 0;
         }
 
-        let total_progress: u32 =
-            self.components.iter().map(|c| c.progress as u32).sum();
+        let total_download_size: u64 = self.component_download_sizes.values().sum();
+        if total_download_size == 0 {
+            // Fallback to simple average if no size information available
+            let total_progress: u32 =
+                self.components.iter().map(|c| c.progress as u32).sum();
+            return (total_progress / self.components.len() as u32) as u8;
+        }
 
-        (total_progress / self.components.len() as u32) as u8
+        let weighted_progress: u64 = self
+            .components
+            .iter()
+            .map(|c| {
+                let size = self.component_download_sizes.get(&c.name).unwrap_or(&0);
+                (c.progress as u64) * size
+            })
+            .sum();
+
+        ((weighted_progress * 100) / (total_download_size * 100)) as u8
     }
 }
 
 pub fn init_dbus_properties(
-    components: &[ManifestComponent],
+    claim: &Claim,
     iface: &InterfaceRef<UpdateAgentManager<UpdateProgress>>,
 ) {
-    iface.get_mut().0.components = components
+    let progress = &mut iface.get_mut().0;
+
+    progress.components = claim
+        .manifest_components()
         .iter()
         .map(|c| ComponentStatus {
             name: c.name.clone(),
             state: ComponentState::None,
             progress: 0,
         })
+        .collect();
+
+    // Store download sizes from sources
+    progress.component_download_sizes = claim
+        .sources()
+        .iter()
+        .map(|(name, source)| (name.clone(), source.size))
         .collect();
 }
 
@@ -92,4 +117,104 @@ pub fn update_dbus_progress(
     .wrap_err("Failed to emit overall_progress_changed signal")?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use orb_update_agent_dbus::{ComponentState, ComponentStatus};
+
+    #[test]
+    fn test_weighted_progress_calculation() {
+        let mut progress = UpdateProgress {
+            components: vec![
+                ComponentStatus {
+                    name: "small".to_string(),
+                    state: ComponentState::Downloading,
+                    progress: 50, // 50% of 100MB = 50MB worth of progress
+                },
+                ComponentStatus {
+                    name: "large".to_string(),
+                    state: ComponentState::Downloading,
+                    progress: 25, // 25% of 900MB = 225MB worth of progress
+                },
+            ],
+            overall_status: UpdateAgentState::Downloading,
+            component_download_sizes: {
+                let mut sizes = HashMap::new();
+                sizes.insert("small".to_string(), 100_000_000); // 100MB
+                sizes.insert("large".to_string(), 900_000_000); // 900MB
+                sizes
+            },
+        };
+
+        // Total size: 1000MB
+        // Weighted progress: (50 * 100MB) + (25 * 900MB) = 5000MB + 22500MB = 27500MB
+        // Overall progress: (27500MB * 100) / (1000MB * 100) = 27%
+        assert_eq!(progress.overall_progress(), 27);
+    }
+
+    #[test]
+    fn test_fallback_to_simple_average_when_no_sizes() {
+        let mut progress = UpdateProgress {
+            components: vec![
+                ComponentStatus {
+                    name: "comp1".to_string(),
+                    state: ComponentState::Downloading,
+                    progress: 30,
+                },
+                ComponentStatus {
+                    name: "comp2".to_string(),
+                    state: ComponentState::Downloading,
+                    progress: 70,
+                },
+            ],
+            overall_status: UpdateAgentState::Downloading,
+            component_download_sizes: HashMap::new(), // No size information
+        };
+
+        // Should fallback to simple average: (30 + 70) / 2 = 50
+        assert_eq!(progress.overall_progress(), 50);
+    }
+
+    #[test]
+    fn test_empty_components() {
+        let progress = UpdateProgress {
+            components: vec![],
+            overall_status: UpdateAgentState::None,
+            component_download_sizes: HashMap::new(),
+        };
+
+        assert_eq!(progress.overall_progress(), 0);
+    }
+
+    #[test]
+    fn test_missing_size_for_component() {
+        let mut progress = UpdateProgress {
+            components: vec![
+                ComponentStatus {
+                    name: "known".to_string(),
+                    state: ComponentState::Downloading,
+                    progress: 50,
+                },
+                ComponentStatus {
+                    name: "unknown".to_string(),
+                    state: ComponentState::Downloading,
+                    progress: 75,
+                },
+            ],
+            overall_status: UpdateAgentState::Downloading,
+            component_download_sizes: {
+                let mut sizes = HashMap::new();
+                sizes.insert("known".to_string(), 500_000_000); // 500MB
+                                                                // "unknown" component size is missing
+                sizes
+            },
+        };
+
+        // Only the "known" component should contribute to weighted progress
+        // Weighted progress: (50 * 500MB) + (75 * 0MB) = 25000MB
+        // Overall progress: (25000MB * 100) / (500MB * 100) = 50%
+        assert_eq!(progress.overall_progress(), 50);
+    }
 }

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -264,7 +264,7 @@ fn run(args: &Args) -> eyre::Result<()> {
     };
 
     if let Some(iface) = &update_iface {
-        interfaces::init_dbus_properties(claim.manifest_components(), iface);
+        interfaces::init_dbus_properties(&claim, iface);
     }
 
     match serde_json::to_string(&claim) {


### PR DESCRIPTION
Add overall status report(incl. NoNewVersion and Rebooting) and simple overall progress tracking. Example of signals:


```
Signals after installation just before reboot
---
signal time=1749406547.941895 sender=:1.8082 -> destination=(null destination) serial=44 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "Progress"
         variant             array [
               struct {
                  string "boot"
                  uint32 5
                  byte 100
               }
               struct {
                  string "system"
                  uint32 5
                  byte 100
               }
               struct {
                  string "main_mcu"
                  uint32 5
                  byte 100
               }
               struct {
                  string "sec_mcu"
                  uint32 5
                  byte 100
               }
            ]
      )
   ]
   array [
   ]
signal time=1749406547.942100 sender=:1.8082 -> destination=(null destination) serial=45 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "OverallStatus"
         variant             uint32 6
      )
   ]
   array [
   ]
signal time=1749406547.942165 sender=:1.8082 -> destination=(null destination) serial=46 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "OverallProgress"
         variant             byte 100
      )
   ]
   array [
   ]
---

Signals during download
---
signal time=1749404913.846737 sender=:1.3679 -> destination=(null destination) serial=11556 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "Progress"
         variant             array [
               struct {
                  string "boot"
                  uint32 3
                  byte 100
               }
               struct {
                  string "system"
                  uint32 2
                  byte 99
               }
               struct {
                  string "main_mcu"
                  uint32 1
                  byte 0
               }
               struct {
                  string "sec_mcu"
                  uint32 1
                  byte 0
               }
            ]
      )
   ]
   array [
   ]
signal time=1749404913.847063 sender=:1.3679 -> destination=(null destination) serial=11557 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "OverallStatus"
         variant             uint32 2
      )
   ]
   array [
   ]
signal time=1749404913.847394 sender=:1.3679 -> destination=(null destination) serial=11558 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "OverallProgress"
         variant             byte 49
      )
   ]
   array [
   ]
---
No new version
---
signal time=1749409010.947394 sender=:1.10429 -> destination=(null destination) serial=5 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "Progress"
         variant             array [
            ]
      )
   ]
   array [
   ]
signal time=1749409010.947522 sender=:1.10429 -> destination=(null destination) serial=6 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "OverallStatus"
         variant             uint32 7
      )
   ]
   array [
   ]
signal time=1749409010.947566 sender=:1.10429 -> destination=(null destination) serial=7 path=/org/worldcoin/UpdateAgentManager1; interface=org.freedesktop.DBus.Properties; member=PropertiesChanged
   string "org.worldcoin.UpdateAgentManager1"
   array [
      dict entry(
         string "OverallProgress"
         variant             byte 0
      )
   ]
   array [
   ]
---
```
