### PR TITLE
fix(nix): don't start zellij by default

### DIFF
--- a/nix/machines/home-hil.nix
+++ b/nix/machines/home-hil.nix
@@ -55,8 +55,6 @@ in
   };
   programs.zellij = {
     enable = true;
-    enableBashIntegration = true;
-    enableZshIntegration = true;
     package = pkgs.unstable.zellij;
   };
   programs.direnv = {


### PR DESCRIPTION
I noticed old instances of picocom etc were being left behind because all teleport shells were happening with zellij