### PR TITLE
fix(qr-link): drop QR v5 and bump secure hash()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,10 +1076,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http-client"
-version = "1.1.4"
+name = "aws-smithy-http"
+version = "0.63.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "623254723e8dfd535f566ee7b2381645f8981da086b5c4aa26c0c41582bb1d2c"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1092,6 +1113,7 @@ dependencies = [
  "hyper-rustls 0.24.2",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs 0.8.2",
  "tokio",
  "tracing",
 ]
@@ -1116,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1881b1ea6d313f9890710d65c158bdab6fb08c91ea825f74c1c8c357baf4cc"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
 dependencies = [
  "aws-smithy-runtime-api",
 ]
@@ -1135,12 +1157,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.4"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bbe9d018d646b96c7be063dd07987849862b0e6d07c778aad7d93d1be6c1ef0"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.62.5",
+ "aws-smithy-http 0.63.6",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1151,6 +1173,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
+ "http-body-util",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -1728,7 +1751,7 @@ dependencies = [
  "log",
  "num",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rustls 0.23.35",
  "rustls-native-certs 0.8.2",
  "rustls-pemfile 2.2.0",
@@ -2483,15 +2506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "coreaudio-rs"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,7 +2912,7 @@ checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
 dependencies = [
  "bitvec",
  "deku_derive",
- "no_std_io2",
+ "no_std_io2 0.8.1",
  "rustversion",
 ]
 
@@ -3773,7 +3787,7 @@ checksum = "18c1ddb9231d8554c2d6bdf4cfaabf0c59251658c68b6c95cd52dd0c513a912a"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -4762,7 +4776,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.17",
  "tinyvec",
@@ -4784,7 +4798,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.17",
@@ -5288,7 +5302,7 @@ dependencies = [
  "hyper 1.7.0",
  "hyper-util",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
  "url",
  "xmltree",
@@ -6300,25 +6314,25 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libflate"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249fa21ba2b59e8cbd69e722f5b31e1b466db96c937ae3de23e8b99ead0d1383"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2 0.9.3",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.0",
+ "no_std_io2 0.9.3",
  "rle-decode-fast",
 ]
 
@@ -7305,6 +7319,15 @@ name = "no_std_io2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
 ]
@@ -9740,7 +9763,7 @@ dependencies = [
  "nested_enum_utils",
  "netwatch 0.8.0",
  "num_enum",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "smallvec",
  "snafu 0.8.9",
@@ -10079,7 +10102,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.10.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -10125,7 +10148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -10145,7 +10168,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -10336,7 +10359,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls 0.23.35",
@@ -10407,9 +10430,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -10835,7 +10858,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e211f878258887b3e65dd3c8ff9f530fe109f441a117ee0cdc27f341355032"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -12071,7 +12094,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -12511,7 +12534,7 @@ dependencies = [
  "precis-core",
  "precis-profiles",
  "quoted-string-parser",
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -12529,7 +12552,7 @@ dependencies = [
  "hex 0.4.3",
  "parking_lot 0.12.5",
  "pnet_packet",
- "rand 0.9.2",
+ "rand 0.9.4",
  "socket2 0.6.1",
  "thiserror 1.0.69",
  "tokio",
@@ -12544,7 +12567,7 @@ checksum = "790d8444f7db1e88f70aed3234cab8e42c48e05360bfc86ca7dce0d9a5d95d26"
 dependencies = [
  "acto",
  "hickory-proto",
- "rand 0.9.2",
+ "rand 0.9.4",
  "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
@@ -13200,7 +13223,7 @@ dependencies = [
  "getrandom 0.3.4",
  "http 1.3.1",
  "httparse",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustls-pki-types",
  "simdutf8",
@@ -13222,7 +13245,7 @@ dependencies = [
  "getrandom 0.3.4",
  "http 1.3.1",
  "httparse",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustls-pki-types",
  "simdutf8",
@@ -13743,7 +13766,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
  "web-time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8483,7 +8483,7 @@ name = "orb-qr-link"
 version = "0.1.0"
 dependencies = [
  "data-encoding",
- "orb-relay-messages 0.0.0 (git+https://github.com/worldcoin/orb-relay-messages.git?rev=455cb14ccd691398ac2af14aa49011d741e854c0)",
+ "orb-relay-messages 0.0.0 (git+https://github.com/worldcoin/orb-relay-messages.git?rev=9bc83771b15cbf22796e93a7276040db4d63a64d)",
  "thiserror 1.0.69",
  "uuid 1.19.0",
 ]
@@ -8524,7 +8524,7 @@ dependencies = [
 [[package]]
 name = "orb-relay-messages"
 version = "0.0.0"
-source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=455cb14ccd691398ac2af14aa49011d741e854c0#455cb14ccd691398ac2af14aa49011d741e854c0"
+source = "git+https://github.com/worldcoin/orb-relay-messages.git?rev=9bc83771b15cbf22796e93a7276040db4d63a64d#9bc83771b15cbf22796e93a7276040db4d63a64d"
 dependencies = [
  "blake3",
  "prost 0.14.1",

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,8 @@ ignore = [
 	{ id = "RUSTSEC-2026-0049", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
 	# rand 0.8.5 is a transitive dep; unsound only under rare conditions (custom logger + thread_rng + trace logging)
 	{ id = "RUSTSEC-2026-0097", reason = "transitive dep, unsound only under rare conditions with custom logger accessing rand::rng(), upgrade blocked by upstream" },
+	{ id = "RUSTSEC-2026-0098", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
+	{ id = "RUSTSEC-2026-0099", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
 ]
 unmaintained = "workspace" # only warn for direct dependencies (not transitive ones)
 version = 2

--- a/qr-link/Cargo.toml
+++ b/qr-link/Cargo.toml
@@ -24,7 +24,7 @@ uuid = { version = "1.4.1", features = ["v4"] }
 [dev-dependencies.orb-relay-messages]
 features = ["client"]
 git = "https://github.com/worldcoin/orb-relay-messages.git"
-rev = "455cb14ccd691398ac2af14aa49011d741e854c0"
+rev = "9bc83771b15cbf22796e93a7276040db4d63a64d"
 
 [[test]]
 name = "qr-codes"

--- a/qr-link/src/decode.rs
+++ b/qr-link/src/decode.rs
@@ -23,19 +23,15 @@ pub fn decode_qr_with_version(qr: &str) -> Result<(u8, Uuid, Vec<u8>), DecodeErr
         return Err(DecodeError::Malformed);
     };
     match version {
-        b'4' | b'5' => {
+        b'4' => {
             let (orb_relay_id, app_authenticated_data_hash) = decode_payload(qr)?;
-            Ok((version - b'0', orb_relay_id, app_authenticated_data_hash))
+            Ok((4, orb_relay_id, app_authenticated_data_hash))
         }
         _ => Err(DecodeError::UnsupportedVersion),
     }
 }
 
 /// Decodes a QR payload: 16-byte orb relay UUID followed by hash bytes.
-/// The wire format (UUID + hash bytes) is the same for v4 and v5, but the
-/// hash bytes differ because v5 uses a length-prefixed BLAKE3 hash.
-/// The caller must use the version from [`decode_qr_with_version`] to pick
-/// the matching verify method.
 fn decode_payload(qr: &str) -> Result<(Uuid, Vec<u8>), DecodeError> {
     let Ok(payload) = BASE64_NOPAD.decode(&qr.as_bytes()[1..]) else {
         return Err(DecodeError::Base64);

--- a/qr-link/src/encode.rs
+++ b/qr-link/src/encode.rs
@@ -1,30 +1,11 @@
 use data_encoding::BASE64_NOPAD;
 use uuid::Uuid;
 
-/// QR-code version prefix for legacy hash.
-pub const QR_VERSION_V4: u8 = b'4';
+/// QR-code version prefix.
+pub const QR_VERSION: u8 = b'4';
 
-/// QR-code version prefix for length-prefixed hash.
-pub const QR_VERSION_V5: u8 = b'5';
-
-/// Generates a QR-code (V4) string using the legacy hash format.
+/// Generates a QR-code (V4) string from `orb relay id` and `app_authenticated_data`
 pub fn encode_static_qr(
-    orb_relay_id: &Uuid,
-    authenticated_data_hash: impl AsRef<[u8]>,
-) -> String {
-    encode_qr(QR_VERSION_V4, orb_relay_id, authenticated_data_hash)
-}
-
-/// Generates a QR-code (V5) string using the length-prefixed hash format.
-pub fn encode_static_qr_v5(
-    orb_relay_id: &Uuid,
-    authenticated_data_hash: impl AsRef<[u8]>,
-) -> String {
-    encode_qr(QR_VERSION_V5, orb_relay_id, authenticated_data_hash)
-}
-
-fn encode_qr(
-    version: u8,
     orb_relay_id: &Uuid,
     authenticated_data_hash: impl AsRef<[u8]>,
 ) -> String {
@@ -33,7 +14,7 @@ fn encode_qr(
     payload.extend_from_slice(authenticated_data_hash.as_ref());
 
     let mut qr = String::new();
-    qr.push(version.into());
+    qr.push(QR_VERSION.into());
     BASE64_NOPAD.encode_append(&payload, &mut qr);
     qr
 }

--- a/qr-link/src/lib.rs
+++ b/qr-link/src/lib.rs
@@ -23,4 +23,4 @@ mod encode;
 #[cfg(feature = "decode")]
 pub use decode::{decode_qr_with_version, DecodeError};
 #[cfg(feature = "encode")]
-pub use encode::{encode_static_qr, encode_static_qr_v5};
+pub use encode::encode_static_qr;

--- a/qr-link/tests/qr-codes.rs
+++ b/qr-link/tests/qr-codes.rs
@@ -1,16 +1,6 @@
-use orb_qr_link::{decode_qr_with_version, encode_static_qr, encode_static_qr_v5};
+use orb_qr_link::{decode_qr_with_version, encode_static_qr};
 use orb_relay_messages::common::v1::AppAuthenticatedData;
 use uuid::Uuid;
-
-fn sample_data() -> AppAuthenticatedData {
-    AppAuthenticatedData {
-        identity_commitment: "0xabcd".to_string(),
-        self_custody_public_key: "key".to_string(),
-        pcp_version: 3,
-        os: "Android".to_string(),
-        os_version: "1.2.3".to_string(),
-    }
-}
 
 #[test]
 fn test_encode_decode() {
@@ -27,6 +17,7 @@ MCowBQYDK2VuAyEA2boNBmJX4lGkA9kjthS5crXOBxu2BPycKRMakpzgLG4=
         pcp_version: 3,
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
+        version: AppAuthenticatedData::VERSION,
     };
     let hash_app_data = app_data.hash(16);
     let qr = encode_static_qr(&orb_relay_id, hash_app_data);
@@ -49,6 +40,7 @@ MCowBQYDK2VuAyEA2boNBmJX4lGkA9kjthS5crXOBxu2BPycKRMakpzgLG4=
         pcp_version: 3,
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
+        version: AppAuthenticatedData::VERSION,
     };
     let hash_app_data = app_data.hash(16);
     let qr = encode_static_qr(&orb_relay_id, hash_app_data);
@@ -62,6 +54,7 @@ MCowBQYDK2VuAyEA2boNBmJX4lGkA9kjthS5crXOBxu2BPycKRMakpzgLG4=
         pcp_version: 2,
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
+        version: AppAuthenticatedData::VERSION,
     };
     assert!(!incorrect_app_data.verify(parsed_app_data));
 }
@@ -84,6 +77,7 @@ fn test_empty_hash_qr_decodes_but_verify_rejects() {
         pcp_version: 3,
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
+        version: AppAuthenticatedData::VERSION,
     };
     assert!(!app_data.verify(hash));
 }
@@ -97,6 +91,7 @@ fn test_different_pcp_version_fails_verify() {
         pcp_version: 3,
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
+        version: AppAuthenticatedData::VERSION,
     };
     let hash = app_data.hash(16);
     let qr = encode_static_qr(&orb_relay_id, hash);
@@ -118,6 +113,7 @@ fn test_corrupted_hash_fails_verify() {
         pcp_version: 3,
         os: "Android".to_string(),
         os_version: "1.2.3".to_string(),
+        version: AppAuthenticatedData::VERSION,
     };
     let mut hash = app_data.hash(16);
     hash[0] ^= 0xFF;
@@ -150,56 +146,4 @@ fn test_roundtrip_preserves_orb_relay_id() {
         let (_, parsed_id, _) = decode_qr_with_version(&qr).unwrap();
         assert_eq!(id, parsed_id);
     }
-}
-
-// --- V5 (length-prefixed hash) tests ---
-
-#[test]
-fn test_v5_encode_decode_roundtrip() {
-    let orb_relay_id = Uuid::new_v4();
-    let app_data = sample_data();
-    let hash = app_data.hash_with_length_prefix(16);
-    let qr = encode_static_qr_v5(&orb_relay_id, hash);
-    let (version, parsed_id, parsed_hash) = decode_qr_with_version(&qr).unwrap();
-    assert_eq!(version, 5);
-    assert_eq!(parsed_id, orb_relay_id);
-    assert!(app_data.verify_with_length_prefix(parsed_hash));
-}
-
-#[test]
-fn test_v5_rejects_wrong_data() {
-    let orb_relay_id = Uuid::new_v4();
-    let app_data = sample_data();
-    let hash = app_data.hash_with_length_prefix(16);
-    let qr = encode_static_qr_v5(&orb_relay_id, hash);
-    let (_, _, parsed_hash) = decode_qr_with_version(&qr).unwrap();
-
-    let wrong_data = AppAuthenticatedData {
-        identity_commitment: "0x9999".to_string(),
-        ..sample_data()
-    };
-    assert!(!wrong_data.verify_with_length_prefix(parsed_hash));
-}
-
-#[test]
-fn test_v5_hash_not_accepted_by_legacy_verify() {
-    let app_data = sample_data();
-    let v5_hash = app_data.hash_with_length_prefix(16);
-    assert!(!app_data.verify(&v5_hash));
-}
-
-#[test]
-fn test_v4_hash_not_accepted_by_v5_verify() {
-    let app_data = sample_data();
-    let v4_hash = app_data.hash(16);
-    assert!(!app_data.verify_with_length_prefix(&v4_hash));
-}
-
-#[test]
-fn test_v5_empty_hash_rejected() {
-    let orb_relay_id = Uuid::nil();
-    let qr = encode_static_qr_v5(&orb_relay_id, &[] as &[u8]);
-    let (version, _, hash) = decode_qr_with_version(&qr).unwrap();
-    assert_eq!(version, 5);
-    assert!(!sample_data().verify_with_length_prefix(hash));
 }


### PR DESCRIPTION
Depends on: https://github.com/worldcoin/orb-relay-messages/pull/99