### PR TITLE
fix: ESP partition mount

### DIFF
--- a/update-agent/src/update/capsule.rs
+++ b/update-agent/src/update/capsule.rs
@@ -18,7 +18,7 @@ pub const EFI_OS_INDICATIONS: &str =
 pub const EFI_OS_REQUEST_CAPSULE_UPDATE: [u8; 12] =
     [0x07, 0x0, 0x0, 0x0, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
 
-const ESP_PARTITION_PATH: &str = "/dev/disk/by-partlabel/esp";
+const ESP_PARTITION_PATH: &str = "/dev/disk/by-partlabel/ESP";
 const CAPSULE_INSTALL_NAME: &str = "EFI/UpdateCapsule/bootloader-update.Cap";
 
 #[derive(Debug, Error)]

--- a/update-agent/src/update/capsule.rs
+++ b/update-agent/src/update/capsule.rs
@@ -1,3 +1,4 @@
+use gpt::partition_types;
 /// Nvidia docs: https://web.archive.org/web/20231012155023/https://docs.nvidia.com/jetson/archives/r35.3.1/DeveloperGuide/text/SD/Bootloader/UpdateAndRedundancy.html#manually-trigger-the-capsule-update
 ///
 /// For UEFI documentation see: [1] 8.5.5 Delivery of Capsules via file on Mass Storage device
@@ -18,7 +19,6 @@ pub const EFI_OS_INDICATIONS: &str =
 pub const EFI_OS_REQUEST_CAPSULE_UPDATE: [u8; 12] =
     [0x07, 0x0, 0x0, 0x0, 0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0];
 
-const ESP_PARTITION_PATH: &str = "/dev/disk/by-partlabel/ESP";
 const CAPSULE_INSTALL_NAME: &str = "EFI/UpdateCapsule/bootloader-update.Cap";
 
 #[derive(Debug, Error)]
@@ -31,14 +31,71 @@ enum Error {
     CopyCapsule(#[source] std::io::Error),
     #[error("Failed to write OsIndications: {0}")]
     WriteOsIndications(#[source] eyre::Report),
+    #[error("Failed to find EFI System Partition")]
+    ESPPartitionNotFound,
+    #[error("Failed to open GPT disk {0}: {1}")]
+    OpenGptDisk(PathBuf, #[source] gpt::GptError),
+    #[error("Multiple EFI system partitions found on {0}: {1:?}")]
+    MultipleESPPartitions(PathBuf, Vec<u32>),
+}
+
+fn find_esp_partition() -> Result<PathBuf, Error> {
+    // Try common storage devices in order
+    let devices = ["/dev/nvme0n1", "/dev/mmcblk0"];
+
+    for device_path in &devices {
+        // Try to open the device as a GPT disk
+        let disk = match gpt::GptConfig::new().open(device_path) {
+            Ok(disk) => disk,
+            Err(gpt::GptError::Io(io_error))
+                if io_error.kind() == io::ErrorKind::NotFound =>
+            {
+                // Device doesn't exist (ENOENT), skip to next device
+                continue;
+            }
+            Err(e) => return Err(Error::OpenGptDisk(PathBuf::from(device_path), e)),
+        };
+
+        // Find all EFI System Partitions
+        let efi_partitions: Vec<u32> = disk
+            .partitions()
+            .iter()
+            .filter_map(|(partition_id, partition)| {
+                if partition.part_type_guid == partition_types::EFI {
+                    Some(*partition_id)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        match efi_partitions.len() {
+            0 => continue, // No EFI partition on this device, try next
+            1 => {
+                return Ok(PathBuf::from(format!(
+                    "{}p{}",
+                    device_path, efi_partitions[0]
+                )))
+            }
+            _ => {
+                return Err(Error::MultipleESPPartitions(
+                    PathBuf::from(device_path),
+                    efi_partitions,
+                ))
+            }
+        }
+    }
+
+    Err(Error::ESPPartitionNotFound)
 }
 
 fn save_capsule<R>(mut src: R) -> Result<(), Error>
 where
     R: io::Read + io::Seek,
 {
-    let esp = TemporaryMount::new(ESP_PARTITION_PATH)
-        .map_err(|e| Error::Mount(e, ESP_PARTITION_PATH.into()))?;
+    let esp_partition_path = find_esp_partition()?;
+    let esp = TemporaryMount::new(&esp_partition_path)
+        .map_err(|e| Error::Mount(e, esp_partition_path))?;
     let mut capsule = esp
         .create_file(CAPSULE_INSTALL_NAME)
         .map_err(|e| Error::CreateFile(e, CAPSULE_INSTALL_NAME.into()))?;


### PR DESCRIPTION
On diamond, EFI System Partition has label ESP (uppercase), while on pearl it is `esp` (lowercase). Fix update-agent to find the ESP partition based on the partition type.

--

The check for multiple ESP partitions is explicitly required, because we have some orbs with multiple ESP partitions. I think all EVTs are like that.