### PR TITLE
fix(mcu-util): white led minimum value

### DIFF
--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -340,7 +340,9 @@ impl MainBoard {
                 .isotp_iface
                 .send(McuPayload::ToMain(
                     main_messaging::jetson_to_mcu::Payload::WhiteLedsBrightness(
-                        main_messaging::WhiteLeDsBrightness { brightness: 5 },
+                        main_messaging::WhiteLeDsBrightness {
+                            brightness: 50, /* thousandth, so 0.5% */
+                        },
                     ),
                 ))
                 .await


### PR DESCRIPTION
0.05% doesn't turn on the booster leds
so set to 0.5%