### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/* @fouge @TheButlah @vmenge @oldgalileo
+*                       @worldcoin/orb-platform


### PR DESCRIPTION
orb-platform team is now a proxy for orb-software (did not change name to avoid headaches)

relevant pr
https://github.com/worldcoin/infrastructure/pull/23705