### PR TITLE
fix(blobs): better seeds for keys

### DIFF
--- a/orb-blob/p2p/tests/two_peers_1_bootstrap.rs
+++ b/orb-blob/p2p/tests/two_peers_1_bootstrap.rs
@@ -4,7 +4,7 @@ use color_eyre::Result;
 use eyre::Context;
 use iroh::{NodeId, SecretKey};
 use orb_blob_p2p::{BlobRef, Client};
-use rand::{RngCore, SeedableRng};
+use rand::SeedableRng;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -132,14 +132,8 @@ async fn spawn_node(
 }
 
 fn example_keys(n: u8) -> Vec<SecretKey> {
-    const SEED: u64 = 1337; // seed for reproducibility of tests
+    const SEED: u64 = 12390691653007221674; // seed for reproducibility of tests
     let mut rng = rand::rngs::StdRng::seed_from_u64(SEED);
 
-    let mut bytes = [0; 32];
-    (0..n)
-        .map(|_| {
-            rng.fill_bytes(&mut bytes);
-            SecretKey::from_bytes(&bytes)
-        })
-        .collect()
+    (0..n).map(|_| SecretKey::generate(&mut rng)).collect()
 }

--- a/orb-blob/tests/e2e_node_share.rs
+++ b/orb-blob/tests/e2e_node_share.rs
@@ -1,6 +1,7 @@
 use async_tempfile::TempFile;
 use fixture::Fixture;
 use iroh::SecretKey;
+use rand::SeedableRng;
 use reqwest::{Client, StatusCode};
 use serde_json::json;
 use std::time::Duration;
@@ -8,17 +9,17 @@ use tokio::fs;
 
 mod fixture;
 
+const SEED: u64 = 10838079729341059672;
+
 #[tokio::test]
 async fn it_shares_files_across_nodes() {
     color_eyre::install().unwrap();
     tracing_subscriber::fmt::init();
 
     // Arrange
-    let upload_fx_key =
-        SecretKey::from_bytes("a".repeat(32).as_bytes().try_into().unwrap());
-
-    let download_fx_key =
-        SecretKey::from_bytes("z".repeat(32).as_bytes().try_into().unwrap());
+    let mut rng = rand::rngs::StdRng::seed_from_u64(SEED);
+    let upload_fx_key = SecretKey::generate(&mut rng);
+    let download_fx_key = SecretKey::generate(&mut rng);
 
     let well_known_nodes = vec![upload_fx_key.public(), download_fx_key.public()];
 


### PR DESCRIPTION
just in case we are using secretkeys in our tests that others on the iroh discovery service are using, this will help avoid collisions.