### PR TITLE
refactor(backend-status): rename LteInfo to CellularStatus

### DIFF
--- a/backend-status/dbus/src/lib.rs
+++ b/backend-status/dbus/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod types;
 
 use orb_telemetry::TraceCtx;
-use types::{CoreStats, LteInfo, NetStats, UpdateProgress, WifiNetwork};
+use types::{CellularStatus, CoreStats, NetStats, UpdateProgress, WifiNetwork};
 use zbus::{fdo::Result, interface};
 
 pub trait BackendStatusT: Send + Sync + 'static {
@@ -20,7 +20,7 @@ pub trait BackendStatusT: Send + Sync + 'static {
     fn provide_net_stats(&self, net_stats: NetStats, trace_ctx: TraceCtx)
         -> Result<()>;
 
-    fn provide_lte_info(&self, lte_info: LteInfo) -> Result<()>;
+    fn provide_cellular_status(&self, status: CellularStatus) -> Result<()>;
 
     fn provide_core_stats(
         &self,
@@ -64,8 +64,8 @@ impl<T: BackendStatusT> BackendStatusT for BackendStatus<T> {
         self.0.provide_net_stats(net_stats, trace_ctx)
     }
 
-    fn provide_lte_info(&self, lte_info: LteInfo) -> Result<()> {
-        self.0.provide_lte_info(lte_info)
+    fn provide_cellular_status(&self, status: CellularStatus) -> Result<()> {
+        self.0.provide_cellular_status(status)
     }
 
     fn provide_core_stats(

--- a/backend-status/dbus/src/types.rs
+++ b/backend-status/dbus/src/types.rs
@@ -67,20 +67,20 @@ pub struct NetIntf {
 /// All Option<T> fields make use of the `option-as-array` features of zbus.
 /// https://dbus2.github.io/zbus/faq.html#2-encoding-as-an-array-a
 #[derive(Debug, Clone, Type, Serialize, Deserialize, PartialEq)]
-pub struct LteInfo {
-    imei: String,
-    iccid: String,
+pub struct CellularStatus {
+    pub imei: String,
+    pub iccid: String,
     /// Radio Access Technology -- e.g.: gsm, lte
-    rat: Option<String>,
-    operator: Option<String>,
+    pub rat: Option<String>,
+    pub operator: Option<String>,
     /// Reference Option Received Power — how strong the LTE signal is.
-    rsrp: Option<f64>,
+    pub rsrp: Option<f64>,
     ///Reference Signal Received Quality — signal quality, affected by interference.
-    rsrq: Option<f64>,
+    pub rsrq: Option<f64>,
     /// Received Signal Strength Indicator — total signal power (including noise)
-    rssi: Option<f64>,
+    pub rssi: Option<f64>,
     /// Signal-to-Noise Ratio — how "clean" the signal is.
-    snr: Option<f64>,
+    pub snr: Option<f64>,
 }
 
 //--------------------------------

--- a/location/src/dbus.rs
+++ b/location/src/dbus.rs
@@ -82,9 +82,9 @@ mod tests {
             Ok(())
         }
 
-        fn provide_lte_info(
+        fn provide_cellular_status(
             &self,
-            _lte_info: orb_backend_status_dbus::types::LteInfo,
+            _status: orb_backend_status_dbus::types::CellularStatus,
         ) -> zbus::fdo::Result<()> {
             Ok(())
         }


### PR DESCRIPTION
## changes
- renamed `LteInfo` to `CellularStatus`
- made all `CellularStatus` fields public