### PR TITLE
update link to .cargo/config.toml

### DIFF
--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -92,7 +92,7 @@ tokio-console`, then scp it over.
 
 Then, you must build the binary you want to debug unstable tokio features
 enabled. To do this, uncomment the line in
-[.cargo/config.toml](.cargo/config.toml) about tokio unstable. 
+[.cargo/config.toml](https://github.com/gap-editor/orb-software/blob/main/.cargo/config.toml) about tokio unstable. 
 
 Finally, make sure that the binary has the appropriate RUST_LOG level set up.
 try using `RUST_LOG="info,tokio=trace,runtime=trace"`.


### PR DESCRIPTION
non-working link (redirect) is [here](https://worldcoin.github.io/orb-software/development.html). we need to change hyperlink-method because with previous one opens-pages (https://worldcoin.github.io/orb-software/.cargo/config.toml)