### PR TITLE
chore(connd): set default metric value for ethernet

### DIFF
--- a/orb-connd/nm_cfg/20-defaults.conf
+++ b/orb-connd/nm_cfg/20-defaults.conf
@@ -8,7 +8,7 @@ ipv4.route-metric=300
 ipv4.ignore-auto-dns=true
 ipv4.dns=8.8.4.4;8.8.8.8;9.9.9.9;1.1.1.1
 
-ipv6.route-metric=400
+ipv6.route-metric=300
 
 [connection-wifi]
 match-device=type:wifi


### PR DESCRIPTION
making sure that priority wise ethernet > wifi > cellular by default