### PR TITLE
fix(jobs-agent): race condition whenrequesting a new job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7695,6 +7695,7 @@ dependencies = [
  "dashmap 6.1.0",
  "dbus-launch",
  "figment",
+ "flume",
  "futures",
  "libc",
  "listenfd",

--- a/jobs-agent/Cargo.toml
+++ b/jobs-agent/Cargo.toml
@@ -73,6 +73,7 @@ orb-build-info = { workspace = true, features = ["build-script"] }
 [dev-dependencies]
 async-tempfile = { workspace = true }
 dbus-launch = "0.2.0"
+flume.workspace = true
 serial_test = "3.2.0"
 test-utils = { workspace = true }
 test-with.workspace = true

--- a/jobs-agent/README.md
+++ b/jobs-agent/README.md
@@ -1,29 +1,33 @@
-# Orb Jobs Agent (jobs-agent)
+# Orb Jobs Agent (orb-jobs-agent)
 
-The Orb Jobs Agent is a process to provide remote execution of prescribed commands. Commands are invoked by incoming requests and the functionality of the command is provided completely by the Orb implementation.
-
-## Jobs Agent Operation
-
-The jobs agent client and server exchange job request messages and execution results in a manner described below.
+The Orb Jobs Agent is a process to provide remote execution of prescribed commands. Commands are invoked by incoming requests and the
+functionality of the command is provided completely by the Orb implementation.
 
 ### Taxonomy
 
-- **Job**: A set of commands issued to one or more Orbs. Jobs are created by external applications such as the Orb Fleet CLI tool.
-- **Job Notify**: A notification sent from the Server to the Client that new jobs are pending.
-- **Job Request**: A request from the Client to the Server to send the next Job Execution.
-- **Job Execution**: A specific command to execute by the current Orb
-- **Job Update**: A result from the Orb describing the outcome or progress of a command execution
+- `orb-jobs-agent`: A systemd service that runs on the orb, executing a `JobExecution`(s) sent by `fleet-cmdr`
+- `fleet-cmdr`: A backend service owned by the Fleet Management team that sends `JobExecution`(s) to the orb. 
+- `JobNotify`: A notification sent from `fleet-cmdr` to the `orb-jobs-agent` that new jobs are pending.
+- `JobRequestNext`: A request from the `orb-jobs-agent` to the `fleet-cmdr` to send the next `JobExecution`.
+- `JobExecution`: A specific command to execute by the current Orb
+- `JobExecutionUpdate`: A result from the `orb-jobs-agent` describing the outcome or progress of a command execution
+- `JobCancel`: A cancellation request to stop a running job in `orb-jobs-agent`.
 
-### Protocol
+### fleet-cmdr's role from the orb-jobs-agent perspective
+- `fleet-cmdr` provides an interface for users to enqueue new jobs to its internal queue
+- when a new job is enqueued in `fleet-cmdr`, it sends a `JobNotify` to `orb-jobs-agent`
+- when `fleet-cmdr` receives a `JobRequestNext` from `orb-jobs-agent`, it sends the first job (that is not already 
+in progress) from its queue
+- when `fleet-cmdr` receives a `JobExecutionUpdate` from `orb-jobs-agent`, it removes that job from its internal queue
 
-The Jobs Agent connects to the Orb Relay on startup, then follows this protocol:
+### orb-jobs-agent role
+- on startup, `orb-jobs-agent` requests `fleet-cmdr` for a new job with `JobRequestNext`
+- when `orb-jobs-agent` receives a `JobNotify` from `fleet-cmdr` it requests a new job with a `JobRequestNext`
+- when `orb-jobs-agent` receives a `JobExecution` from `fleet-cmdr` it executes a job
+- on completion of a job, `orb-jobs-agent` reports back to `fleet-cmdr` with a `JobExecutionUpdate`
+- on completion of a job, `orb-jobs-agent` requests `fleet-cmdr` for a new job with a `JobRequestNext`
 
-1. Client send a **Job Request**
-2. If any **Job Executions** are pending for the Orb the next one is sent to the Client
-3. The Client performs the command and returns a **Job Update** back to the Service to indicate the outcome or progress of the command.
-4. The Server receives the **Job Update** it records the status and provided output. If the **Job Update** status is:
-   - IN PROGRESS: record the state any progress output. Wait for further **Job Updates**
-   - SUCCESS: update the current **Job** as succeeded for this Orb. Send the next **Job Execution** for the current **Job** (if available), or from the next **Job** (if available) to the client
-   - FAILED: update the current **Job** as 'failed' for this Orb. Send the next **Job Execution** from the next **Job** (if available)
-5. Once all pending **Job Executions** are performed, the client will wait for the next **Job Notify** from the Server. 
-6. On receiving **Job Notify** go to step 1.
+### notes
+- jobs can be cancelled
+- some jobs can be run in parallel, other jobs not
+

--- a/jobs-agent/README.md
+++ b/jobs-agent/README.md
@@ -17,7 +17,7 @@ functionality of the command is provided completely by the Orb implementation.
 - `fleet-cmdr` provides an interface for users to enqueue new jobs to its internal queue
 - when a new job is enqueued in `fleet-cmdr`, it sends a `JobNotify` to `orb-jobs-agent`
 - when `fleet-cmdr` receives a `JobRequestNext` from `orb-jobs-agent`, it sends the first job (that is not already 
-in progress) from its queue
+in progress) from its queue with `JobExecution`
 - when `fleet-cmdr` receives a `JobExecutionUpdate` from `orb-jobs-agent`, it removes that job from its internal queue
 
 ### orb-jobs-agent role

--- a/jobs-agent/src/job_system/client.rs
+++ b/jobs-agent/src/job_system/client.rs
@@ -52,11 +52,7 @@ impl JobClient {
                         match JobNotify::decode(any.value.as_slice()) {
                             Ok(job_notify) => {
                                 info!("received JobNotify: {:?}", job_notify);
-                                let running_job_ids =
-                                    self.job_registry.get_active_job_ids().await;
-                                let _ = self
-                                    .request_next_job_with_running_ids(&running_job_ids)
-                                    .await;
+                                let _ = self.request_next_job().await;
                             }
                             Err(e) => {
                                 error!("error decoding JobNotify: {:?}", e);
@@ -105,29 +101,21 @@ impl JobClient {
         }
     }
 
-    /// Requests for a next job to be run, regardless of what jobs
-    /// might be running.
-    pub async fn request_next_job(&self) -> Result<(), orb_relay_client::Err> {
-        self.request_next_job_with_running_ids(&[]).await
-    }
-
     /// Requests for a next job to be run, excluding the ones that are
     /// currently running (determined by `running_job_execution_ids` arg)
-    pub async fn request_next_job_with_running_ids(
-        &self,
-        running_job_execution_ids: &[String],
-    ) -> Result<(), orb_relay_client::Err> {
-        // Create JobRequestNext with ignore_job_execution_ids field
-        let job_request = if running_job_execution_ids.is_empty() {
-            JobRequestNext::default()
-        } else {
-            // Create JobRequestNext with running job execution IDs to ignore
-            self.create_job_request_with_ignore_ids(running_job_execution_ids)
+    pub async fn request_next_job(&self) -> Result<(), orb_relay_client::Err> {
+        let mut running_ids = self.job_registry.get_active_job_ids().await;
+        let mut completed_ids = self.job_registry.get_completed_job_ids().await;
+
+        running_ids.append(&mut completed_ids);
+        let job_ids_to_ignore = running_ids;
+
+        let job_request = JobRequestNext {
+            ignore_job_execution_ids: job_ids_to_ignore.clone(),
         };
 
         let any = Any::from_msg(&job_request).unwrap();
-        match self
-            .relay_client
+        self.relay_client
             .send(
                 SendMessage::to(EntityType::Service)
                     .id(self.target_service_id.clone())
@@ -135,39 +123,15 @@ impl JobClient {
                     .qos(QoS::AtLeastOnce)
                     .payload(any.encode_to_vec()),
             )
-            .await
-        {
-            Ok(_) => {
-                if running_job_execution_ids.is_empty() {
-                    info!(
-                        "sent JobRequestNext to namespace: {}, service: {}",
-                        self.relay_namespace, self.target_service_id
-                    );
-                } else {
-                    info!(
-                        "sent JobRequestNext ignoring {} job execution IDs: {:?}",
-                        running_job_execution_ids.len(),
-                        running_job_execution_ids
-                    );
-                }
-                Ok(())
-            }
-            Err(e) => {
-                error!("error sending JobRequestNext: {:?}", e);
-                Err(e)
-            }
-        }
-    }
+            .await?;
 
-    fn create_job_request_with_ignore_ids(
-        &self,
-        running_job_execution_ids: &[String],
-    ) -> JobRequestNext {
-        // Create a JobRequestNext with ignore_job_execution_ids field populated
-        // This tells the backend to ignore these job execution IDs when determining the next job
-        JobRequestNext {
-            ignore_job_execution_ids: running_job_execution_ids.to_vec(),
-        }
+        info!(
+            "sent JobRequestNext ignoring {} job execution IDs: {:?}",
+            job_ids_to_ignore.len(),
+            job_ids_to_ignore
+        );
+
+        Ok(())
     }
 
     /// Check if we should request more jobs and do so if appropriate
@@ -183,23 +147,14 @@ impl JobClient {
             return Ok(false);
         }
 
-        // Get currently running job execution IDs
-        let running_job_ids = self.job_registry.get_active_job_ids().await;
-
         // Request next job with current running job IDs
-        match self
-            .request_next_job_with_running_ids(&running_job_ids)
+        self.request_next_job()
             .await
-        {
-            Ok(()) => {
-                info!("Successfully requested additional job for parallel execution");
-                Ok(true)
-            }
-            Err(e) => {
-                error!("Failed to request additional job: {:?}", e);
-                Err(e)
-            }
-        }
+            .inspect_err(|e| error!("Failed to request additional job: {:?}", e))?;
+
+        info!("Successfully requested additional job for parallel execution");
+
+        Ok(true)
     }
 
     pub async fn send_job_update(
@@ -208,8 +163,7 @@ impl JobClient {
     ) -> Result<(), orb_relay_client::Err> {
         info!("sending job update: {:?}", job_update);
         let any = Any::from_msg(job_update).unwrap();
-        match self
-            .relay_client
+        self.relay_client
             .send(
                 SendMessage::to(EntityType::Service)
                     .id(self.target_service_id.clone())
@@ -218,16 +172,11 @@ impl JobClient {
                     .payload(any.encode_to_vec()),
             )
             .await
-        {
-            Ok(_) => {
-                info!("sent JobExecutionUpdate");
-                Ok(())
-            }
-            Err(e) => {
-                error!("error sending JobExecutionUpdate: {:?}", e);
-                Err(e)
-            }
-        }
+            .inspect_err(|e| error!("error sending JobExecutionUpdate: {:?}", e))?;
+
+        info!("sent JobExecutionUpdate");
+
+        Ok(())
     }
 }
 

--- a/jobs-agent/tests/check_my_orb.rs
+++ b/jobs-agent/tests/check_my_orb.rs
@@ -1,6 +1,5 @@
 use common::{fake_orb::FakeOrb, fixture::JobAgentFixture};
-use std::time::Duration;
-use tokio::{fs, time};
+use tokio::fs;
 
 mod common;
 
@@ -13,9 +12,10 @@ async fn it_executes_check_my_orb() {
     fx.spawn_program(FakeOrb::new().await);
 
     // Act
-    fx.enqueue_job("check_my_orb").await;
-    time::sleep(Duration::from_millis(1_000)).await; // give enough time exec cmd
-                                                     // TODO: USE NOTIFY FOR FLAKYNESS
+    fx.enqueue_job("check_my_orb")
+        .await
+        .wait_for_completion()
+        .await;
 
     // Assert
     let actual = fx

--- a/jobs-agent/tests/common/job_queue.rs
+++ b/jobs-agent/tests/common/job_queue.rs
@@ -41,7 +41,9 @@ impl JobQueue {
 
         let queued_job = QueuedJob { exec, ack_tx };
 
-        self.val.lock().await.push(queued_job);
+        let mut queue = self.val.lock().await;
+        queue.retain(|j| j.exec.job_execution_id != ticket.exec_id);
+        queue.push(queued_job);
 
         ticket
     }
@@ -68,6 +70,6 @@ impl JobQueue {
         };
 
         let removed_job = val.remove(pos);
-        removed_job.ack_tx.send(()).unwrap();
+        let _ = removed_job.ack_tx.send(());
     }
 }

--- a/jobs-agent/tests/common/job_queue.rs
+++ b/jobs-agent/tests/common/job_queue.rs
@@ -1,0 +1,73 @@
+#![allow(dead_code)]
+use orb_relay_messages::jobs::v1::JobExecution;
+use test_utils::async_bag::AsyncBag;
+
+/// A double for the job queue handling implemented on fleet-cmdr.
+///
+/// Cheap to clone (`AsyncBag` uses an `Arc` underneath).
+#[derive(Default, Clone, Debug)]
+pub struct JobQueue {
+    val: AsyncBag<Vec<QueuedJob>>,
+}
+
+#[derive(Debug)]
+pub struct QueuedJob {
+    exec: JobExecution,
+    /// Used to acknowledge job has been handled
+    ack_tx: flume::Sender<()>,
+}
+
+/// Ticket given once a job is enqueued.
+#[derive(Debug)]
+pub struct Ticket {
+    pub exec_id: String,
+    ack_rx: flume::Receiver<()>,
+}
+
+impl Ticket {
+    pub async fn wait_for_completion(&self) {
+        self.ack_rx.recv_async().await.unwrap();
+    }
+}
+
+impl JobQueue {
+    pub async fn enqueue(&self, exec: JobExecution) -> Ticket {
+        let (ack_tx, ack_rx) = flume::unbounded();
+
+        let ticket = Ticket {
+            exec_id: exec.job_execution_id.clone(),
+            ack_rx,
+        };
+
+        let queued_job = QueuedJob { exec, ack_tx };
+
+        self.val.lock().await.push(queued_job);
+
+        ticket
+    }
+
+    pub async fn next(&self, exec_ids_to_ignore: &[String]) -> Option<JobExecution> {
+        self.val
+            .lock()
+            .await
+            .iter()
+            .find(|j| !exec_ids_to_ignore.contains(&j.exec.job_execution_id))
+            .map(|j| &j.exec)
+            .cloned()
+    }
+
+    pub async fn handled(&self, job_exec_id: impl Into<String>) {
+        let job_exec_id = job_exec_id.into();
+
+        let mut val = self.val.lock().await;
+        let Some(pos) = val
+            .iter()
+            .position(|j| j.exec.job_execution_id == job_exec_id)
+        else {
+            return;
+        };
+
+        let removed_job = val.remove(pos);
+        removed_job.ack_tx.send(()).unwrap();
+    }
+}

--- a/jobs-agent/tests/common/mod.rs
+++ b/jobs-agent/tests/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod fake_orb;
 pub mod fixture;
+pub mod job_queue;

--- a/jobs-agent/tests/job_handler.rs
+++ b/jobs-agent/tests/job_handler.rs
@@ -13,8 +13,6 @@ use tokio::{
 
 mod common;
 
-// flakey on macOS, once i fix flakyness i can remove it
-#[cfg_attr(target_os = "macos", test_with::no_env(GITHUB_ACTIONS))]
 #[tokio::test]
 async fn sequential_jobs_block_other_jobs_execution() {
     // Arrange
@@ -36,16 +34,13 @@ async fn sequential_jobs_block_other_jobs_execution() {
 
     // Act
     fx.enqueue_job("first").await;
-    fx.enqueue_job("second").await;
-    time::sleep(wait_time * 2).await;
+    fx.enqueue_job("second").await.wait_for_completion().await;
 
     // Assert
     let results = fx.execution_updates.map_iter(|x| x.std_out).await;
     assert_eq!(results, ["one", "two"]);
 }
 
-// flakey on macOS, once i fix flakyness i can remove it
-#[cfg_attr(target_os = "macos", test_with::no_env(GITHUB_ACTIONS))]
 #[tokio::test]
 async fn can_start_parallel_jobs_in_parallel() {
     // Arrange
@@ -66,9 +61,9 @@ async fn can_start_parallel_jobs_in_parallel() {
     );
 
     // Act
-    fx.enqueue_job("first").await;
+    let ticket = fx.enqueue_job("first").await;
     fx.enqueue_job("second").await;
-    time::sleep(wait_time * 2).await;
+    ticket.wait_for_completion().await;
 
     // Assert
     let results = fx.execution_updates.map_iter(|x| x.std_out).await;
@@ -78,6 +73,22 @@ async fn can_start_parallel_jobs_in_parallel() {
 #[tokio::test]
 async fn parallel_jobs_dont_exceed_max() {
     // TODO!
+}
+
+#[tokio::test]
+async fn gracefully_handles_unsupported_cmds() {
+    // Arrange
+    let fx = JobAgentFixture::new().await;
+    let deps = Deps::new(Host, fx.settings.clone());
+
+    task::spawn(JobHandler::builder().build(deps).run());
+
+    // Act
+    fx.enqueue_job("joberoni").await.wait_for_completion().await;
+
+    // Assert
+    let results = fx.execution_updates.map_iter(|x| x.std_out).await;
+    assert_eq!(results, ["two", "one"]);
 }
 
 #[tokio::test]
@@ -113,10 +124,10 @@ async fn it_cancels_a_long_running_job() {
     );
 
     // Act
-    let exec_id = fx.enqueue_job("timeout").await;
+    let ticket = fx.enqueue_job("timeout").await;
     time::sleep(wait_time * 4).await;
-    fx.cancel_job(&exec_id).await;
-    time::sleep(wait_time * 4).await;
+    fx.cancel_job(&ticket.exec_id).await;
+    ticket.wait_for_completion().await;
 
     // Assert
     let results = fx.execution_updates.map_iter(|x| x.std_out).await;

--- a/jobs-agent/tests/job_handler.rs
+++ b/jobs-agent/tests/job_handler.rs
@@ -5,6 +5,7 @@ use orb_jobs_agent::{
     program::Deps,
     shell::Host,
 };
+use orb_relay_messages::jobs::v1::JobExecutionStatus;
 use std::time::Duration;
 use tokio::{
     task,
@@ -47,7 +48,7 @@ async fn can_start_parallel_jobs_in_parallel() {
     let fx = JobAgentFixture::new().await;
     let deps = Deps::new(Host, fx.settings.clone());
 
-    let wait_time = Duration::from_millis(100);
+    let wait_time = Duration::from_millis(500);
 
     task::spawn(
         JobHandler::builder()
@@ -87,8 +88,8 @@ async fn gracefully_handles_unsupported_cmds() {
     fx.enqueue_job("joberoni").await.wait_for_completion().await;
 
     // Assert
-    let results = fx.execution_updates.map_iter(|x| x.std_out).await;
-    assert_eq!(results, ["two", "one"]);
+    let results = fx.execution_updates.map_iter(|x| x.status).await;
+    assert_eq!(results, [JobExecutionStatus::FailedUnsupported as i32]);
 }
 
 #[tokio::test]

--- a/jobs-agent/tests/orb_details.rs
+++ b/jobs-agent/tests/orb_details.rs
@@ -1,21 +1,19 @@
 use common::fixture::JobAgentFixture;
 use orb_jobs_agent::shell::Host;
-use std::time::Duration;
-use tokio::time;
 
 mod common;
 
-// flakey on macOS, once i fix flakyness i can remove it
-#[cfg_attr(target_os = "macos", test_with::no_env(GITHUB_ACTIONS))]
 #[tokio::test]
-async fn reads_file_successfully() {
+async fn it_reads_orb_details_successfully() {
     // Arrange
     let fx = JobAgentFixture::new().await;
-    let _handle = fx.spawn_program(Host);
+    fx.spawn_program(Host);
 
     // Act
-    fx.enqueue_job("orb_details").await;
-    time::sleep(Duration::from_millis(100)).await; // act buffer
+    fx.enqueue_job("orb_details")
+        .await
+        .wait_for_completion()
+        .await;
 
     // Assert
     let actual = fx.execution_updates.map_iter(|x| x.std_out).await;

--- a/jobs-agent/tests/read_file.rs
+++ b/jobs-agent/tests/read_file.rs
@@ -1,13 +1,10 @@
 use async_tempfile::TempFile;
 use common::fixture::JobAgentFixture;
 use orb_jobs_agent::shell::Host;
-use std::time::Duration;
-use tokio::{fs, time};
+use tokio::fs;
 
 mod common;
 
-// flakey on macOS, once i fix flakyness i can remove it
-#[cfg_attr(target_os = "macos", test_with::no_env(GITHUB_ACTIONS))]
 #[tokio::test]
 async fn reads_file_successfully() {
     // Arrange
@@ -20,8 +17,10 @@ async fn reads_file_successfully() {
     fx.spawn_program(Host);
 
     // Act
-    fx.enqueue_job(format!("read_file {filepath}")).await;
-    time::sleep(Duration::from_millis(1_000)).await; // give enough time to read file
+    fx.enqueue_job(format!("read_file {filepath}"))
+        .await
+        .wait_for_completion()
+        .await;
 
     // Assert
     let result = fx.execution_updates.map_iter(|x| x.std_out).await;

--- a/jobs-agent/tests/reboot.rs
+++ b/jobs-agent/tests/reboot.rs
@@ -1,6 +1,7 @@
 use common::{fake_orb::FakeOrb, fixture::JobAgentFixture};
 use orb_relay_messages::jobs::v1::JobExecutionStatus;
-use tokio::fs;
+use std::time::Duration;
+use tokio::{fs, time};
 
 mod common;
 
@@ -16,7 +17,7 @@ async fn it_reboots() {
 
     // 1. Executes command, creates pending reboot lockfile
     let ticket = fx.enqueue_job("reboot").await;
-    ticket.wait_for_completion().await;
+    time::sleep(Duration::from_secs(1)).await;
 
     // Assert
     let jobs = fx.execution_updates.read().await;

--- a/jobs-agent/tests/reboot.rs
+++ b/jobs-agent/tests/reboot.rs
@@ -1,7 +1,6 @@
 use common::{fake_orb::FakeOrb, fixture::JobAgentFixture};
 use orb_relay_messages::jobs::v1::JobExecutionStatus;
-use std::time::Duration;
-use tokio::{fs, time};
+use tokio::fs;
 
 mod common;
 
@@ -16,8 +15,8 @@ async fn it_reboots() {
     let reboot_lockfile = fx.settings.store_path.join("reboot.lock");
 
     // 1. Executes command, creates pending reboot lockfile
-    let execution_id = fx.enqueue_job("reboot").await;
-    time::sleep(Duration::from_millis(500)).await; // give enough time exec cmd
+    let ticket = fx.enqueue_job("reboot").await;
+    ticket.wait_for_completion().await;
 
     // Assert
     let jobs = fx.execution_updates.read().await;
@@ -25,7 +24,7 @@ async fn it_reboots() {
 
     let pending_execution_id = fs::read_to_string(&reboot_lockfile).await.unwrap();
 
-    assert_eq!(execution_id, pending_execution_id);
+    assert_eq!(ticket.exec_id, pending_execution_id);
     assert_eq!(actual.std_out, "rebooting\n");
     assert_eq!(actual.status, JobExecutionStatus::InProgress as i32);
 
@@ -34,8 +33,10 @@ async fn it_reboots() {
     fx.spawn_program(FakeOrb::new().await);
 
     // 3. Receive command from backend, finish execution -- lockfile should be removed
-    fx.enqueue_job_with_id("reboot", execution_id).await;
-    time::sleep(Duration::from_millis(500)).await; // give enough time exec cmd
+    fx.enqueue_job_with_id("reboot", ticket.exec_id)
+        .await
+        .wait_for_completion()
+        .await;
 
     // Assert
     let jobs = fx.execution_updates.read().await;

--- a/test-utils/src/async_bag.rs
+++ b/test-utils/src/async_bag.rs
@@ -1,8 +1,24 @@
 use std::{ops::Deref, sync::Arc};
 use tokio::sync::{Mutex, MutexGuard};
 
-#[derive(Clone, Debug)]
+/// Wrapper for `Arc<Mutex<T>>` used to make testing easier.
+#[derive(Debug)]
 pub struct AsyncBag<T>(Arc<Mutex<T>>);
+
+impl<T> Clone for AsyncBag<T> {
+    fn clone(&self) -> Self {
+        AsyncBag(self.0.clone())
+    }
+}
+
+impl<T> Default for AsyncBag<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        AsyncBag(Arc::new(Mutex::new(T::default())))
+    }
+}
 
 impl<T> AsyncBag<T> {
     pub fn new(t: T) -> Self {


### PR DESCRIPTION
## fixes
- race condition if a job completes a job, but ends up requesting a new job before the server has time to remove it from its queue

## tests
- test for the above race  condition
- test we return FailedUnsupported for unknown jobs

## docs
- updated readme