### PR TITLE
chore(connd): better systemd retart config

### DIFF
--- a/orb-connd/debian/worldcoin-connd.service
+++ b/orb-connd/debian/worldcoin-connd.service
@@ -11,7 +11,9 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
 Environment=RUST_BACKTRACE=1
 ExecStart=/usr/local/bin/orb-connd
 SyslogIdentifier=worldcoin-connd
-Restart=on-failure
+Restart=always
+RestartSec=3
+StartLimitIntervalSec=0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## changes
- change systemd restart logic for `worldcoin-connd` so that it is never rate limited and waits 3s between each restart