### PR TITLE
fix: Revert "chore(ci): remove obsolete orb-os version suffix (#745)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,10 +33,22 @@ on:
         options:
           - "beta"
           - "tmp"
+      overall_version:
+        description: |
+          In which orb-os version will this release be used?
+        required: true
+        type: choice
+        default: LL
+        options:
+          - JJ
+          - KK
+          - LL
+          - MM
 
 env:
   CI_CHANNEL: ${{ inputs.channel }}
   CI_COMPONENT: ${{ inputs.component }}
+  CI_OVERALL_VERSION: ${{ inputs.overall_version }}
   GH_TOKEN: ${{ github.token }} # For gh cli
 
 jobs:
@@ -85,10 +97,11 @@ jobs:
           echo "CI_CHANNEL=${CI_CHANNEL}"
           echo "CI_COMPONENT=${CI_COMPONENT}"
           echo "CI_SEMVER=${CI_SEMVER}"
+          echo "CI_OVERALL_VERSION=${CI_OVERALL_VERSION}"
 
           prefix="${CI_COMPONENT}/v${CI_SEMVER}-${CI_CHANNEL}"
           # This regex searches for the prerelease number `.0` in `foo/v1.2.3-beta.0+KK`
-          regex="${CI_COMPONENT}\/v${CI_SEMVER}-${CI_CHANNEL}\.([0-9]+)(\+[A-Z]{2})?"
+          regex="${CI_COMPONENT}\/v${CI_SEMVER}-${CI_CHANNEL}\.([0-9]+)\+[A-Z]{2}"
 
           # This finds the latest prerelease number.
           # see https://github.com/cli/cli/blob/6b19a854710ff2c81070f109f35434cd20e40115/pkg/cmd/release/list/http.go#L83
@@ -96,7 +109,7 @@ jobs:
           channel_num=$((${channel_num:--1} + 1)) # increment number
           echo "Detected next channel num to be ${channel_num}"
 
-          CI_RELEASE_NAME="${CI_COMPONENT}/v${CI_SEMVER}-${CI_CHANNEL}.${channel_num}"
+          CI_RELEASE_NAME="${CI_COMPONENT}/v${CI_SEMVER}-${CI_CHANNEL}.${channel_num}+${CI_OVERALL_VERSION}"
           echo "CI_RELEASE_NAME=${CI_RELEASE_NAME}" >>${GITHUB_ENV}
           echo "CI_RELEASE_NAME=${CI_RELEASE_NAME}" >>${GITHUB_OUTPUT}
 


### PR DESCRIPTION
This reverts commit 46a285fba3e6e161a6dde3523a83cd77966fc978.

Currently we can't release, not sure where does it get's blocked, couldn't find it in infra