### PR TITLE
fix(connd): report tx and rx delta to dd for more useful metrics

### DIFF
--- a/connd/src/dd_reporter.rs
+++ b/connd/src/dd_reporter.rs
@@ -1,5 +1,5 @@
 use crate::{
-    modem::Modem,
+    modem::{net_stats::NetStats, Modem},
     utils::{retry_for, State},
 };
 use color_eyre::{eyre::eyre, Result};
@@ -22,9 +22,14 @@ pub fn start(modem: State<Modem>, report_interval: Duration) -> JoinHandle<Resul
         info!("successfully created dogstatd::Client");
 
         let dd_client = Arc::new(dd_client);
+        let mut prev_net_stats = modem
+            .read(|m| m.net_stats.clone())
+            .map_err(|e| eyre!("dd_repoter::start, modem.read: {e}"))?;
 
         loop {
-            if let Err(e) = report(modem.clone(), dd_client.clone()).await {
+            if let Err(e) =
+                report(modem.clone(), dd_client.clone(), &mut prev_net_stats).await
+            {
                 error!("failed to report to backend status: {e}");
             }
 
@@ -43,28 +48,42 @@ async fn make_dd_client() -> Result<dogstatsd::Client> {
     .map_err(|e| eyre!("failed to join make_dd_client thread: {e}"))?
 }
 
-async fn report(modem: State<Modem>, dd_client: Arc<dogstatsd::Client>) -> Result<()> {
+async fn report(
+    modem: State<Modem>,
+    dd_client: Arc<dogstatsd::Client>,
+    prev_net_stats: &mut NetStats,
+) -> Result<()> {
+    let (state, rat, operator, gauges, new_net_stats) = modem
+        .read(|m| {
+            let sig = m.signal.as_ref();
+
+            let gauges = vec![
+                ("orb.lte.signal.rsrp", sig.and_then(|s| s.rsrp)),
+                ("orb.lte.signal.rsrq", sig.and_then(|s| s.rsrq)),
+                ("orb.lte.signal.rssi", sig.and_then(|s| s.rssi)),
+                ("orb.lte.signal.snr", sig.and_then(|s| s.snr)),
+            ];
+
+            (
+                m.state.clone(),
+                m.rat.clone(),
+                m.operator.clone(),
+                gauges,
+                m.net_stats.clone(),
+            )
+        })
+        .map_err(|e| {
+            eyre!("failed to read ConnectionState from State<Modem>: {e:?}")
+        })?;
+
+    let net_stats_delta = NetStats {
+        rx_bytes: new_net_stats.rx_bytes - prev_net_stats.rx_bytes,
+        tx_bytes: new_net_stats.tx_bytes - prev_net_stats.tx_bytes,
+    };
+
+    *prev_net_stats = new_net_stats;
+
     task::spawn_blocking(move || {
-        let (state, rat, operator, gauges) = modem
-            .read(|m| {
-                let sig = m.signal.as_ref();
-                let ns = m.net_stats.as_ref();
-
-                let gauges = vec![
-                    ("orb.lte.signal.rsrp", sig.and_then(|s| s.rsrp)),
-                    ("orb.lte.signal.rsrq", sig.and_then(|s| s.rsrq)),
-                    ("orb.lte.signal.rssi", sig.and_then(|s| s.rssi)),
-                    ("orb.lte.signal.snr", sig.and_then(|s| s.snr)),
-                    ("orb.lte.net.rx_bytes", ns.map(|n| n.rx_bytes as f64)),
-                    ("orb.lte.net.tx_bytes", ns.map(|n| n.tx_bytes as f64)),
-                ];
-
-                (m.state.clone(), m.rat.clone(), m.operator.clone(), gauges)
-            })
-            .map_err(|e| {
-                eyre!("failed to read ConnectionState from State<Modem>: {e:?}")
-            })?;
-
         if state.is_online() {
             let heartbeat_tags: Vec<String> = [
                 rat.map(|r| format!("rat:{r}")),
@@ -83,6 +102,18 @@ async fn report(modem: State<Modem>, dd_client: Arc<dogstatsd::Client>) -> Resul
             .for_each(|(name, v)| {
                 let _ = dd_client.gauge(name, v.to_string(), NO_TAGS);
             });
+
+        let _ = dd_client.incr_by_value(
+            "orb.lte.net.rx_bytes_delta",
+            net_stats_delta.rx_bytes as i64,
+            NO_TAGS,
+        );
+
+        let _ = dd_client.incr_by_value(
+            "orb.lte.net.tx_bytes_delta",
+            net_stats_delta.tx_bytes as i64,
+            NO_TAGS,
+        );
 
         Ok(())
     })

--- a/connd/src/lib.rs
+++ b/connd/src/lib.rs
@@ -1,5 +1,5 @@
 use color_eyre::eyre::Result;
-use modem::{modem_manager, Modem};
+use modem::{modem_manager, net_stats::NetStats, Modem};
 use orb_info::orb_os_release::{OrbOsPlatform, OrbOsRelease};
 use std::time::Duration;
 use tokio::signal::unix::{self, SignalKind};
@@ -57,8 +57,9 @@ async fn make_modem() -> Result<State<Modem>> {
         let iccid = modem_manager::get_iccid().await?;
         let state = modem_manager::get_connection_state(&modem_id).await?;
         modem_manager::start_signal_refresh(&modem_id).await?;
+        let net_stats = NetStats::from_wwan0().await?;
 
-        Ok(Modem::new(modem_id, iccid, imei, state))
+        Ok(Modem::new(modem_id, iccid, imei, state, net_stats))
     }
     .await
     .inspect_err(|e| error!("make_modem: {e}"));

--- a/connd/src/modem/mod.rs
+++ b/connd/src/modem/mod.rs
@@ -23,7 +23,7 @@ pub struct Modem {
 
     pub signal: Option<LteSignal>,
     pub location: Option<GppLocation>,
-    pub net_stats: Option<NetStats>,
+    pub net_stats: NetStats,
 }
 
 impl Modem {
@@ -32,6 +32,7 @@ impl Modem {
         iccid: String,
         imei: String,
         state: ConnectionState,
+        net_stats: NetStats,
     ) -> Self {
         Self {
             id,
@@ -44,7 +45,7 @@ impl Modem {
             disconnected_count: 0,
             signal: None,
             location: None,
-            net_stats: None,
+            net_stats,
         }
     }
 }

--- a/connd/src/modem/net_stats.rs
+++ b/connd/src/modem/net_stats.rs
@@ -2,7 +2,7 @@ use crate::utils::run_cmd;
 use color_eyre::{eyre::eyre, Result};
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct NetStats {
     pub tx_bytes: u64,
     pub rx_bytes: u64,

--- a/connd/src/modem_monitor.rs
+++ b/connd/src/modem_monitor.rs
@@ -73,7 +73,7 @@ async fn update_modem(modem: &State<Modem>) -> Result<()> {
             m.location = location;
 
             if let Ok(stats) = net_stats {
-                m.net_stats = Some(stats);
+                m.net_stats = stats;
             }
         })
         .map_err(|e| eyre!("failed to write to State<Modem>: {e:?}"))?;


### PR DESCRIPTION
## fix
- reporting of `wwan0` `tx_bytes` and `rx_bytes` metrics to dd  are now done using a counter to building dashboards is easier 