### PR TITLE
fix(blobs): stop broadcasting when no bootstrap

### DIFF
--- a/orb-blob/src/program.rs
+++ b/orb-blob/src/program.rs
@@ -27,6 +27,7 @@ pub async fn run(
     listener: TcpListener,
     shutdown: CancellationToken,
 ) -> Result<()> {
+    let is_well_known_nodes_empty = cfg.well_known_nodes.is_empty();
     let port = cfg.port;
     let deps = Deps::new(cfg).await?;
     let blob_store = deps.blob_store.clone();
@@ -34,10 +35,13 @@ pub async fn run(
     let blob_store_clone = deps.blob_store.clone();
     let p2pclient_clone = deps.p2pclient.clone();
     let shutdown_broadcast = shutdown.child_token();
+
     let broadcast_task = async move {
-        broadcast_and_shit(p2pclient_clone, blob_store_clone, shutdown_broadcast)
-            .await
-            .wrap_err("task panicked")?;
+        if !is_well_known_nodes_empty {
+            broadcast_and_shit(p2pclient_clone, blob_store_clone, shutdown_broadcast)
+                .await
+                .wrap_err("task panicked")?;
+        }
 
         Ok(())
     };

--- a/orb-blob/tests/blob_create.rs
+++ b/orb-blob/tests/blob_create.rs
@@ -14,7 +14,7 @@ async fn it_adds_a_file_to_the_store() {
     tracing_subscriber::fmt::init();
 
     // Arrange
-    let mut fx = Fixture::builder().build().await;
+    let mut fx = Fixture::builder().well_known_nodes(vec![]).build().await;
     let client = Client::new();
     let store_path = fx.blob_store.dir_path().to_str().unwrap().to_owned();
 

--- a/orb-blob/tests/blob_delete.rs
+++ b/orb-blob/tests/blob_delete.rs
@@ -7,12 +7,13 @@ use std::str::FromStr;
 use tokio::fs;
 mod fixture;
 
-#[allow(dead_code)]
+#[tokio::test]
+#[ignore = "deletion isnt working yet"]
 async fn it_deletes_a_file_from_store() {
     color_eyre::install().unwrap();
     tracing_subscriber::fmt::init();
 
-    let mut fx = Fixture::builder().build().await;
+    let mut fx = Fixture::builder().well_known_nodes(vec![]).build().await;
     let client = Client::new();
     let store_path = fx.blob_store.dir_path().to_owned();
 

--- a/orb-blob/tests/e2e_node_share.rs
+++ b/orb-blob/tests/e2e_node_share.rs
@@ -45,7 +45,10 @@ async fn it_shares_files_across_nodes() {
     let download_file = TempFile::new().await.unwrap();
     let download_file_path = download_file.file_path().to_str().unwrap();
 
-    let client = Client::new();
+    let client = Client::builder()
+        .timeout(Duration::from_secs(20))
+        .build()
+        .unwrap();
 
     // Upload
     let res = client

--- a/orb-blob/tests/fixture.rs
+++ b/orb-blob/tests/fixture.rs
@@ -27,7 +27,7 @@ impl Fixture {
     pub async fn new(
         #[builder(default = 1)] min_peer_req: usize,
         #[builder(default=Duration::from_secs(30))] peer_listen_timeout: Duration,
-        #[builder(default=Vec::new())] well_known_nodes: Vec<PublicKey>,
+        well_known_nodes: Vec<PublicKey>,
         secret_key: Option<SecretKey>,
         #[builder(default = true)] local: bool,
     ) -> Self {

--- a/orb-blob/tests/health.rs
+++ b/orb-blob/tests/health.rs
@@ -8,7 +8,7 @@ async fn test_health_endpoint_returns_no_content() {
     color_eyre::install().unwrap();
     tracing_subscriber::fmt::init();
 
-    let fx = Fixture::builder().build().await;
+    let fx = Fixture::builder().well_known_nodes(vec![]).build().await;
 
     let res = reqwest::get(format!("http://{}/health", fx.addr))
         .await


### PR DESCRIPTION
Its an error to try and broadcast when there are no bootstrap nodes, and the library (intentionally) panics. We should stop attempting to broadcast in cases where we are the only node / we have no bootstrap nodes.