### PR TITLE
fix(hil): fix mDNS and add sshpass

### DIFF
--- a/nix/machines/nixos-common.nix
+++ b/nix/machines/nixos-common.nix
@@ -75,6 +75,7 @@ in
     git
     neovim
     parted
+    sshpass
     usbutils
     vim
     (python3.withPackages pythonShell)
@@ -101,6 +102,9 @@ in
     # set to "false" if giving you trouble
     dnsovertls = "opportunistic";
   };
+  networking.firewall.allowedUDPPorts = [
+    5353 # mDNS
+  ];
 
   # use the latest Linux kernel
   boot = {


### PR DESCRIPTION
sshpass is used to allow gh actions to specify the ssh password non-interactively.
additionally, we need mDNS for sshing into the orb of a known ID.