### PR TITLE
test(jobs-agent): test canceling a job works

### DIFF
--- a/jobs-agent/src/handlers/logs.rs
+++ b/jobs-agent/src/handlers/logs.rs
@@ -85,6 +85,8 @@ pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
                     .send()
                     .await
                     .map_err(|e| eyre!("failed to send progress update!: {e:?}"))?;
+
+                line.clear();
             }
         }
     }

--- a/jobs-agent/src/handlers/reboot.rs
+++ b/jobs-agent/src/handlers/reboot.rs
@@ -34,7 +34,7 @@ pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
                 .await?;
 
             ctx.progress()
-                .stdout("rebooting")
+                .stdout("rebooting\n")
                 .send()
                 .await
                 .map_err(|e| eyre!("failed to send progress {e:?}"))?;

--- a/jobs-agent/src/job_system/client.rs
+++ b/jobs-agent/src/job_system/client.rs
@@ -52,7 +52,8 @@ impl JobClient {
                         match JobNotify::decode(any.value.as_slice()) {
                             Ok(job_notify) => {
                                 info!("received JobNotify: {:?}", job_notify);
-                                let _ = self.request_next_job().await;
+                                let running_job_ids = self.job_registry.get_active_job_ids().await;
+                                let _ = self.request_next_job_with_running_ids(&running_job_ids).await;
                             }
                             Err(e) => {
                                 error!("error decoding JobNotify: {:?}", e);

--- a/jobs-agent/src/job_system/client.rs
+++ b/jobs-agent/src/job_system/client.rs
@@ -1,6 +1,6 @@
 use crate::job_system::orchestrator::{JobConfig, JobRegistry};
 use color_eyre::eyre::Result;
-use orb_relay_client::{Client, SendMessage};
+use orb_relay_client::{Client, QoS, SendMessage};
 use orb_relay_messages::{
     jobs::v1::{
         JobCancel, JobExecution, JobExecutionUpdate, JobNotify, JobRequestNext,
@@ -128,6 +128,7 @@ impl JobClient {
                 SendMessage::to(EntityType::Service)
                     .id(self.target_service_id.clone())
                     .namespace(self.relay_namespace.clone())
+                    .qos(QoS::AtLeastOnce)
                     .payload(any.encode_to_vec()),
             )
             .await
@@ -209,6 +210,7 @@ impl JobClient {
                 SendMessage::to(EntityType::Service)
                     .id(self.target_service_id.clone())
                     .namespace(self.relay_namespace.clone())
+                    .qos(QoS::AtLeastOnce)
                     .payload(any.encode_to_vec()),
             )
             .await

--- a/jobs-agent/src/job_system/client.rs
+++ b/jobs-agent/src/job_system/client.rs
@@ -52,8 +52,11 @@ impl JobClient {
                         match JobNotify::decode(any.value.as_slice()) {
                             Ok(job_notify) => {
                                 info!("received JobNotify: {:?}", job_notify);
-                                let running_job_ids = self.job_registry.get_active_job_ids().await;
-                                let _ = self.request_next_job_with_running_ids(&running_job_ids).await;
+                                let running_job_ids =
+                                    self.job_registry.get_active_job_ids().await;
+                                let _ = self
+                                    .request_next_job_with_running_ids(&running_job_ids)
+                                    .await;
                             }
                             Err(e) => {
                                 error!("error decoding JobNotify: {:?}", e);

--- a/jobs-agent/src/job_system/handler.rs
+++ b/jobs-agent/src/job_system/handler.rs
@@ -310,6 +310,11 @@ impl JobHandler {
             }
         }
 
+        if self.job_registry.is_job_active(ctx.execution_id()).await {
+            info!("trying to execute a job that is already running. ignored");
+            return self;
+        }
+
         // Create completion channel for this job
         let (completion_tx, completion_rx) = oneshot::channel();
 

--- a/jobs-agent/src/job_system/handler.rs
+++ b/jobs-agent/src/job_system/handler.rs
@@ -311,7 +311,12 @@ impl JobHandler {
         }
 
         if self.job_registry.is_job_active(ctx.execution_id()).await {
-            info!("trying to execute a job that is already running. ignored");
+            info!(
+                "trying to execute a job that is already running. ignored. {} {}",
+                ctx.cmd(),
+                ctx.execution_id()
+            );
+
             return self;
         }
 

--- a/jobs-agent/src/job_system/orchestrator.rs
+++ b/jobs-agent/src/job_system/orchestrator.rs
@@ -21,7 +21,7 @@ pub struct JobRegistry {
 struct ActiveJob {
     job_type: String,
     cancel_token: CancellationToken,
-    handle: tokio::task::JoinHandle<()>,
+    _handle: tokio::task::JoinHandle<()>,
 }
 
 impl Default for JobRegistry {
@@ -51,7 +51,7 @@ impl JobRegistry {
             ActiveJob {
                 job_type,
                 cancel_token: cancellation_token,
-                handle: task_handle,
+                _handle: task_handle,
             },
         );
     }
@@ -68,7 +68,6 @@ impl JobRegistry {
         if let Some(active_job) = jobs.get(job_execution_id) {
             info!("Cancelling job: {}", job_execution_id);
             active_job.cancel_token.cancel();
-            active_job.handle.abort();
             true
         } else {
             warn!("Attempted to cancel non-existent job: {}", job_execution_id);

--- a/jobs-agent/tests/job_handler.rs
+++ b/jobs-agent/tests/job_handler.rs
@@ -41,10 +41,7 @@ async fn sequential_jobs_block_other_jobs_execution() {
 
     // Assert
     let results = fx.execution_updates.map_iter(|x| x.std_out).await;
-    // unsure: this here is only if jobnotify isn't sent on every job being added
-    // assert_eq!(results, ["one", "two"]);
-    // this here is if jobnotiffy is always sent
-    assert_eq!(results, ["one"]);
+    assert_eq!(results, ["one", "two"]);
 }
 
 // flakey on macOS, once i fix flakyness i can remove it

--- a/jobs-agent/tests/job_handler.rs
+++ b/jobs-agent/tests/job_handler.rs
@@ -1,3 +1,4 @@
+use color_eyre::eyre::bail;
 use common::fixture::JobAgentFixture;
 use orb_jobs_agent::{
     job_system::{ctx::JobExecutionUpdateExt, handler::JobHandler},
@@ -5,7 +6,10 @@ use orb_jobs_agent::{
     shell::Host,
 };
 use std::time::Duration;
-use tokio::{task, time};
+use tokio::{
+    task,
+    time::{self, Instant},
+};
 
 mod common;
 
@@ -37,7 +41,10 @@ async fn sequential_jobs_block_other_jobs_execution() {
 
     // Assert
     let results = fx.execution_updates.map_iter(|x| x.std_out).await;
-    assert_eq!(results, ["one", "two"]);
+    // unsure: this here is only if jobnotify isn't sent on every job being added
+    // assert_eq!(results, ["one", "two"]);
+    // this here is if jobnotiffy is always sent
+    assert_eq!(results, ["one"]);
 }
 
 // flakey on macOS, once i fix flakyness i can remove it
@@ -74,4 +81,47 @@ async fn can_start_parallel_jobs_in_parallel() {
 #[tokio::test]
 async fn parallel_jobs_dont_exceed_max() {
     // TODO!
+}
+
+#[tokio::test]
+async fn it_cancels_a_long_running_job() {
+    // Arrange
+    let fx = JobAgentFixture::with_namespace("cancel_long_running_job").await;
+    let deps = Deps::new(Host, fx.settings.clone());
+
+    let wait_time = Duration::from_millis(50);
+
+    task::spawn(
+        JobHandler::builder()
+            .parallel("timeout", move |ctx| async move {
+                let start = Instant::now();
+
+                loop {
+                    if start.elapsed() > Duration::from_secs(5) {
+                        bail!("timed out!");
+                    }
+
+                    if ctx.is_cancelled() {
+                        break;
+                    }
+
+                    println!("looping!");
+                    time::sleep(wait_time).await;
+                }
+
+                Ok(ctx.success().stdout("cancelled succesfully!"))
+            })
+            .build(deps)
+            .run(),
+    );
+
+    // Act
+    let exec_id = fx.enqueue_job("timeout").await;
+    time::sleep(wait_time * 4).await;
+    fx.cancel_job(&exec_id).await;
+    time::sleep(wait_time * 4).await;
+
+    // Assert
+    let results = fx.execution_updates.map_iter(|x| x.std_out).await;
+    assert_eq!(results[0], "cancelled succesfully!");
 }

--- a/jobs-agent/tests/reboot.rs
+++ b/jobs-agent/tests/reboot.rs
@@ -26,7 +26,7 @@ async fn it_reboots() {
     let pending_execution_id = fs::read_to_string(&reboot_lockfile).await.unwrap();
 
     assert_eq!(execution_id, pending_execution_id);
-    assert_eq!(actual.std_out, "rebooting");
+    assert_eq!(actual.std_out, "rebooting\n");
     assert_eq!(actual.status, JobExecutionStatus::InProgress as i32);
 
     // 2. Simulate Orb Reboot


### PR DESCRIPTION
## tests
- add a test to be sure cancelling a job works

## fixes
- memory leak when tailing logss
- race condition due `JobClient::listen_for_jobs` not including ids to ignore and main handle function not checking if id is of a job already running
- lack of retry for `AuthToken` acquisition