### PR TITLE
feat(hil): nfsboot unmount cleanly

### DIFF
--- a/hil/src/commands/nfsboot.rs
+++ b/hil/src/commands/nfsboot.rs
@@ -49,9 +49,14 @@ impl Nfsboot {
         let rts_path = self.maybe_download_rts().await?;
         debug!("resolved RTS path: {rts_path}");
 
-        crate::nfsboot::nfsboot(rts_path, self.mounts)
+        let _mount_guard = crate::nfsboot::nfsboot(rts_path, self.mounts)
             .await
-            .wrap_err("error while booting via nfs")
+            .wrap_err("error while booting via nfs")?;
+
+        info!("filesystems mounted, press ctrl-c to unmount and exit");
+
+        std::future::pending::<()>().await;
+        unreachable!()
     }
 
     async fn maybe_download_rts(&self) -> Result<Utf8PathBuf> {

--- a/hil/src/main.rs
+++ b/hil/src/main.rs
@@ -12,6 +12,7 @@ use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use color_eyre::{eyre::WrapErr, Result};
 use orb_build_info::{make_build_info, BuildInfo};
+use tracing::warn;
 use tracing_subscriber::{filter::LevelFilter, fmt, prelude::*, EnvFilter};
 
 const BUILD_INFO: BuildInfo = make_build_info!();
@@ -76,6 +77,6 @@ async fn main() -> Result<()> {
     tokio::select! {
         result = run_fut => result,
         // Needed to cleanly call destructors.
-        result = tokio::signal::ctrl_c() => result.wrap_err("failed to listen for ctrl-c"),
+        result = tokio::signal::ctrl_c() => result.wrap_err("failed to listen for ctrl-c").map(|()| warn!("exiting")),
     }
 }


### PR DESCRIPTION
nfsboot subcommand now waits until SIGINT to exit. And on exit, it unmounts what it mounted. It also handles the tempdir correctly, by accounting for the need to rm with sudo.