### PR TITLE
feat(hil): expose nfs

### DIFF
--- a/nix/machines/hil-common.nix
+++ b/nix/machines/hil-common.nix
@@ -19,6 +19,27 @@ in
 
   # Enable networking
   networking.networkmanager.enable = true;
+  networking.networkmanager.ensureProfiles.profiles = {
+    "Orb RCM Ethernet" = {
+      connection = {
+        autoconnect-priority = "-999";
+        id = "Orb RCM Ethernet";
+        interface-name = "enp0s20f0u1"; # TODO: hard coding?
+        type = "ethernet";
+        uuid = "eb829d4c-5314-38d1-98fc-a31b4be8892f"; # TODO make this not hard coded?
+      };
+      ethernet = { };
+      ipv4 = {
+        method = "shared"; # sets up DHCP server and shares internet
+      };
+      ipv6 = {
+        addr-gen-mode = "default";
+        method = "shared"; # sets up DHCP server and shares internet
+      };
+      proxy = { };
+    };
+  };
+
 
   # Set your time zone.
   time.timeZone = "America/New_York";
@@ -87,10 +108,44 @@ in
   # List services that you want to enable:
 
   # Open ports in the firewall.
-  # networking.firewall.allowedTCPPorts = [ ... ];
-  # networking.firewall.allowedUDPPorts = [ ... ];
+  networking.firewall.allowedTCPPorts = [
+    # all of these are nfs related: https://nixos.wiki/wiki/NFS#Firewall
+    111
+    2049
+    4000
+    4001
+    4002
+    20048
+  ];
+  networking.firewall.allowedUDPPorts = [
+    # all of these are nfs related: https://nixos.wiki/wiki/NFS#Firewall
+    67
+    111
+    2049
+    4000
+    4001
+    4002
+    20048
+  ];
   # Or disable the firewall altogether.
   # networking.firewall.enable = false;
+
+  services.nfs = {
+    server = {
+      enable = true;
+      exports = ''
+        # First 10 bits of FE80 are designated by RFC4291 to be link-local networks
+        # https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.6
+        # /srv fe80::/10(rw,fsid=0,no_subtree_check)
+        /srv 10.42.0.0/24(rw,fsid=0,no_subtree_check)
+      '';
+      # fixed rpc.statd port; for firewall
+      lockdPort = 4001;
+      mountdPort = 4002;
+      statdPort = 4000;
+      extraNfsdConfig = '''';
+    };
+  };
 
   services.teleport = {
     enable = true;

--- a/nix/machines/hil-common.nix
+++ b/nix/machines/hil-common.nix
@@ -24,9 +24,8 @@ in
       connection = {
         autoconnect-priority = "-999";
         id = "Orb RCM Ethernet";
-        interface-name = "enp0s20f0u1"; # TODO: hard coding?
+        interface-name = "orbeth0";
         type = "ethernet";
-        uuid = "eb829d4c-5314-38d1-98fc-a31b4be8892f"; # TODO make this not hard coded?
       };
       ethernet = { };
       ipv4 = {
@@ -39,6 +38,16 @@ in
       proxy = { };
     };
   };
+  # Give the jetson USB ethernet a known name
+  services.udev.extraRules = ''
+    ACTION=="add", \
+    SUBSYSTEM=="net", \
+    SUBSYSTEMS=="usb", \
+    ATTRS{idVendor}=="0955", \
+    ATTRS{idProduct}=="7035", \
+    NAME="orbeth0"
+  '';
+
 
 
   # Set your time zone.

--- a/nix/machines/nixos-common.nix
+++ b/nix/machines/nixos-common.nix
@@ -111,7 +111,7 @@ in
     #   "kernel.unprivileged_userns_clone" = 1;
     # };
     # Needed for https://github.com/NixOS/nixpkgs/issues/58959
-    supportedFilesystems = lib.mkForce [ "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
+    supportedFilesystems = lib.mkForce [ "nfs" "btrfs" "reiserfs" "vfat" "f2fs" "xfs" "ntfs" "cifs" ];
 
     # Docs: https://elixir.bootlin.com/linux/v6.12.1/source/Documentation/admin-guide/serial-console.rst
     # All consoles listed here will be usable and are automatically logged into.

--- a/nix/shells/tegra-bash.nix
+++ b/nix/shells/tegra-bash.nix
@@ -18,6 +18,7 @@ pkgs.buildFHSEnv {
   name = "tegra-bash";
   targetPkgs = pkgs: (with pkgs; [
     (python3.withPackages pythonShell)
+    abootimg
     bun
     curl
     dtc


### PR DESCRIPTION
This PR does several things:
* adds the necessary packages to the `tegra-bash` FHSEnv to enable the use of the boot-from-ram bootloader0 scripts.
* Configures a known name for the network interface of the orb's RCM ethernet, based on VID and PID, and names it `orbeth0`. This allows us to replicate our configuration across many orbs and NUCs.
* Configures a networkmanager connection for `orbeth0`, in particular setting it as a "shared" connection, which will cause the orb to run a DHCP server to assign ip addresses to the orb - necessary for NFS.
* Configures the NUC to run a NFS server. Anything under `/srv` will be exposed to the orb over NFS, and only on the local ipv4 10.42.0.0/24 subnet.
* Configures port forwarding for the NFS server.