### PR TITLE
fix(agentwire): use precise captures to match pre-2024 edition

### DIFF
--- a/agentwire/src/port.rs
+++ b/agentwire/src/port.rs
@@ -352,7 +352,7 @@ impl<T: Port> Input<T> {
 
     /// Returns a closure, which creates a new output value with the source
     /// timestamp of the input.
-    pub fn chain_fn(&self) -> impl Fn(T::Output) -> Output<T> {
+    pub fn chain_fn(&self) -> impl Fn(T::Output) -> Output<T> + use<T> {
         let source_ts = self.source_ts;
         move |value| Output { value, source_ts }
     }
@@ -372,7 +372,7 @@ where
 
     /// Returns a closure, which creates a new output value with the source
     /// timestamp of the input.
-    pub fn chain_fn(&self) -> impl Fn(T::Output) -> Output<T> {
+    pub fn chain_fn(&self) -> impl Fn(T::Output) -> Output<T> + use<T> {
         let source_ts = self.source_ts;
         move |value| Output { value, source_ts }
     }
@@ -398,7 +398,7 @@ impl<T: Port> Output<T> {
 
     /// Returns a closure, which creates a new output value with the source
     /// timestamp of the original output.
-    pub fn derive_fn<O: Port>(&self) -> impl Fn(O::Output) -> Output<O> {
+    pub fn derive_fn<O: Port>(&self) -> impl Fn(O::Output) -> Output<O> + use<T, O> {
         let source_ts = self.source_ts;
         move |value| Output { value, source_ts }
     }
@@ -413,7 +413,7 @@ impl<T: Port> Output<T> {
 
     /// Returns a closure, which creates a new input value with the source
     /// timestamp of the output.
-    pub fn chain_fn<O: Port>(&self) -> impl Fn(O::Input) -> Input<O> {
+    pub fn chain_fn<O: Port>(&self) -> impl Fn(O::Input) -> Input<O> + use<T, O> {
         let source_ts = self.source_ts;
         move |value| Input { value, source_ts }
     }


### PR DESCRIPTION
rust 2024 [introduces a change](https://rust-lang.github.io/rfcs/3617-precise-capturing.html#lifetime-capture-rules-2024) to how opaque types (like impl T) capture generics. The opaque types now capture *all* generics instead of only those that appear in the opaque type. 

In #551 we upgraded to rust 2024, which means that the generics captured by opaque types are capturing *more* generics than previously intended - this is called ["overcapturing"](https://rust-lang.github.io/rfcs/3617-precise-capturing.html#background). As an example of this, consider [this function signature](https://github.com/worldcoin/orb-software/blob/12d0881c93458d56e248c87af16235466ae3506a/agentwire/src/port.rs#L375) from agentwire:

```rust
pub fn chain_fn(&self) -> impl Fn(T::Output) -> Output<T> {
    let source_ts = self.source_ts;
    move |value| Output { value, source_ts }
}
```

Expanding this the lifetimes, we get the following (Note the `&'a self`):

```rust
pub fn chain_fn<'a>(&'a self) -> impl Fn(T::Output) -> Output<T> {
    let source_ts = self.source_ts;
    move |value| Output { value, source_ts }
}
```

If we want to be precise, lets use the `use<..>` syntax, also know as the [precise captures](https://doc.rust-lang.org/reference/types/impl-trait.html#precise-capturing) syntax, to demonstrate the difference between rust 2021 and rust 2024.

In rust 2021, the code further can be expanded to (note the `use<T>`):
```rust
pub fn chain_fn<'a>(&'a self) -> impl Fn(T::Output) -> Output<T> + use<T> {
    let source_ts = self.source_ts;
    move |value| Output { value, source_ts }
}
```

In rust 2024, the code expands to (note the `use<'a, T>`):
```rust
pub fn chain_fn<'a>(&'a self) -> impl Fn(T::Output) -> Output<T> + use<'a, T> {
    let source_ts = self.source_ts;
    move |value| Output { value, source_ts }
}
```

You can see that in rust 2024, the code now additionally captures the `'a` lifetime, whereas it did not before. This is a problem! It means that the compiler at `chain_fn`'s callsite will think that the closure borrows from `&'a self`. But if you look at the actual closure, it is a `move` closure and doesn't actually borrow from `self` at all. Hence the opaque type `impl Fn(T::Output) -> Output<T> + use<'a, T>` is overcapturing the generics - `'a` doesn't need to be in the `use<..>`, but it shows up anyway.

This becomes a problem: uses who wish to get a `&mut Port` while hanging onto a closure returned by `port.chain_fn()`, will erroneously have the borrow checker yell at them, because the borrow checker thinks that the closure is borrowing from `port`, when it is not. That is what causes the following error in orb-core:

```
❯ cargo check --all --all-targets
    Blocking waiting for file lock on build directory
    Checking orb-core-common v0.0.1 (/home/ryan.butler/P/wc/orb-core/src/common)
error[E0499]: cannot borrow `port` as mutable more than once at a time
   --> src/common/python.rs:164:25
    |
159 |                 let input = port.recv();
    |                             ---- first mutable borrow occurs here
...
164 |                         port.send(&chain(output));
    |                         ^^^^       ----- first borrow later used here
    |                         |
    |                         second mutable borrow occurs here
    |
note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
   --> src/common/python.rs:160:29
    |
160 |                 let chain = input.chain_fn();
    |                             ^^^^^^^^^^^^^^^^
help: if you can modify this crate, add a precise capturing bound to avoid overcapturing: `+ use<T>`
   --> /home/ryan.butler/.cargo/git/checkouts/orb-software-f7329de80b5b53e9/12d0881/agentwire/src/port.rs:375:31
    |
375 |     pub fn chain_fn(&self) -> impl Fn(T::Output) -> Output<T> {
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0499`.
error: could not compile `orb-core-common` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
error: could not compile `orb-core-common` (lib test) due to 1 previous error
```

This error happens due to the incorrect overcapture, causing borrowing conflicts.

The correct solution is to make the captures more precise, and explicitly `use<T>` instead of the implied `use<'a, T>`.