### PR TITLE
feat: Add FAILURE_UNSUPPORTED job status to jobs agent and utilize orb_info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7145,7 +7145,7 @@ dependencies = [
 [[package]]
 name = "orb-relay-client"
 version = "0.0.1"
-source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=a2e071584d2e56c76961bb9d04b06cc06f673b90#a2e071584d2e56c76961bb9d04b06cc06f673b90"
+source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e#ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e"
 dependencies = [
  "bon",
  "color-eyre",
@@ -7164,7 +7164,7 @@ dependencies = [
 [[package]]
 name = "orb-relay-messages"
 version = "0.0.0"
-source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=a2e071584d2e56c76961bb9d04b06cc06f673b90#a2e071584d2e56c76961bb9d04b06cc06f673b90"
+source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e#ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e"
 dependencies = [
  "prost 0.13.4",
  "prost-build 0.13.4",
@@ -7176,7 +7176,7 @@ dependencies = [
 [[package]]
 name = "orb-relay-test-utils"
 version = "0.0.1"
-source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=a2e071584d2e56c76961bb9d04b06cc06f673b90#a2e071584d2e56c76961bb9d04b06cc06f673b90"
+source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e#ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e"
 dependencies = [
  "async-stream",
  "flume",

--- a/jobs-agent/Cargo.toml
+++ b/jobs-agent/Cargo.toml
@@ -41,16 +41,16 @@ zbus_systemd = { workspace = true, features = ["systemd1", "login1"] }
 
 [dependencies.orb-relay-client]
 git = "https://github.com/worldcoin/orb-relay-messages.git"
-rev = "a2e071584d2e56c76961bb9d04b06cc06f673b90"
+rev = "ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e"
 
 [dependencies.orb-relay-messages]
 git = "https://github.com/worldcoin/orb-relay-messages.git"
-rev = "a2e071584d2e56c76961bb9d04b06cc06f673b90"
+rev = "ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e"
 features = ["client"]
 
 [dependencies.orb-relay-test-utils]
 git = "https://github.com/worldcoin/orb-relay-messages.git"
-rev = "a2e071584d2e56c76961bb9d04b06cc06f673b90"
+rev = "ee0d9f4877e7d4a7dcd99df84649dc0a89235b2e"
 
 [build-dependencies]
 orb-build-info = { workspace = true, features = ["build-script"] }

--- a/jobs-agent/src/args.rs
+++ b/jobs-agent/src/args.rs
@@ -18,8 +18,8 @@ pub struct Args {
     /// The path to the config file.
     #[clap(long)]
     pub config: Option<String>,
-    /// The orb id.
-    #[clap(long, env = "ORB_ID", default_value = None)]
+    /// The orb id (optional - will be automatically read from system if not provided).
+    #[clap(long)]
     pub orb_id: Option<String>,
     /// The orb token.
     #[clap(long, env = "ORB_TOKEN", default_value = None)]

--- a/jobs-agent/src/handlers/mod.rs
+++ b/jobs-agent/src/handlers/mod.rs
@@ -192,7 +192,10 @@ impl OrbCommandHandlers {
                 };
 
                 if let Err(e) = job_client.send_job_update(&update).await {
-                    error!("Failed to send job update for unsupported command: {:?}", e);
+                    error!(
+                        "Failed to send job update for unsupported command: {:?}",
+                        e
+                    );
                 }
 
                 completion_tx
@@ -355,6 +358,10 @@ mod tests {
         let completion = completion_rx.await.unwrap();
         assert_eq!(completion.status, JobExecutionStatus::Failed); // Should be Failed in completion
         assert_eq!(completion.job_execution_id, "test_job_execution_id");
-        assert!(completion.final_message.as_ref().unwrap().contains("unsupported command"));
+        assert!(completion
+            .final_message
+            .as_ref()
+            .unwrap()
+            .contains("unsupported command"));
     }
 }

--- a/jobs-agent/src/handlers/mod.rs
+++ b/jobs-agent/src/handlers/mod.rs
@@ -182,23 +182,23 @@ impl OrbCommandHandlers {
                     .await
             }
             _ => {
-                // Unknown command - send failure update and complete
+                // Unknown command - send unsupported failure update and complete
                 let update = JobExecutionUpdate {
                     job_id: job.job_id.clone(),
                     job_execution_id: job.job_execution_id.clone(),
-                    status: JobExecutionStatus::Failed as i32,
+                    status: JobExecutionStatus::FailedUnsupported as i32,
                     std_out: String::new(),
-                    std_err: format!("unknown command: {}", job.job_document),
+                    std_err: format!("unsupported command: {}", job.job_document),
                 };
 
                 if let Err(e) = job_client.send_job_update(&update).await {
-                    error!("Failed to send job update for unknown command: {:?}", e);
+                    error!("Failed to send job update for unsupported command: {:?}", e);
                 }
 
                 completion_tx
                     .send(JobCompletion::failure(
                         job.job_execution_id.clone(),
-                        format!("unknown command: {}", job.job_document),
+                        format!("unsupported command: {}", job.job_document),
                     ))
                     .ok();
 
@@ -308,5 +308,53 @@ mod tests {
         let completion = completion_rx.await.unwrap();
         assert_eq!(completion.status, JobExecutionStatus::Succeeded);
         assert_eq!(completion.job_execution_id, "test_job_execution_id");
+    }
+
+    #[tokio::test]
+    async fn test_handle_job_execution_unsupported_command() {
+        // Arrange
+        let sv = create_test_server().await;
+        let _client_svc =
+            create_test_client("test_svc", "test_namespace", EntityType::Service, &sv)
+                .await;
+        let client_orb =
+            create_test_client("test_orb", "test_namespace", EntityType::Orb, &sv)
+                .await;
+        let job_client_orb = JobClient::new(
+            client_orb.clone(),
+            "test_orb",
+            "test_namespace",
+            JobRegistry::new(),
+            crate::orchestrator::JobConfig::new(),
+        );
+        let handlers = OrbCommandHandlers::init().await;
+
+        // Act
+        let request = JobExecution {
+            job_id: "test_job_id".to_string(),
+            job_execution_id: "test_job_execution_id".to_string(),
+            job_document: "unsupported_command".to_string(), // Unknown command
+            should_cancel: false,
+        };
+
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let cancel_token = CancellationToken::new();
+
+        // Start the handler
+        let result = handlers
+            .handle_job_execution(
+                &request,
+                &job_client_orb,
+                completion_tx,
+                cancel_token,
+            )
+            .await;
+        assert!(result.is_ok());
+
+        // Wait for completion
+        let completion = completion_rx.await.unwrap();
+        assert_eq!(completion.status, JobExecutionStatus::Failed); // Should be Failed in completion
+        assert_eq!(completion.job_execution_id, "test_job_execution_id");
+        assert!(completion.final_message.as_ref().unwrap().contains("unsupported command"));
     }
 }

--- a/jobs-agent/src/main.rs
+++ b/jobs-agent/src/main.rs
@@ -36,7 +36,11 @@ async fn main() -> Result<()> {
 async fn run(args: &Args) -> Result<()> {
     info!("Starting jobs agent: {:?}", args);
 
-    let orb_id = OrbId::from_str(args.orb_id.as_ref().unwrap())?;
+    let orb_id = if let Some(id) = &args.orb_id {
+        OrbId::from_str(id)?
+    } else {
+        OrbId::read().await?
+    };
     let endpoints = args.relay_host.clone().unwrap_or_else(|| {
         Endpoints::new(Backend::from_env().expect("Backend env error"), &orb_id)
             .relay
@@ -63,7 +67,7 @@ async fn run(args: &Args) -> Result<()> {
     // Init Relay Client
     info!("Connecting to relay: {:?}", endpoints);
     let opts = ClientOpts::entity(EntityType::Orb)
-        .id(args.orb_id.clone().unwrap())
+        .id(orb_id.as_str().to_string())
         .endpoint(endpoints.clone())
         .namespace(args.relay_namespace.clone().unwrap())
         .auth(Auth::TokenReceiver(auth_token))


### PR DESCRIPTION
This PR makes two specific changes:

1. Add support for the FAILURE_UNSUPPORTED job status to indicate when a jobs-agent is unable to process a job, as it does not have a corresponding handler. This will help us diagnose job failures related to out of date jobs-agents in the field.
2. Use the orb_info package to read information about the orb ID if it's not passed via the CLI args. 