### PR TITLE
refactor(hil): break persistent population out of flash fn

### DIFF
--- a/hil/src/commands/flash.rs
+++ b/hil/src/commands/flash.rs
@@ -5,6 +5,7 @@ use color_eyre::{
     Result,
 };
 use orb_s3_helpers::{ExistingFileBehavior, S3Uri};
+use rand::{rngs::StdRng, SeedableRng};
 use tracing::info;
 
 use crate::{current_dir, rts::FlashVariant};
@@ -88,9 +89,14 @@ impl Flash {
             (false, true) => FlashVariant::Fast,
             (false, false) => FlashVariant::HilFast,
         };
-        crate::rts::flash(variant, &rts_path, args.persistent_img_path.as_std_path())
-            .await
-            .wrap_err("error while flashing")?;
+        crate::rts::flash(
+            variant,
+            &rts_path,
+            args.persistent_img_path.as_std_path(),
+            StdRng::from_rng(rand::thread_rng()).unwrap(),
+        )
+        .await
+        .wrap_err("error while flashing")?;
 
         Ok(())
     }

--- a/hil/src/commands/nfsboot.rs
+++ b/hil/src/commands/nfsboot.rs
@@ -5,6 +5,7 @@ use color_eyre::{
     Result,
 };
 use orb_s3_helpers::{ExistingFileBehavior, S3Uri};
+use rand::SeedableRng;
 use tracing::{debug, info};
 
 use crate::nfsboot::{error_detection_for_host_state, request_sudo, MountSpec};
@@ -36,6 +37,9 @@ pub struct Nfsboot {
     /// Bind-mounts in the form <orb_mount_name>,<host_path>. Repeat --mount to add more.
     #[arg(long = "mount")]
     mounts: Vec<MountSpec>,
+    /// Path to directory containing persistent .img files to copy to bootloader dir
+    #[arg(long)]
+    persistent_img_path: Utf8PathBuf,
 }
 
 impl Nfsboot {
@@ -49,12 +53,17 @@ impl Nfsboot {
         let rts_path = self.maybe_download_rts().await?;
         debug!("resolved RTS path: {rts_path}");
 
-        let _mount_guard = crate::nfsboot::nfsboot(rts_path, self.mounts)
-            .await
-            .wrap_err("error while booting via nfs")?;
+        let rng = rand::rngs::StdRng::from_rng(rand::thread_rng()).unwrap();
+        let _mount_guard = crate::nfsboot::nfsboot(
+            rts_path,
+            self.mounts,
+            self.persistent_img_path.as_ref(),
+            rng,
+        )
+        .await
+        .wrap_err("error while booting via nfs")?;
 
         info!("filesystems mounted, press ctrl-c to unmount and exit");
-
         std::future::pending::<()>().await;
         unreachable!()
     }

--- a/hil/src/nfsboot.rs
+++ b/hil/src/nfsboot.rs
@@ -44,11 +44,19 @@ impl From<Mounter> for MountGuard {
 pub async fn nfsboot(
     path_to_rts: Utf8PathBuf,
     mounts: Vec<MountSpec>,
+    persistent_img_path: &Path,
+    rng: impl rand::Rng + Send + 'static,
 ) -> Result<MountGuard> {
     let tmp_dir = tokio::task::spawn_blocking(move || extract(&path_to_rts))
         .await
         .wrap_err("task panicked")??;
     debug!("{tmp_dir:?}");
+    crate::rts::populate_persistent(
+        tmp_dir.path().to_path_buf(),
+        persistent_img_path.to_path_buf(),
+        rng,
+    )
+    .await?;
 
     let scratch_dir = tmp_dir.path().join("scratch");
     tokio::fs::create_dir(&scratch_dir)

--- a/hil/src/rts.rs
+++ b/hil/src/rts.rs
@@ -1,12 +1,12 @@
 #![allow(clippy::uninlined_format_args)]
-use std::fs::File;
 use std::io::Write;
 use std::path::Path;
+use std::{fs::File, path::PathBuf};
 
 use camino::Utf8Path;
 use cmd_lib::run_cmd;
 use color_eyre::{
-    eyre::{ensure, WrapErr},
+    eyre::{bail, ensure, WrapErr},
     Result, Section,
 };
 use tempfile::TempDir;
@@ -17,6 +17,7 @@ pub async fn flash(
     variant: FlashVariant,
     path_to_rts_tar: &Utf8Path,
     persistent_img_path: &Path,
+    rng: (impl rand::Rng + Send + 'static),
 ) -> Result<()> {
     ensure!(
         is_recovery_mode_detected().await?,
@@ -31,16 +32,16 @@ pub async fn flash(
         .wrap_err("task panicked")??;
     println!("{tmp_dir:?}");
 
+    let tmp_dir_path = tmp_dir.path().to_path_buf();
+    populate_persistent(tmp_dir_path, persistent_img_path, rng).await?;
+
     ensure!(
         is_recovery_mode_detected().await?,
         "orb not in recovery mode"
     );
-
-    tokio::task::spawn_blocking(move || {
-        flash_cmd(variant, tmp_dir.path(), &persistent_img_path)
-    })
-    .await
-    .wrap_err("task panicked")??;
+    tokio::task::spawn_blocking(move || flash_cmd(variant, tmp_dir.path()))
+        .await
+        .wrap_err("task panicked")??;
 
     Ok(())
 }
@@ -51,6 +52,8 @@ pub enum FlashVariant {
     Regular,
     HilFast,
     Hil,
+    #[expect(unused)]
+    Nfsboot,
 }
 
 impl FlashVariant {
@@ -60,11 +63,12 @@ impl FlashVariant {
             FlashVariant::Regular => "flashcmd.txt",
             FlashVariant::HilFast => "hil-fastflashcmd.txt",
             FlashVariant::Hil => "hil-flashcmd.txt",
+            FlashVariant::Nfsboot => "nfsbootcmd.sh",
         }
     }
 }
 
-pub fn extract(path_to_rts: &Utf8Path) -> Result<TempDir> {
+pub(crate) fn extract(path_to_rts: &Utf8Path) -> Result<TempDir> {
     ensure!(
         path_to_rts.try_exists().unwrap_or(false),
         "{path_to_rts} doesn't exist"
@@ -102,16 +106,46 @@ fn generate_random_files(output_dir: &Path, rng: &mut impl rand::Rng) -> Result<
     Ok(())
 }
 
-fn flash_cmd(
-    variant: FlashVariant,
+pub(crate) async fn populate_persistent(
+    extracted_dir: PathBuf,
+    persistent_img_path: PathBuf,
+    mut rng: impl rand::Rng + Send + 'static,
+) -> Result<()> {
+    let persistent_img_path_clone = persistent_img_path.clone();
+    tokio::task::spawn_blocking(move || {
+        populate_persistent_inner(&extracted_dir, &persistent_img_path_clone, &mut rng)
+    })
+    .await
+    .wrap_err("task panicked")?
+    .wrap_err_with(|| {
+        format!(
+            "failed to populate the rts with the persistent images from \
+            {persistent_img_path:?}"
+        )
+    })
+}
+
+// TODO: None of this needs to be sync, but I (@thebutlah) left it intact for now due
+// to crunch.
+fn populate_persistent_inner(
     extracted_dir: &Path,
     persistent_img_path: &Path,
+    rng: &mut impl rand::Rng,
 ) -> Result<()> {
-    let bootloader_dir = extracted_dir.join("ready-to-sign").join("bootloader");
-    ensure!(
-        bootloader_dir.try_exists().unwrap_or(false),
-        "{bootloader_dir:?} doesn't exist"
-    );
+    let Some(bootloader_dir) = ["ready-to-sign", "rts"]
+        .into_iter()
+        .filter_map(|d| {
+            let bootloader_dir = extracted_dir.join(d).join("bootloader");
+
+            bootloader_dir
+                .try_exists()
+                .unwrap_or(false)
+                .then_some(bootloader_dir)
+        })
+        .next()
+    else {
+        bail!("could not find a bootloader directory under {extracted_dir:?}");
+    };
 
     // Copy .img files from persistent path to bootloader directory
     ensure!(
@@ -131,14 +165,31 @@ fn flash_cmd(
         .wrap_err("failed to copy .img files to bootloader directory")
         .with_note(|| format!("persistent_img_path was {persistent_img_path:?}, bootloader_dir was {bootloader_dir:?}"))?;
 
-    let cmd_file_name = variant.file_name();
-
     // Generate random UID files
-    generate_random_files(&bootloader_dir, &mut rand::thread_rng())?;
+    generate_random_files(&bootloader_dir, rng)?;
 
+    Ok(())
+}
+
+fn flash_cmd(variant: FlashVariant, extracted_dir: &Path) -> Result<()> {
+    let Some(bootloader_dir) = ["ready-to-sign", "rts"]
+        .into_iter()
+        .filter_map(|d| {
+            let bootloader_dir = extracted_dir.join(d).join("bootloader");
+
+            bootloader_dir
+                .try_exists()
+                .unwrap_or(false)
+                .then_some(bootloader_dir)
+        })
+        .next()
+    else {
+        bail!("could not find a bootloader directory under {extracted_dir:?}");
+    };
+
+    let cmd_file_name = variant.file_name();
     let result = run_cmd! {
         cd $bootloader_dir;
-        info "Removing fetch persistent commands from flash script";
         info running $cmd_file_name;
         bash $cmd_file_name;
         info finished flashing!;


### PR DESCRIPTION
We are gonna need the persistent files populated both when we flash and when we do the mounting of the nfs. Therefore lets break it out into its own function to be more explicit about the ordering of things.