### PR TITLE
fix: Fix dbus env setting in worldcoin-jobs-agent service file

### DIFF
--- a/jobs-agent/debian/worldcoin-jobs-agent.service
+++ b/jobs-agent/debian/worldcoin-jobs-agent.service
@@ -11,8 +11,6 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
 Environment=RUST_BACKTRACE=1
 ExecStart=/usr/local/bin/orb-jobs-agent
 SyslogIdentifier=worldcoin-jobs-agent
-User=worldcoin
-Group=worldcoin
 Restart=always
 
 [Install]

--- a/jobs-agent/debian/worldcoin-jobs-agent.service
+++ b/jobs-agent/debian/worldcoin-jobs-agent.service
@@ -7,7 +7,9 @@ Requires=network.target
 Environment="HOME=/home/worldcoin"
 WorkingDirectory=/home/worldcoin
 Type=exec
-ExecStart=/bin/bash -c 'exec env ORB_ID="$(/usr/local/bin/orb-id)" /usr/local/bin/orb-jobs-agent'
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
+Environment=RUST_BACKTRACE=1
+ExecStart=/usr/local/bin/orb-jobs-agent
 SyslogIdentifier=worldcoin-jobs-agent
 User=worldcoin
 Group=worldcoin

--- a/jobs-agent/src/args.rs
+++ b/jobs-agent/src/args.rs
@@ -28,7 +28,7 @@ pub struct Args {
     #[clap(long, env = "RELAY_HOST", default_value = None)]
     pub relay_host: Option<String>,
     /// The relay namespace.
-    #[clap(long, env = "RELAY_NAMESPACE", default_value = "fleet-cmdr")]
+    #[clap(long, env = "RELAY_NAMESPACE", default_value = "jobs")]
     pub relay_namespace: Option<String>,
     /// The target job-server service id to send messages to.
     #[clap(long, env = "TARGET_SERVICE_ID", default_value = "job-server")]


### PR DESCRIPTION
Also corrects the relay namespace that the orb-jobs-agent uses to communicate with the jobs server. 