### PR TITLE
fix(jobs-agent): logging cancellation should return a cancellation exec upd

### DIFF
--- a/jobs-agent/src/handlers/logs.rs
+++ b/jobs-agent/src/handlers/logs.rs
@@ -71,8 +71,14 @@ pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
             let mut line = String::new();
 
             loop {
-                if now.elapsed() > max_duration || ctx.is_cancelled() {
-                    return Ok(ctx.success().stderr("cancelled"));
+                if now.elapsed() > max_duration {
+                    return Ok(ctx
+                        .success()
+                        .stdout("we have reached max allowed duration for logging"));
+                }
+
+                if ctx.is_cancelled() {
+                    return Ok(ctx.cancelled());
                 }
 
                 let bytes_read = reader.read_line(&mut line).await?;

--- a/jobs-agent/src/job_system/ctx.rs
+++ b/jobs-agent/src/job_system/ctx.rs
@@ -1,6 +1,5 @@
-use crate::program::Deps;
-
 use super::{client::JobClient, handler::Handler};
+use crate::program::Deps;
 use bon::bon;
 use orb_relay_messages::jobs::v1::{
     JobExecution, JobExecutionStatus, JobExecutionUpdate,
@@ -98,10 +97,6 @@ impl Ctx {
         self.cancel_token.is_cancelled()
     }
 
-    pub fn cancel(&self) {
-        self.cancel_token.cancel()
-    }
-
     /// Returns a reference to the dependencies registered
     /// in `program.rs`.
     pub fn deps(&self) -> &Arc<Deps> {
@@ -148,6 +143,17 @@ impl Ctx {
     /// ```
     pub fn failure(&self) -> JobExecutionUpdate {
         self.status(JobExecutionStatus::Failed)
+    }
+
+    /// Helper method to create a `JobExecutionUpdate` with the appropriate
+    /// `job_id` and `job_execution_id`.
+    /// ```ignore
+    /// pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
+    ///    Ok(ctx.cancelled().stdout("cancelled job"))
+    /// }
+    /// ```
+    pub fn cancelled(&self) -> JobExecutionUpdate {
+        self.status(JobExecutionStatus::Cancelled)
     }
 
     #[builder(finish_fn = send)]


### PR DESCRIPTION
## new 
- `Ctx::cancelled` helper to created a `JobExecutionUpdate` with the cancelled status

## fixes
- return cancellation execution update when job is cancelled