### PR TITLE
fix(iso-tp): orb-mcu-util with can-fd

### DIFF
--- a/update-verifier/debian/orb-update-verifier.worldcoin-update-verifier.service
+++ b/update-verifier/debian/orb-update-verifier.worldcoin-update-verifier.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Worldcoin Update Verifier Service.
 StartLimitInterval=0
+After=worldcoin-configure-can@can0.service worldcoin-create-hardware-version.service
 
 [Service]
 Type=oneshot

--- a/update-verifier/src/lib.rs
+++ b/update-verifier/src/lib.rs
@@ -57,6 +57,7 @@ pub fn run() -> eyre::Result<()> {
 pub fn get_mcu_util_info() -> Result<String, Error> {
     // Get the current MCU version from orb-mcu-util
     let mcu_util_output = Command::new("orb-mcu-util")
+        .arg("--can-fd")
         .arg("info")
         .output()
         .map_err(|e| eyre!("Failed to run orb-mcu-util: {e}"))?;


### PR DESCRIPTION
when booting, isotp errors are detected on the mcu side because both worldcoin-create-hardware-version and update-verifier are trying to communicate with the mcu over iso-tp with the same pair of addresses

use can-fd to prevent that issue from happening
