### PR TITLE
fix: abort the build if building for non-linux

### DIFF
--- a/update-agent-loader/build.rs
+++ b/update-agent-loader/build.rs
@@ -6,7 +6,7 @@ use std::fs;
 fn main() {
     // This package is Linux-only, skip build on other platforms
     if !cfg!(target_os = "linux") {
-        println!("cargo:warning=update-agent-loader is only supported on Linux, skipping build");
+        println!("cargo::error=update-agent-loader is only supported on Linux, skipping build");
         return;
     }
 


### PR DESCRIPTION
Fixing AI slop.

There are 2 problems fixed here:
- building for non-linux is actually a fatal error, not a warning
- to report an error it needs to print 'cargo::error' (see two semicolons), but LLM wrote it with 1 error. 
