### PR TITLE
fix: orb-backend-status dbus types 

### DIFF
--- a/backend-status/dbus/src/types.rs
+++ b/backend-status/dbus/src/types.rs
@@ -87,16 +87,17 @@ pub struct LteInfo {
 // Core Stats
 //--------------------------------
 
-/// The JSON structure of the orb status request.
+/// CoreStats are provided by orb-core
+#[allow(missing_docs)]
 #[derive(Debug, Default, Clone, Type, Serialize, Deserialize)]
 pub struct CoreStats {
-    pub battery: Battery,
+    pub battery: Option<Battery>,
     pub wifi: Option<Wifi>,
-    pub temperature: Temperature,
-    pub location: Location,
-    pub ssd: Ssd,
-    pub version: OrbVersion,
-    pub mac_address: String,
+    pub temperature: Option<Temperature>,
+    pub location: Option<Location>,
+    pub ssd: Option<Ssd>,
+    pub version: Option<OrbVersion>,
+    pub mac_address: Option<String>,
 }
 
 #[allow(missing_docs)]
@@ -123,17 +124,8 @@ impl Default for Battery {
 pub struct Wifi {
     pub ssid: String,
     pub bssid: String,
-    pub quality: WifiQuality,
-}
-
-#[allow(missing_docs)]
-#[derive(Debug, Default, Clone, SerializeDict, DeserializeDict, Type)]
-#[zvariant(signature = "a{sv}")]
-pub struct WifiQuality {
-    pub bit_rate: f64,
-    pub link_quality: i64,
-    pub signal_level: i64,
-    pub noise_level: i64,
+    pub rssi: i64,
+    pub freq: i64,
 }
 
 #[allow(missing_docs)]

--- a/backend-status/src/backend/status.rs
+++ b/backend-status/src/backend/status.rs
@@ -198,43 +198,45 @@ async fn build_status_request_v2(
         battery: current_status
             .core_stats
             .as_ref()
-            .map(|core_stats| BatteryApiV2 {
-                level: Some(core_stats.battery.level),
-                is_charging: Some(core_stats.battery.is_charging),
+            .and_then(|core_stats| core_stats.battery.as_ref())
+            .map(|battery| BatteryApiV2 {
+                level: Some(battery.level),
+                is_charging: Some(battery.is_charging),
             }),
         mac_address: current_status
             .core_stats
             .as_ref()
-            .map(|core_stats| core_stats.mac_address.clone()),
+            .and_then(|core_stats| core_stats.mac_address.clone()),
         ssd: current_status
             .core_stats
             .as_ref()
-            .map(|core_stats| SsdStatusApiV2 {
-                file_left: Some(core_stats.ssd.file_left),
-                space_left: Some(core_stats.ssd.space_left),
-                signup_left_to_upload: Some(core_stats.ssd.signup_left_to_upload),
+            .and_then(|core_stats| core_stats.ssd.as_ref())
+            .map(|ssd| SsdStatusApiV2 {
+                file_left: Some(ssd.file_left),
+                space_left: Some(ssd.space_left),
+                signup_left_to_upload: Some(ssd.signup_left_to_upload),
             }),
-        temperature: current_status.core_stats.as_ref().map(|core_stats| {
-            TemperatureApiV2 {
-                cpu: Some(core_stats.temperature.cpu),
-                gpu: Some(core_stats.temperature.gpu),
-                front_unit: Some(core_stats.temperature.front_unit),
-                front_pcb: Some(core_stats.temperature.front_pcb),
-                battery_pcb: Some(core_stats.temperature.battery_pcb),
-                battery_cell: Some(core_stats.temperature.battery_cell),
-                backup_battery: Some(core_stats.temperature.backup_battery),
-                liquid_lens: Some(core_stats.temperature.liquid_lens),
-                main_accelerometer: Some(core_stats.temperature.main_accelerometer),
-                main_mcu: Some(core_stats.temperature.main_mcu),
-                mainboard: Some(core_stats.temperature.mainboard),
-                security_accelerometer: Some(
-                    core_stats.temperature.security_accelerometer,
-                ),
-                security_mcu: Some(core_stats.temperature.security_mcu),
-                battery_pack: Some(core_stats.temperature.battery_pack),
-                ssd: Some(core_stats.temperature.ssd),
-            }
-        }),
+        temperature: current_status
+            .core_stats
+            .as_ref()
+            .and_then(|core_stats| core_stats.temperature.as_ref())
+            .map(|temperature| TemperatureApiV2 {
+                cpu: Some(temperature.cpu),
+                gpu: Some(temperature.gpu),
+                front_unit: Some(temperature.front_unit),
+                front_pcb: Some(temperature.front_pcb),
+                battery_pcb: Some(temperature.battery_pcb),
+                battery_cell: Some(temperature.battery_cell),
+                backup_battery: Some(temperature.backup_battery),
+                liquid_lens: Some(temperature.liquid_lens),
+                main_accelerometer: Some(temperature.main_accelerometer),
+                main_mcu: Some(temperature.main_mcu),
+                mainboard: Some(temperature.mainboard),
+                security_accelerometer: Some(temperature.security_accelerometer),
+                security_mcu: Some(temperature.security_mcu),
+                battery_pack: Some(temperature.battery_pack),
+                ssd: Some(temperature.ssd),
+            }),
         wifi: current_status
             .core_stats
             .as_ref()
@@ -242,11 +244,12 @@ async fn build_status_request_v2(
             .map(|wifi| WifiApiV2 {
                 ssid: Some(wifi.ssid.clone()),
                 bssid: Some(wifi.bssid.clone()),
+                freq: Some(wifi.freq),
                 quality: Some(WifiQualityApiV2 {
-                    bit_rate: Some(wifi.quality.bit_rate),
-                    link_quality: Some(wifi.quality.link_quality as i32),
-                    signal_level: Some(wifi.quality.signal_level as i32),
-                    noise_level: Some(wifi.quality.noise_level as i32),
+                    signal_level: Some(wifi.rssi as i32),
+                    bit_rate: None,
+                    link_quality: None,
+                    noise_level: None,
                 }),
             }),
         timestamp: Utc::now(),

--- a/backend-status/src/backend/types.rs
+++ b/backend-status/src/backend/types.rs
@@ -49,6 +49,8 @@ pub struct WifiApiV2 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bssid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub freq: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<WifiQualityApiV2>,
 }
 

--- a/backend-status/src/dbus/intf_impl.rs
+++ b/backend-status/src/dbus/intf_impl.rs
@@ -225,7 +225,7 @@ mod tests {
 
     use super::*;
     use orb_backend_status_dbus::types::{
-        Battery, Location, NetIntf, OrbVersion, Ssd, Temperature, Wifi, WifiQuality,
+        Battery, Location, NetIntf, OrbVersion, Ssd, Temperature, Wifi,
     };
     use orb_info::{OrbId, OrbJabilId, OrbName};
     use std::{str::FromStr, time::Duration};
@@ -337,21 +337,17 @@ mod tests {
 
         // Provide core stats
         let core_stats = CoreStats {
-            battery: Battery {
+            battery: Some(Battery {
                 level: 0.5,
                 is_charging: true,
-            },
+            }),
             wifi: Some(Wifi {
                 ssid: "test-ssid".to_string(),
                 bssid: "00:11:22:33:44:55".to_string(),
-                quality: WifiQuality {
-                    bit_rate: 100.0,
-                    link_quality: 100,
-                    signal_level: 100,
-                    noise_level: 100,
-                },
+                rssi: 100,
+                freq: 2412,
             }),
-            temperature: Temperature {
+            temperature: Some(Temperature {
                 cpu: 0.5,
                 gpu: 0.5,
                 front_unit: 0.5,
@@ -388,20 +384,20 @@ mod tests {
                 front_unit_940_center_bottom: 0.5,
                 front_unit_white_top: 0.5,
                 front_unit_shroud_rgb_top: 0.5,
-            },
-            location: Location {
+            }),
+            location: Some(Location {
                 latitude: 0.5,
                 longitude: 0.5,
-            },
-            ssd: Ssd {
+            }),
+            ssd: Some(Ssd {
                 file_left: 100,
                 space_left: 100,
                 signup_left_to_upload: 100,
-            },
-            version: OrbVersion {
+            }),
+            version: Some(OrbVersion {
                 current_release: "1.0.0".to_string(),
-            },
-            mac_address: "00:11:22:33:44:55".to_string(),
+            }),
+            mac_address: Some("00:11:22:33:44:55".to_string()),
         };
 
         backend_status


### PR DESCRIPTION
Updated `CoreStats` to have optional fields.