### PR TITLE
fix typos in documentation and comments

### DIFF
--- a/backend-status/README.md
+++ b/backend-status/README.md
@@ -1,5 +1,5 @@
 # orb-backend-status
 
-This daemon provide a dbus sink to collect status from varous orb systems and periodically provide them to the Orb Fleet Backend.
+This daemon provide a dbus sink to collect status from various orb systems and periodically provide them to the Orb Fleet Backend.
 
 If you are on mac, be sure that you installed dbus. See the toplevel [README.md]

--- a/slot-ctrl/src/lib.rs
+++ b/slot-ctrl/src/lib.rs
@@ -186,7 +186,7 @@ impl OrbSlotCtrl {
                 // We don't do anything else here because marking slot as ok is handled on Diamond by:
                 // /opt/nvidia/l4t-rootfs-validation-config
                 // /opt/nvidia/l4t-bootloader-config
-                // Once or if we remove acccess to /dev/mem, the nvidia services will break and we will
+                // Once or if we remove access to /dev/mem, the nvidia services will break and we will
                 // need to do it ourselves.
 
                 Ok(())

--- a/supervisor/src/interfaces/manager.rs
+++ b/supervisor/src/interfaces/manager.rs
@@ -136,7 +136,7 @@ impl Manager {
         let conn = self
             .system_connection
             .as_ref()
-            .expect("manager must be conntected to system dbus");
+            .expect("manager must be connected to system dbus");
         let systemd_proxy = systemd1::ManagerProxy::new(conn).await?;
         // Spawn task to shut down worldcoin core
         let mut shutdown_core_task =


### PR DESCRIPTION


## Description

This PR fixes several typos found in documentation and code comments across the codebase:

### Changes Made

- **`backend-status/README.md`**: Fixed "varous" → "various" in service description
- **`slot-ctrl/src/lib.rs`**: Fixed "acccess" → "access" in comment
- **`supervisor/src/interfaces/manager.rs`**: Fixed "conntected" → "connected" in expect message

