### PR TITLE
fix(hil): slightly increase delay between username and pass

### DIFF
--- a/hil/src/commands/login.rs
+++ b/hil/src/commands/login.rs
@@ -112,7 +112,7 @@ impl Login {
             .write_all(format!("{LOGIN_PROMPT_USER}\n").as_bytes())
             .await
             .wrap_err("error while typing username")?;
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(2000)).await;
 
         info!("Entering password");
         let serial_rx_copy = BroadcastStream::new(serial_rx.resubscribe());

--- a/nix/machines/hil-common.nix
+++ b/nix/machines/hil-common.nix
@@ -189,6 +189,7 @@ in
       replace = true;
       user = ghRunnerUser;
 
+
       serviceOverrides = {
         Environment = "\"PATH=/run/wrappers/bin:/run/current-system/sw/bin\""; # fixes missing sudo
 


### PR DESCRIPTION
We were getting log messages like:
```
2025-08-29T19:47:59.921716Z  INFO orb_hil::commands::login: Detected login prompt!
2025-08-29T19:48:00.122286Z  INFO orb_hil::commands::login: Entering username
localhost login: worldcoin
2025-08-29T19:48:00.324010Z  INFO orb_hil::commands::login: Entering password
***
Password: 
```
Which made it seem that maybe we were waiting too little time between username and password. Previously we delayed 200ms, now we delay 2000ms.