### PR TITLE
chore(ui): wifi qr scan animation

### DIFF
--- a/ui/rgb/src/lib.rs
+++ b/ui/rgb/src/lib.rs
@@ -143,7 +143,7 @@ impl Argb {
     pub const DIAMOND_RING_ERROR_SALMON: Argb = Argb(Some(8), 127, 20, 0);
 
     /// QR Phase colors - diamond
-    pub const DIAMOND_CENTER_WIFI_QR_SCAN: Argb = Argb(Some(6), 0, 15, 100);
+    pub const DIAMOND_CENTER_WIFI_QR_SCAN: Argb = Self::DIAMOND_CENTER_USER_QR_SCAN;
     pub const DIAMOND_CENTER_OPERATOR_QR_SCAN: Argb = Self::DIAMOND_CENTER_USER_QR_SCAN;
     pub const DIAMOND_CENTER_USER_QR_SCAN: Argb = Argb(Some(6), 80, 30, 2);
     pub const DIAMOND_CENTER_USER_QR_SCAN_COMPLETED: Argb = Argb(Some(6), 230, 80, 3);

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -437,9 +437,11 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                         self.operator_idle.no_wlan();
                         self.set_center(
                             LEVEL_BACKGROUND,
-                            animations::Static::<DIAMOND_CENTER_LED_COUNT>::new(
+                            animations::sine_blend::SineBlend::new(
                                 Argb::DIAMOND_CENTER_WIFI_QR_SCAN,
-                                None,
+                                Argb::OFF,
+                                4.0,
+                                0.0,
                             )
                             .fade_in(1.5),
                         );

--- a/ui/src/engine/diamond.rs
+++ b/ui/src/engine/diamond.rs
@@ -333,6 +333,11 @@ impl EventHandler for Runner<DIAMOND_RING_LED_COUNT, DIAMOND_CENTER_LED_COUNT> {
                 self.operator_pulse.trigger(1., 1., false, false);
             }
             Event::NetworkConnectionSuccess => {
+                self.stop_center(LEVEL_BACKGROUND, Transition::ForceStop);
+                self.set_center(
+                    LEVEL_BACKGROUND,
+                    animations::Static::new(Argb::OFF, None),
+                );
                 self.sound.queue(
                     sound::Type::Melody(sound::Melody::InternetConnectionSuccessful),
                     Duration::ZERO,


### PR DESCRIPTION
Removes the blue static color of the wifi-qr-scan phase.
Introduces a breathing animation. The sine-wave high color is equal to user-qr-scan, and low is `Argb::Off`.