### PR TITLE
chore: Update orb-relay-messages dependency for fleet-cmdr

### DIFF
--- a/fleet-cmdr/Cargo.toml
+++ b/fleet-cmdr/Cargo.toml
@@ -45,7 +45,7 @@ rev = "6690dd50789fb79de792e2138e37cf4757130a7e"
 
 [dependencies.orb-relay-messages]
 git = "https://github.com/worldcoin/orb-relay-messages.git"
-rev = "6690dd50789fb79de792e2138e37cf4757130a7e"
+rev = "b03ad944188b33bbc26615061343de1a350c69cb"
 features = ["client"]
 
 [dependencies.orb-relay-test-utils]


### PR DESCRIPTION
Need to align the orb-relay-messages dependency between the fleet cmdr client in orb-software with the jobs service in orb-fleet-backend. 