### PR TITLE
chore(jobs-agent): add to systemd-journal group

### DIFF
--- a/jobs-agent/debian/worldcoin-jobs-agent.service
+++ b/jobs-agent/debian/worldcoin-jobs-agent.service
@@ -12,6 +12,7 @@ Environment=RUST_BACKTRACE=1
 ExecStart=/usr/local/bin/orb-jobs-agent
 SyslogIdentifier=worldcoin-jobs-agent
 Restart=always
+SupplementaryGroups=systemd-journal
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
adds jobs-agent to `systemd-journal` group in order to be able to read logs