### PR TITLE
chore(hil): update nvim config

### DIFF
--- a/nix/machines/home-hil.nix
+++ b/nix/machines/home-hil.nix
@@ -72,8 +72,8 @@ in
       source = pkgs.fetchFromGitHub {
         owner = "thebutlah";
         repo = "init.lua";
-        rev = "ea6cc4e6f98cd99e7ab26dd1a750d34919adc454";
-        hash = "sha256-P6rhEBTOuXf28L+0EYtdyt3q0bxSKnNFFmuykPpFrQ0=";
+        rev = "2c3c458325dbe9ee46793d92cea4c541e3c2babd";
+        hash = "sha256-MOtj/lCK36oTmnY2HxCLSW6LnzZ5jheaK34EUlKC2qs=";
       };
     };
     "zellij/config.kdl" = {


### PR DESCRIPTION
nvim failed with treesitter errors because the treesitter plugin was too old for the latest neovim.