### PR TITLE
fix: don't crahs if capabilities are not present on the modem

### DIFF
--- a/orb-connd/src/telemetry/mod.rs
+++ b/orb-connd/src/telemetry/mod.rs
@@ -13,7 +13,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 pub mod backend_status_cellular_reporter;
 pub mod backend_status_wifi_reporter;
@@ -93,8 +93,10 @@ async fn make_modem_status(
                 Some(sim_info.iccid)
             }
         };
-
-        mm.signal_setup(&modem.id, Duration::from_secs(10)).await?;
+        
+        if let Err(e) = mm.signal_setup(&modem.id, Duration::from_secs(10)).await {
+            warn!("make_modem_status: signal setup unsupported/failed: {e}");
+        }
 
         let net_stats = NetStats::collect(sysfs, "wwan0").await?;
 

--- a/orb-connd/src/telemetry/mod.rs
+++ b/orb-connd/src/telemetry/mod.rs
@@ -93,7 +93,7 @@ async fn make_modem_status(
                 Some(sim_info.iccid)
             }
         };
-        
+
         if let Err(e) = mm.signal_setup(&modem.id, Duration::from_secs(10)).await {
             warn!("make_modem_status: signal setup unsupported/failed: {e}");
         }


### PR DESCRIPTION
This is kinda temporary circumvemnts the issue, but ideally we should try to set it up peridocically. In the ticket couple of devices are linked that have capabilities ready after few retries - and this PR basically won't retry again if first time it was a failure.