### PR TITLE
fix(hil): don't require persistent path when flashing

### DIFF
--- a/hil/src/commands/flash.rs
+++ b/hil/src/commands/flash.rs
@@ -36,7 +36,7 @@ pub struct Flash {
     overwrite_existing: bool,
     /// Path to directory containing persistent .img files to copy to bootloader dir
     #[arg(long)]
-    persistent_img_path: Utf8PathBuf,
+    persistent_img_path: Option<Utf8PathBuf>,
 }
 
 impl Flash {
@@ -92,7 +92,7 @@ impl Flash {
         crate::rts::flash(
             variant,
             &rts_path,
-            args.persistent_img_path.as_std_path(),
+            args.persistent_img_path.as_deref().map(|p| p.as_std_path()),
             StdRng::from_rng(rand::thread_rng()).unwrap(),
         )
         .await

--- a/hil/src/nfsboot.rs
+++ b/hil/src/nfsboot.rs
@@ -62,12 +62,8 @@ pub async fn nfsboot(
     }
 
     if let Some(persistent_img_path) = persistent_img_path {
-        crate::rts::populate_persistent(
-            tmp_dir.path().to_path_buf(),
-            persistent_img_path.to_path_buf(),
-            rng,
-        )
-        .await?;
+        crate::rts::populate_persistent(tmp_dir.path(), persistent_img_path, rng)
+            .await?;
     }
 
     let scratch_dir = tmp_dir.path().join("scratch");


### PR DESCRIPTION
fixes a usability regression. Not all users have the persistent image pre-poulated. orb-hil is not just for CI but for developers.