### PR TITLE
feat(mcu-util): security board hardware states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7807,7 +7807,7 @@ dependencies = [
  "can-rs 0.0.0",
  "color-eyre",
  "futures",
- "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17)",
+ "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=d747b2298161f0dc18ea9b4dd1d544a716c1ef7d)",
  "pin-project",
  "prost 0.12.6",
  "thiserror 1.0.65",
@@ -7837,7 +7837,7 @@ dependencies = [
 [[package]]
 name = "orb-messages"
 version = "0.0.0"
-source = "git+https://github.com/worldcoin/orb-messages?rev=a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17#a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17"
+source = "git+https://github.com/worldcoin/orb-messages?rev=c439077c7c1bc3a8eb6f224c32b5b4d60d094809#c439077c7c1bc3a8eb6f224c32b5b4d60d094809"
 dependencies = [
  "prost 0.12.6",
  "prost-build 0.12.6",
@@ -7847,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "orb-messages"
 version = "0.0.0"
-source = "git+https://github.com/worldcoin/orb-messages?rev=c439077c7c1bc3a8eb6f224c32b5b4d60d094809#c439077c7c1bc3a8eb6f224c32b5b4d60d094809"
+source = "git+https://github.com/worldcoin/orb-messages?rev=d747b2298161f0dc18ea9b4dd1d544a716c1ef7d#d747b2298161f0dc18ea9b4dd1d544a716c1ef7d"
 dependencies = [
  "prost 0.12.6",
  "prost-build 0.12.6",
@@ -8103,7 +8103,7 @@ dependencies = [
  "hound",
  "humantime",
  "orb-build-info",
- "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17)",
+ "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=d747b2298161f0dc18ea9b4dd1d544a716c1ef7d)",
  "orb-rgb",
  "orb-sound",
  "orb-telemetry",
@@ -8234,7 +8234,7 @@ dependencies = [
  "libc",
  "orb-build-info",
  "orb-info",
- "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17)",
+ "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=d747b2298161f0dc18ea9b4dd1d544a716c1ef7d)",
  "orb-slot-ctrl",
  "orb-telemetry",
  "polling 2.5.2",
@@ -8325,7 +8325,7 @@ dependencies = [
  "eyre",
  "futures",
  "orb-build-info",
- "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17)",
+ "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=d747b2298161f0dc18ea9b4dd1d544a716c1ef7d)",
  "orb-telemetry",
  "prost 0.12.6",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,7 @@ test-utils.path = "test-utils"
 
 [workspace.dependencies.orb-messages]
 git = "https://github.com/worldcoin/orb-messages"
-rev = "a8d9ae8fe4aba2eac17cf1634f95dae20b19cf17"
+rev = "d747b2298161f0dc18ea9b4dd1d544a716c1ef7d"
 
 # increase the optimization of third party crates in dev builds.
 # [profile.dev.package."*"]


### PR DESCRIPTION
report all the hardware states from main and security mcu with `info -d`
 command.

this is how much we can get as of right now
```
orb-mcu-util info -d
🔮 Orb info:
	revision:	Diamond_DVT2
	battery charge:	65%
	voltage:	15807mV
	charging:	yes
🚜 Main board:
	current image:	v3.1.19-0x0 (dev)
	secondary slot:	v3.1.17-0xf06de109 (prod)
🔐 Security board:
	current image:	v3.1.19-0x0 (dev)
	battery charge:	100%
	voltage:	4130mV
	charging:	no

🛠️ Hardware states:
als          STATUS_SUCCESS                      
fan_tach     STATUS_SUCCESS                      
jetson       STATUS_SUCCESS                      booted
liquid_lens  STATUS_SUCCESS                      
polarizer    STATUS_ERROR_NOT_INITIALIZED        bumps not correctly detected
pvcc         STATUS_SUCCESS                      ir leds usable
sensor_bar   STATUS_SUCCESS                      
sound        STATUS_SUCCESS                      
supercaps    STATUS_ERROR_INVALID_STATE          1 voltages out of range
tmp_front    STATUS_SUCCESS                      
tmp_lens     STATUS_SUCCESS                      
tmp_main     STATUS_SUCCESS                      
tof_1d       STATUS_SUCCESS                      
voltages     STATUS_SUCCESS                      OK
heatsink     STATUS_SUCCESS                      mounted/sealed
ir_eye_cam   STATUS_SUCCESS                      mounted/sealed
jetson_conn  STATUS_SUCCESS                      mounted/sealed
s_bckp_batt  STATUS_SUCCESS                      full
se050        STATUS_SUCCESS                      comm ok, provisioned
sec_shield   STATUS_ERROR_INVALID_STATE          unmounted/tampered
shells       STATUS_ERROR_INVALID_STATE          unmounted/tampered
```