### PR TITLE
fix(hil): update tegra-bash.nix for diamond

### DIFF
--- a/nix/shells/tegra-bash.nix
+++ b/nix/shells/tegra-bash.nix
@@ -18,8 +18,13 @@ pkgs.buildFHSUserEnv {
   name = "tegra-bash";
   targetPkgs = pkgs: (with pkgs; [
     (python3.withPackages pythonShell)
+    bun
     curl
+    dtc
+    gcc
+    libxml2
     lz4
+    openssl
     perl
     udev
   ]);


### PR DESCRIPTION
the fhsenv was missing various libraries needed for the new flashing scripts.