### PR TITLE
feat(mcu-util): diag data

### DIFF
--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -40,7 +40,7 @@ struct Args {
 enum SubCommand {
     /// Print Orb's state data
     #[clap(action)]
-    Info,
+    Info(InfoOpts),
     /// Reboot a microcontroller. Rebooting the main MCU can be used to reboot the Orb.
     #[clap(subcommand)]
     Reboot(Mcu),
@@ -68,6 +68,13 @@ enum SubCommand {
     },
     #[clap(subcommand)]
     PowerCycle(PowerCycleComponent),
+}
+
+#[derive(Parser, Debug)]
+pub struct InfoOpts {
+    /// Print Orb's diagnostic data
+    #[clap(short, long, default_value = "false")]
+    diag: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -240,8 +247,8 @@ async fn execute(args: Args) -> Result<()> {
     let (mut orb, orb_tasks) = Orb::new(args.can_fd).await?;
 
     match args.subcmd {
-        SubCommand::Info => {
-            let orb_info = orb.get_info().await?;
+        SubCommand::Info(opts) => {
+            let orb_info = orb.get_info(opts.diag).await?;
             debug!("{:?}", orb_info);
             println!("{:#}", orb_info);
         }

--- a/mcu-util/src/orb/security_board.rs
+++ b/mcu-util/src/orb/security_board.rs
@@ -173,7 +173,7 @@ impl Board for SecurityBoard {
         Ok(())
     }
 
-    async fn fetch_info(&mut self, info: &mut OrbInfo) -> Result<()> {
+    async fn fetch_info(&mut self, info: &mut OrbInfo, _diag: bool) -> Result<()> {
         let board_info = SecurityBoardInfo::new()
             .build(self)
             .await


### PR DESCRIPTION
show hardware states when `--diag` is passed with `info` command

full command: 
```
./orb-mcu-util info --diag
🔮 Orb info:
	revision:	Diamond_DVT1
	battery charge:	13%
	voltage:	13430mV
	charging:	no
🚜 Main board:
	current image:	v3.1.7-0x0 (dev)
	secondary slot:	v1.2.3-0x4 (prod)
🔐 Security board:
	current image:	v3.1.5-0x0 (dev)
	secondary slot:	v37.100.0-0x54534557 (prod)
	battery charge:	100%
	voltage:	4130mV
	charging:	no

🛠️ Hardware states:
als          STATUS_SUCCESS                      
fan_tach     STATUS_SUCCESS                      
ir_self      STATUS_ERROR_INVALID_PARAM          💎️safety self-test not impl
polarizer    STATUS_SUCCESS                      homed
pvcc         STATUS_SUCCESS                      ir leds usable
sound        STATUS_SUCCESS                      
tmp_front    STATUS_SUCCESS                      
tmp_lens     STATUS_SUCCESS                      
tmp_main     STATUS_SUCCESS                      
```