### PR TITLE
chore(blob): change test ok to more descriptive name

### DIFF
--- a/orb-blob/tests/health.rs
+++ b/orb-blob/tests/health.rs
@@ -4,7 +4,7 @@ use reqwest::StatusCode;
 mod fixture;
 
 #[tokio::test]
-async fn ok() {
+async fn test_health_endpoint_returns_no_content() {
     let fx = Fixture::new().await;
 
     let res = reqwest::get(format!("http://{}/health", fx.addr))


### PR DESCRIPTION
prevents confusing messages on the terminal when tests are run