### PR TITLE
fix(agentwire): fix infinite loop when no agents enabled

### DIFF
--- a/agentwire/tests/broker.rs
+++ b/agentwire/tests/broker.rs
@@ -1,0 +1,103 @@
+use agentwire::{
+    agent::{Cell, Task},
+    port::{self, Port},
+    Agent, Broker, BrokerFlow,
+};
+use futures::FutureExt;
+
+#[derive(Debug, thiserror::Error)]
+#[error("dummy error")]
+pub struct Error;
+
+struct DummyAgent;
+
+impl Port for DummyAgent {
+    type Input = ();
+    type Output = ();
+
+    const INPUT_CAPACITY: usize = 0;
+    const OUTPUT_CAPACITY: usize = 0;
+}
+
+impl Agent for DummyAgent {
+    const NAME: &'static str = "dummy";
+}
+
+impl Task for DummyAgent {
+    type Error = Error;
+
+    async fn run(self, _port: agentwire::port::Inner<Self>) -> Result<(), Self::Error> {
+        std::future::pending().await
+    }
+}
+
+#[derive(Broker)]
+#[broker(plan = PlanT, error = Error)]
+struct NoAgents {}
+
+impl NoAgents {
+    fn new() -> Self {
+        new_no_agents!()
+    }
+}
+
+#[derive(Broker)]
+#[broker(plan = PlanT, error = Error)]
+struct OneAgent {
+    #[agent(task, init)]
+    dummy: Cell<DummyAgent>,
+}
+
+impl OneAgent {
+    fn new() -> Self {
+        new_one_agent!()
+    }
+
+    #[expect(dead_code, reason = "agent never enabled")]
+    fn init_dummy(&mut self) -> DummyAgent {
+        DummyAgent
+    }
+
+    fn handle_dummy(
+        &mut self,
+        _plan: &mut dyn PlanT,
+        _output: port::Output<DummyAgent>,
+    ) -> Result<BrokerFlow, Error> {
+        unreachable!("agent never enabled")
+    }
+}
+
+trait PlanT {}
+
+#[derive(Debug)]
+struct Plan;
+
+impl PlanT for Plan {}
+
+#[test]
+fn test_broker_with_no_agents_never_blocks() {
+    let waker = futures::task::noop_waker();
+    let mut cx = std::task::Context::from_waker(&waker);
+    let mut plan = Plan;
+
+    let mut no_agents = NoAgents::new();
+    let mut run_fut = no_agents.run(&mut plan);
+    // poll should always immediately return, instead of looping forever.
+    assert!(run_fut.poll_unpin(&mut cx).is_pending());
+    assert!(run_fut.poll_unpin(&mut cx).is_pending());
+    assert!(run_fut.poll_unpin(&mut cx).is_pending());
+}
+
+#[test]
+fn test_broker_with_one_agent_never_blocks() {
+    let waker = futures::task::noop_waker();
+    let mut cx = std::task::Context::from_waker(&waker);
+    let mut plan = Plan;
+
+    let mut one_agent = OneAgent::new();
+    let mut run_fut = one_agent.run(&mut plan);
+    // poll should always immediately return, instead of looping forever.
+    assert!(run_fut.poll_unpin(&mut cx).is_pending());
+    assert!(run_fut.poll_unpin(&mut cx).is_pending());
+    assert!(run_fut.poll_unpin(&mut cx).is_pending());
+}


### PR DESCRIPTION
Prior to this PR, code like the following would exhibit incorrect blocking-in-async behavior, if no agents were enabled. 
```rust
impl Plan {
    async fn run(&mut self, orb: &mut Broker) -> Result<()> {
        let broker_fut = orb.run(self);
        let tout_fut = tokio::time::sleep(Duration::from_secs(4));
        tokio::select! {
            _ = tout_fut => info!("done sleeping"),
             // blocks forever the first time its polled - this prevents the timeout from ever triggering
            result = broker_fut => result?,
        }

        Ok(())
    }
}
```

This would happen because if no agents are enabled, the macro-generated `poll()` function for the future returned by `Broker::run()` would infinitely loop without ever returning. Now instead, it detects if no agents are enabled and returns Poll::pending, which ensures `poll()` is always non-blocking.

I've fixed the offending code and added a test case for it.

NOTE: This PR is only a partial fix. There is still an unhandled edge case, where a user defined poll_extra can cause the same infinite-blocking behavior:

```rust
impl Broker {
    fn poll_extra(
        &mut self,
        _plan: &mut dyn PlanT,
        _cx: &mut Context,
        _fence: std::time::Instant,
    ) -> Result<Option<Poll<()>>> {
        Ok(None)
    }
}
```

However, this is not a regression - this also happens prior to this PR. Fixing this would be desirable, but even the partial fix in this PR is useful - therefore I would like to land this PR first and deal with that additional edge case later.