### PR TITLE
chore(nix): bump flake inputs to fix github runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10340,9 +10340,9 @@ dependencies = [
 
 [[package]]
 name = "scc"
-version = "2.3.2"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef5b45d2864e2f8158e9d1e3d3284add4aeed8cd67e59009d05905b67d5b2d7"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
 dependencies = [
  "sdd",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -63,16 +63,16 @@ exceptions = [
 
 	# We don't atm have a viable altnerative to libsquashfs1 that is
 	# permissively licensed. This is OK as long as we link it dynamically.
-	{ allow = ["LGPL-3.0"], crate = "license-stub-libsquashfs1" },
+	{ allow = ["LGPL-3.0-or-later"], crate = "license-stub-libsquashfs1" },
 
 	# Gstreamer is needed, unless we want to write our own GPU accelerated video codec
 	# or use nvidia video-codec-sdk ourselves. This is OK as long as we link gstreamer
 	# dynamically
-	{ allow = ["LGPL-2.1"], crate = "license-stub-gstreamer" },
+	{ allow = ["LGPL-2.1-only"], crate = "license-stub-gstreamer" },
 
 	# GStreamer depends on glib, so does orb-bidiff-squashfs-shim. This is OK as
 	# long as we link it dynamically.
-	{ allow = ["LGPL-2.1"], crate = "license-stub-glib" },
+	{ allow = ["LGPL-2.1-or-later"], crate = "license-stub-glib" },
 ]
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1755153894,
-        "narHash": "sha256-DEKeIg3MQy5GMFiFRUzcx1hGGBN2ypUPTo0jrMAdmH4=",
+        "lastModified": 1757400094,
+        "narHash": "sha256-5Rcs6juMoMTaMJSR1glravl4QB9yLAFBD8s7KLi4kdQ=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f6874c6e512bc69d881d979a45379b988b80a338",
+        "rev": "0682b9b518792c9428865c511a4c40c9ad85c243",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751468302,
-        "narHash": "sha256-tWosziZTT039x6PgEZUhzGlV8oLvdDmIgKTE8ESMaEA=",
+        "lastModified": 1756679287,
+        "narHash": "sha256-Xd1vOeY9ccDf5VtVK12yM0FS6qqvfUop8UQlxEB+gTQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "501cfec8277f931a9c9af9f23d3105c537faeafe",
+        "rev": "07fc025fe10487dd80f2ec694f1cd790e752d0e8",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751211869,
-        "narHash": "sha256-1Cu92i1KSPbhPCKxoiVG5qnoRiKTgR5CcGSRyLpOd7Y=",
+        "lastModified": 1757408970,
+        "narHash": "sha256-aSgK4BLNFFGvDTNKPeB28lVXYqVn8RdyXDNAvgGq+k0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b43c397f6c213918d6cfe6e3550abfe79b5d1c51",
+        "rev": "d179d77c139e0a3f5c416477f7747e9d6b7ec315",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1750741721,
-        "narHash": "sha256-Z0djmTa1YmnGMfE9jEe05oO4zggjDmxOGKwt844bUhE=",
+        "lastModified": 1757347588,
+        "narHash": "sha256-tLdkkC6XnsY9EOZW9TlpesTclELy8W7lL2ClL+nma8o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4b1164c3215f018c4442463a27689d973cffd750",
+        "rev": "b599843bad24621dcaa5ab60dac98f9b0eb1cabe",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1755004716,
-        "narHash": "sha256-TbhPR5Fqw5LjAeI3/FOPhNNFQCF3cieKCJWWupeZmiA=",
+        "lastModified": 1757362324,
+        "narHash": "sha256-/PAhxheUq4WBrW5i/JHzcCqK5fGWwLKdH6/Lu1tyS18=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "b2a58b8c6eff3c3a2c8b5c70dbf69ead78284194",
+        "rev": "9edc9cbe5d8e832b5864e09854fa94861697d2fd",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
     "seekSdk": {
       "flake": false,
       "locked": {
-        "lastModified": 1660640538,
-        "narHash": "sha256-wI/DEP2frWJjGgh2+62E/CfICL/u5BMgbTqGDtqAt2I=",
+        "lastModified": 1756191916,
+        "narHash": "sha256-uGkr3duoHXNHxrpnIqfwp85hP6QoHZsWO7b46msYxXQ=",
         "owner": "worldcoin",
         "repo": "seek-thermal-sdk",
-        "rev": "b7480e6803d33c59607c0292c4628c4d6de6bbf9",
+        "rev": "63471a7cdc2cd06e1a317ec31c26b9da8aa8f883",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
github runners needed an update. I took the opportunity to just update everything in the flake inputs. Also required changing deny.toml