### PR TITLE
feat: Add support for --json flag in check-my-orb and new wifi_ip handler

### DIFF
--- a/orb-jobs-agent/debian/worldcoin-jobs-agent.service
+++ b/orb-jobs-agent/debian/worldcoin-jobs-agent.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Worldcoin Orb Jobs Agent
-After=network.target
-Requires=network.target
+Requires=worldcoin-attest.service
+After=worldcoin-attest.service
 
 [Service]
 Environment="HOME=/home/worldcoin"

--- a/orb-jobs-agent/src/handlers/check_my_orb.rs
+++ b/orb-jobs-agent/src/handlers/check_my_orb.rs
@@ -2,13 +2,26 @@ use crate::job_system::ctx::{Ctx, JobExecutionUpdateExt};
 use color_eyre::{eyre::Context, Result};
 use orb_relay_messages::jobs::v1::JobExecutionUpdate;
 
-/// command format: `check_my_orb`
+/// command format: `check_my_orb [--json]`
+/// 
+/// examples:
+/// - `check_my_orb` - returns output in default format
+/// - `check_my_orb --json` - returns output in JSON format
 #[tracing::instrument]
 pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
+    // Check if --json flag is provided in arguments
+    let use_json = ctx.args().iter().any(|arg| arg == "--json");
+    
+    // Build command with optional --json flag
+    let mut cmd = vec!["check-my-orb"];
+    if use_json {
+        cmd.push("--json");
+    }
+    
     let output = ctx
         .deps()
         .shell
-        .exec(&["check-my-orb"])
+        .exec(&cmd)
         .await
         .wrap_err("failed to spawn check_my_orb")?
         .wait_with_output()

--- a/orb-jobs-agent/src/handlers/check_my_orb.rs
+++ b/orb-jobs-agent/src/handlers/check_my_orb.rs
@@ -3,7 +3,7 @@ use color_eyre::{eyre::Context, Result};
 use orb_relay_messages::jobs::v1::JobExecutionUpdate;
 
 /// command format: `check_my_orb [--json]`
-/// 
+///
 /// examples:
 /// - `check_my_orb` - returns output in default format
 /// - `check_my_orb --json` - returns output in JSON format
@@ -11,13 +11,13 @@ use orb_relay_messages::jobs::v1::JobExecutionUpdate;
 pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
     // Check if --json flag is provided in arguments
     let use_json = ctx.args().iter().any(|arg| arg == "--json");
-    
+
     // Build command with optional --json flag
     let mut cmd = vec!["check-my-orb"];
     if use_json {
         cmd.push("--json");
     }
-    
+
     let output = ctx
         .deps()
         .shell

--- a/orb-jobs-agent/src/handlers/mod.rs
+++ b/orb-jobs-agent/src/handlers/mod.rs
@@ -5,3 +5,4 @@ pub mod orb_details;
 pub mod read_file;
 pub mod read_gimbal;
 pub mod reboot;
+pub mod wifi_ip;

--- a/orb-jobs-agent/src/handlers/wifi_ip.rs
+++ b/orb-jobs-agent/src/handlers/wifi_ip.rs
@@ -18,7 +18,7 @@ pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
         .wrap_err("failed to get output for route command")?;
 
     let route_info = String::from_utf8_lossy(&route_output.stdout);
-    
+
     // Extract the interface name from the route output
     let interface = route_info
         .split_whitespace()
@@ -32,13 +32,15 @@ pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
         .shell
         .exec(&["ip", "addr", "show", interface])
         .await
-        .wrap_err_with(|| format!("failed to get IP address for interface {}", interface))?
+        .wrap_err_with(|| {
+            format!("failed to get IP address for interface {interface}")
+        })?
         .wait_with_output()
         .await
         .wrap_err("failed to get output for ip addr command")?;
 
     let ip_info = String::from_utf8_lossy(&ip_output.stdout);
-    
+
     // Parse the IP address from the output
     let ip_address = ip_info
         .lines()

--- a/orb-jobs-agent/src/handlers/wifi_ip.rs
+++ b/orb-jobs-agent/src/handlers/wifi_ip.rs
@@ -1,0 +1,60 @@
+use crate::job_system::ctx::{Ctx, JobExecutionUpdateExt};
+use color_eyre::{eyre::Context, Result};
+use orb_relay_messages::jobs::v1::JobExecutionUpdate;
+
+/// command format: `wifi_ip`
+#[tracing::instrument]
+pub async fn handler(ctx: Ctx) -> Result<JobExecutionUpdate> {
+    // Try to get the IP address of the currently connected WiFi interface
+    // First, try to get the default route interface
+    let route_output = ctx
+        .deps()
+        .shell
+        .exec(&["ip", "route", "get", "8.8.8.8"])
+        .await
+        .wrap_err("failed to get default route")?
+        .wait_with_output()
+        .await
+        .wrap_err("failed to get output for route command")?;
+
+    let route_info = String::from_utf8_lossy(&route_output.stdout);
+    
+    // Extract the interface name from the route output
+    let interface = route_info
+        .split_whitespace()
+        .skip_while(|&word| word != "dev")
+        .nth(1)
+        .unwrap_or("wlan0"); // fallback to common WiFi interface name
+
+    // Get the IP address for the detected interface
+    let ip_output = ctx
+        .deps()
+        .shell
+        .exec(&["ip", "addr", "show", interface])
+        .await
+        .wrap_err_with(|| format!("failed to get IP address for interface {}", interface))?
+        .wait_with_output()
+        .await
+        .wrap_err("failed to get output for ip addr command")?;
+
+    let ip_info = String::from_utf8_lossy(&ip_output.stdout);
+    
+    // Parse the IP address from the output
+    let ip_address = ip_info
+        .lines()
+        .find(|line| line.trim().starts_with("inet ") && !line.contains("127.0.0.1"))
+        .and_then(|line| {
+            line.split_whitespace()
+                .nth(1)
+                .and_then(|addr| addr.split('/').next())
+        })
+        .unwrap_or("not found");
+
+    let result = serde_json::json!({
+        "interface": interface,
+        "ip_address": ip_address,
+        "status": if ip_address != "not found" { "connected" } else { "disconnected" }
+    });
+
+    Ok(ctx.success().stdout(result.to_string()))
+}

--- a/orb-jobs-agent/src/program.rs
+++ b/orb-jobs-agent/src/program.rs
@@ -1,5 +1,5 @@
 use crate::{
-    handlers::{check_my_orb, logs, mcu, orb_details, read_file, read_gimbal},
+    handlers::{check_my_orb, logs, mcu, orb_details, read_file, read_gimbal, wifi_ip},
     job_system::handler::JobHandler,
     settings::Settings,
     shell::Shell,
@@ -35,6 +35,7 @@ pub async fn run(deps: Deps) -> Result<()> {
         .parallel("orb_details", orb_details::handler)
         .parallel("read_gimbal", read_gimbal::handler)
         .parallel("mcu", mcu::handler)
+        .parallel("wifi_ip", wifi_ip::handler)
         .parallel_max("logs", 3, logs::handler)
         // .sequential("reboot", reboot::handler) ignored for now, mcu reboot is broken, and
         // regular reboot decreases the retry counter


### PR DESCRIPTION
This pull request adds a new handler for retrieving the WiFi IP address and improves the flexibility of the `check_my_orb` command. It also updates the systemd service dependencies to ensure proper startup order. The most important changes are grouped below:

### New WiFi IP Handler

* Added the `wifi_ip` handler to provide the IP address of the currently connected WiFi interface, including detection logic and output formatting. (`orb-jobs-agent/src/handlers/wifi_ip.rs`)
* Registered the new `wifi_ip` handler in the module exports and the job system, making it available for use. (`orb-jobs-agent/src/handlers/mod.rs`, `orb-jobs-agent/src/program.rs`) [[1]](diffhunk://#diff-828c40d1bb4e8a2bc1a35351f4a0549510dc8c0b004035a96277f1a83096a409R8) [[2]](diffhunk://#diff-6ef7e04362a7d78e147b3e7ed0702028b79c0fe368c0284d1ba85f96b0664f28L2-R2) [[3]](diffhunk://#diff-6ef7e04362a7d78e147b3e7ed0702028b79c0fe368c0284d1ba85f96b0664f28R38)

### Improvements to Command Handling

* Enhanced the `check_my_orb` handler to support an optional `--json` flag, allowing output in either default or JSON format based on user input. (`orb-jobs-agent/src/handlers/check_my_orb.rs`)

### Service Dependency Update

* Changed the systemd service file to require and start after `worldcoin-attest.service`, ensuring the jobs agent starts in the correct order relative to other services. (`orb-jobs-agent/debian/worldcoin-jobs-agent.service`)