### PR TITLE
fix: orb_backend_status_types_redux

### DIFF
--- a/backend-status/dbus/src/types.rs
+++ b/backend-status/dbus/src/types.rs
@@ -92,7 +92,7 @@ pub struct LteInfo {
 #[derive(Debug, Default, Clone, Type, Serialize, Deserialize)]
 pub struct CoreStats {
     pub battery: Battery,
-    pub wifi: Option<Wifi>,
+    pub wifi: Option<WifiNetwork>,
     pub temperature: Temperature,
     pub location: Location,
     pub ssd: Ssd,
@@ -116,16 +116,6 @@ impl Default for Battery {
             is_charging: true,
         }
     }
-}
-
-#[allow(missing_docs)]
-#[derive(Debug, Default, Clone, SerializeDict, DeserializeDict, Type)]
-#[zvariant(signature = "a{sv}")]
-pub struct Wifi {
-    pub ssid: String,
-    pub bssid: String,
-    pub rssi: i64,
-    pub freq: i64,
 }
 
 #[allow(missing_docs)]

--- a/backend-status/src/backend/status.rs
+++ b/backend-status/src/backend/status.rs
@@ -242,9 +242,9 @@ async fn build_status_request_v2(
             .map(|wifi| WifiApiV2 {
                 ssid: Some(wifi.ssid.clone()),
                 bssid: Some(wifi.bssid.clone()),
-                freq: Some(wifi.freq),
+                freq: Some(wifi.frequency),
                 quality: Some(WifiQualityApiV2 {
-                    signal_level: Some(wifi.rssi as i32),
+                    signal_level: Some(wifi.signal_level as i32),
                     bit_rate: None,
                     link_quality: None,
                     noise_level: None,

--- a/backend-status/src/backend/status.rs
+++ b/backend-status/src/backend/status.rs
@@ -244,7 +244,7 @@ async fn build_status_request_v2(
                 bssid: Some(wifi.bssid.clone()),
                 freq: Some(wifi.frequency),
                 quality: Some(WifiQualityApiV2 {
-                    signal_level: Some(wifi.signal_level as i32),
+                    signal_level: Some(wifi.signal_level),
                     bit_rate: None,
                     link_quality: None,
                     noise_level: None,

--- a/backend-status/src/backend/status.rs
+++ b/backend-status/src/backend/status.rs
@@ -242,7 +242,7 @@ async fn build_status_request_v2(
             .map(|wifi| WifiApiV2 {
                 ssid: Some(wifi.ssid.clone()),
                 bssid: Some(wifi.bssid.clone()),
-                freq: Some(wifi.frequency),
+                frequency: Some(wifi.frequency),
                 quality: Some(WifiQualityApiV2 {
                     signal_level: Some(wifi.signal_level),
                     bit_rate: None,

--- a/backend-status/src/backend/types.rs
+++ b/backend-status/src/backend/types.rs
@@ -49,7 +49,7 @@ pub struct WifiApiV2 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bssid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub freq: Option<i64>,
+    pub freq: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<WifiQualityApiV2>,
 }

--- a/backend-status/src/backend/types.rs
+++ b/backend-status/src/backend/types.rs
@@ -49,7 +49,7 @@ pub struct WifiApiV2 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bssid: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub freq: Option<u32>,
+    pub frequency: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quality: Option<WifiQualityApiV2>,
 }

--- a/backend-status/src/dbus/intf_impl.rs
+++ b/backend-status/src/dbus/intf_impl.rs
@@ -225,7 +225,7 @@ mod tests {
 
     use super::*;
     use orb_backend_status_dbus::types::{
-        Battery, Location, NetIntf, OrbVersion, Ssd, Temperature, Wifi,
+        Battery, Location, NetIntf, OrbVersion, Ssd, Temperature, WifiNetwork,
     };
     use orb_info::{OrbId, OrbJabilId, OrbName};
     use std::{str::FromStr, time::Duration};
@@ -341,11 +341,12 @@ mod tests {
                 level: 0.5,
                 is_charging: true,
             },
-            wifi: Some(Wifi {
+            wifi: Some(WifiNetwork {
                 ssid: "test-ssid".to_string(),
                 bssid: "00:11:22:33:44:55".to_string(),
-                rssi: 100,
-                freq: 2412,
+                frequency: 2412,
+                signal_level: 100,
+                flags: String::new(),
             }),
             temperature: Temperature {
                 cpu: 0.5,


### PR DESCRIPTION
- Reuse the existing WifiNetwork status type