### PR TITLE
chore(jobs-agent): disable reboot command

### DIFF
--- a/jobs-agent/src/program.rs
+++ b/jobs-agent/src/program.rs
@@ -1,5 +1,5 @@
 use crate::{
-    handlers::{check_my_orb, logs, mcu, orb_details, read_file, read_gimbal, reboot},
+    handlers::{check_my_orb, logs, mcu, orb_details, read_file, read_gimbal},
     job_system::handler::JobHandler,
     settings::Settings,
     shell::Shell,
@@ -36,7 +36,8 @@ pub async fn run(deps: Deps) -> Result<()> {
         .parallel("read_gimbal", read_gimbal::handler)
         .parallel("mcu", mcu::handler)
         .parallel_max("logs", 3, logs::handler)
-        .sequential("reboot", reboot::handler)
+        // .sequential("reboot", reboot::handler) ignored for now, mcu reboot is broken, and
+        // regular reboot decreases the retry counter
         .build(deps)
         .run()
         .await;

--- a/jobs-agent/tests/reboot.rs
+++ b/jobs-agent/tests/reboot.rs
@@ -7,6 +7,7 @@ mod common;
 
 // No docker in macos on github
 #[cfg_attr(target_os = "macos", test_with::no_env(GITHUB_ACTIONS))]
+#[ignore]
 #[tokio::test]
 async fn it_reboots() {
     // Arrange


### PR DESCRIPTION
disabling the reboot command temporarily due to:
- nvidia retry counter decreasing on every reboot (as opposed to full power cycle)
- `orb-mcu-util reboot main` has a bug where orb isn't powered back on, so we can't use it instead yet