### PR TITLE
chore(deps): Bump reqwest and cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,7 +330,7 @@ dependencies = [
  "indicatif",
  "octocrab",
  "orb-build-info",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "semver",
  "serde",
  "tokio",
@@ -4760,6 +4760,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4767,7 +4768,9 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
  "tokio",
@@ -5228,7 +5231,7 @@ dependencies = [
  "portmapper 0.5.0",
  "rand 0.8.5",
  "rcgen",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "ring",
  "rustls 0.23.29",
  "rustls-webpki 0.102.8",
@@ -5289,7 +5292,7 @@ dependencies = [
  "pkarr",
  "portmapper 0.8.0",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "ring",
  "rustls 0.23.29",
  "rustls-pki-types",
@@ -5576,7 +5579,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "rustls 0.23.29",
  "rustls-webpki 0.102.8",
  "serde",
@@ -5625,7 +5628,7 @@ dependencies = [
  "pkarr",
  "postcard",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "rustls 0.23.29",
  "rustls-pki-types",
  "rustls-webpki 0.103.4",
@@ -7408,7 +7411,7 @@ dependencies = [
  "orb-info",
  "orb-security-utils",
  "orb-telemetry",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "ring",
  "secrecy 0.8.0",
  "serde",
@@ -7450,7 +7453,7 @@ dependencies = [
  "orb-info",
  "orb-telemetry",
  "orb-update-agent-dbus",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "reqwest-middleware",
  "reqwest-tracing",
  "serde",
@@ -7555,7 +7558,7 @@ dependencies = [
  "orb-build-info",
  "orb-telemetry",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "sqlx",
@@ -7584,7 +7587,7 @@ dependencies = [
  "orb-build-info",
  "orb-telemetry",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "sqlx",
@@ -7608,7 +7611,7 @@ dependencies = [
  "iroh-blobs",
  "iroh-gossip",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "sha2",
@@ -7731,7 +7734,7 @@ dependencies = [
  "orb-security-utils",
  "probe-rs",
  "rand 0.8.5",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "secrecy 0.8.0",
  "tempfile",
  "thiserror 1.0.65",
@@ -8028,7 +8031,7 @@ version = "0.0.0"
 dependencies = [
  "eyre",
  "hex-literal",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "ring",
 ]
 
@@ -8294,7 +8297,7 @@ dependencies = [
  "polling 2.5.2",
  "prost 0.12.6",
  "prost-build 0.12.6",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "semver",
  "serde",
  "serde_json",
@@ -8342,7 +8345,7 @@ dependencies = [
  "tokio-serde",
  "tokio-util",
  "tower 0.5.2",
- "tower-http 0.6.2",
+ "tower-http 0.6.6",
  "tracing",
  "wtransport",
 ]
@@ -8761,7 +8764,7 @@ dependencies = [
  "lru 0.13.0",
  "mainline",
  "ntimestamp",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "self_cell",
  "serde",
  "sha1_smol",
@@ -9853,9 +9856,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -9868,17 +9871,13 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls 0.23.29",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -9888,14 +9887,14 @@ dependencies = [
  "tokio-rustls 0.26.1",
  "tokio-util",
  "tower 0.5.2",
+ "tower-http 0.6.6",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.7",
- "windows-registry",
+ "webpki-roots 1.0.3",
 ]
 
 [[package]]
@@ -9907,7 +9906,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.2.0",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "serde",
  "thiserror 1.0.65",
  "tower-service",
@@ -9925,7 +9924,7 @@ dependencies = [
  "http 1.2.0",
  "matchit 0.8.4",
  "opentelemetry",
- "reqwest 0.12.12",
+ "reqwest 0.12.24",
  "reqwest-middleware",
  "tracing",
  "tracing-opentelemetry",
@@ -12393,24 +12392,27 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.8.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
  "http-range-header 0.4.2",
  "httpdate",
+ "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -13102,6 +13104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13311,30 +13322,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -13346,16 +13337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ nix = { version = "0.28", default-features = false, features = [] }
 nusb = "0.2.0"
 pkg-config = "0.3.32"
 rand = "0.8"
-reqwest = { version = "=0.12.12", default-features = false, features = [
+reqwest = { version = "0.12.24", default-features = false, features = [
 	"rustls-tls",
 	"stream",
 ] }

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,7 @@ allow = [
 	"BSD-3-Clause",
 	"BSL-1.0",
 	"CC0-1.0",
+	"CDLA-Permissive-2.0",
 	"ISC",
 	"LicenseRef-ftdi-proprietary",
 	"LicenseRef-ring",


### PR DESCRIPTION
We would like to bump orb-core to latest reqwest and orb-software is blocking the bump.