### PR TITLE
feat(slot-ctrl): unify device behavior

### DIFF
--- a/slot-ctrl/src/domain.rs
+++ b/slot-ctrl/src/domain.rs
@@ -2,7 +2,6 @@ use std::{fmt::Display, str::FromStr};
 
 use derive_more::Display;
 use efivar::EfiVarData;
-use orb_info::orb_os_release::OrbOsPlatform;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -14,16 +13,16 @@ pub enum Error {
     InvalidEfiVarLen { expected: usize, actual: usize },
     #[error("invalid slot configuration")]
     InvalidSlotData,
+    #[error("invalid bootchain-firmware status")]
+    InvalidBootChainFwStatusData,
     #[error("invalid rootfs status")]
     InvalidRootFsStatusData,
-    #[error("failed reading scratch register: {0}")]
-    CouldNotReadScratchReg(String),
+    #[error("failed opening scratch register: {0}")]
+    CouldNotOpenScratchReg(String),
     #[error("invalid retry counter({counter}), exceeding the maximum ({max})")]
     ExceedingRetryCount { counter: u8, max: u8 },
     #[error("{0}")]
     EfiVar(#[from] color_eyre::Report),
-    #[error("unsupported orb type: {0}")]
-    UnsupportedOrbType(OrbOsPlatform),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
@@ -95,13 +94,14 @@ impl TryFrom<u8> for BootChainFwStatus {
             16 => Ok(Self::ErrorSettingScratch),
             17 => Ok(Self::ErrorUpdateBrBctFlagSet),
             18 => Ok(Self::ErrorSettingPrevious),
-            _ => Err(Error::InvalidRootFsStatusData),
+            _ => Err(Error::InvalidBootChainFwStatusData),
         }
     }
 }
 
 /// Representation of the slot.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Display)]
+#[repr(u8)]
 pub enum Slot {
     #[display("a")]
     A = 0,
@@ -111,20 +111,21 @@ pub enum Slot {
 
 /// Representation of the rootfs status.
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Display)]
+#[repr(u8)]
 pub enum RootFsStatus {
     /// Default status of the rootfs.
-    Normal,
-    /// Status of the rootfs where the partitions during an update are written.
-    UpdateInProcess,
-    /// Status of the rootfs where the boot slot was just switched to it.
-    UpdateDone,
-    /// Status of the rootfs is considered unbootable.
-    Unbootable,
+    Normal = 0x0,
+    /// Rootfs status signifying that an update consumption has initiated
+    UpdateInProcess = 0x1,
+    /// Rootfs status signifying that an update was done & active slot switched
+    UpdateDone = 0x2,
+    /// Rootfs status signifying that the target slot is considered unbootable.
+    Unbootable = 0x3,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RetryCounts {
-    pub efi_var: Option<EfiRetryCount>,
+    pub efi_var: EfiRetryCount,
     pub scratch_reg: Option<ScratchRegRetryCount>,
 }
 
@@ -132,13 +133,10 @@ impl Display for RetryCounts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         const NA: &str = "unavailable in this platform";
 
-        write!(f, "efi var: ")?;
-        match self.efi_var {
-            Some(v) => write!(f, "{v}")?,
-            None => write!(f, "{NA}")?,
-        };
+        writeln!(f, "efi var: {}", &self.efi_var)?;
 
-        write!(f, "\nscratch register: ")?;
+        // TODO: Remove once the pearl driver is patched
+        write!(f, "scratch register: ")?;
         match self.scratch_reg {
             Some(v) => write!(f, "{v}")?,
             None => write!(f, "{NA}")?,
@@ -152,10 +150,11 @@ impl Display for RetryCounts {
 pub struct ScratchRegRetryCount(pub u8);
 
 impl ScratchRegRetryCount {
-    pub(crate) const DIAMOND_COUNT_A_PATH: &str =
+    pub(crate) const COUNT_A_PATH: &str =
         "sys/devices/platform/bus@0/c360000.pmc/rootfs_retry_count_a";
-    pub(crate) const DIAMOND_COUNT_B_PATH: &str =
+    pub(crate) const COUNT_B_PATH: &str =
         "sys/devices/platform/bus@0/c360000.pmc/rootfs_retry_count_b";
+    pub(crate) const COUNT_MAX: u8 = 0x3;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Display)]
@@ -201,8 +200,8 @@ impl FromStr for Slot {
 }
 
 impl Slot {
-    pub(crate) const SLOT_A_BYTES: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
-    pub(crate) const SLOT_B_BYTES: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
+    const SLOT_A_BYTES: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
+    const SLOT_B_BYTES: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
 
     pub(crate) const CURRENT_SLOT_PATH: &str =
         "BootChainFwCurrent-781e084c-a330-417c-b678-38e696380cb9";
@@ -215,12 +214,17 @@ impl Slot {
     }
 
     pub fn from_efivar_data(data: &EfiVarData) -> Result<Slot> {
-        if Slot::SLOT_A_BYTES == data.value() {
-            Ok(Slot::A)
-        } else if Slot::SLOT_B_BYTES == data.value() {
-            Ok(Slot::B)
-        } else {
-            Err(Error::InvalidSlotData)
+        if data.len() != 8 {
+            return Err(Error::InvalidEfiVarLen {
+                expected: 8,
+                actual: data.len(),
+            });
+        }
+
+        match data.value() {
+            val if val == Self::SLOT_A_BYTES => Ok(Slot::A),
+            val if val == Self::SLOT_B_BYTES => Ok(Slot::B),
+            _ => Err(Error::InvalidSlotData),
         }
     }
 }
@@ -231,83 +235,43 @@ impl FromStr for RootFsStatus {
     fn from_str(s: &str) -> Result<Self> {
         match s.to_lowercase().as_str() {
             "normal" | "0" => Ok(RootFsStatus::Normal),
-            "updateinprocess" | "updinprocess" | "1" => {
-                Ok(RootFsStatus::UpdateInProcess)
-            }
-            "updatedone" | "upddone" | "2" => Ok(RootFsStatus::UpdateDone),
+            "updateinprocess" | "1" => Ok(RootFsStatus::UpdateInProcess),
+            "updatedone" | "2" => Ok(RootFsStatus::UpdateDone),
             "unbootable" | "3" => Ok(RootFsStatus::Unbootable),
-            _ => Err(Error::InvalidSlotData),
+            _ => Err(Error::InvalidRootFsStatusData),
         }
     }
 }
 
 impl RootFsStatus {
-    // Right now Pearl has extra states in the update status, some thing
-    // we will probably get rid of in the future. Values were also altered and are
-    // different than the default NVIDIA ones (used by Diamond)
-    // https://github.com/worldcoin/edk2-nvidia/blob/ede09eb66b00d5d185ba93b7992390f2a483b46f/Silicon/NVIDIA/Include/NVIDIAConfiguration.h#L23
-    pub(crate) const PEARL_NORMAL: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
-    pub(crate) const PEARL_UPDATE_IN_PROGRESS: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
-    pub(crate) const PEARL_UPDATE_DONE: [u8; 4] = [0x02, 0x00, 0x00, 0x00];
-    pub(crate) const PEARL_UNBOOTABLE: [u8; 4] = [0x03, 0x00, 0x00, 0x00];
-
-    // https://github.com/worldcoin/edk2-nvidia/blob/86a32d95373d6aaf87278093a855ccf193b9c61f/Silicon/NVIDIA/Include/NVIDIAConfiguration.h#L23
-    pub(crate) const DIAMOND_NORMAL: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
-    pub(crate) const DIAMOND_UNBOOTABLE: [u8; 4] = [0xFF, 0x00, 0x00, 0x00];
+    const NORMAL: [u8; 4] = [0x00, 0x00, 0x00, 0x00];
+    const UPDATE_IN_PROGRESS: [u8; 4] = [0x01, 0x00, 0x00, 0x00];
+    const UPDATE_DONE: [u8; 4] = [0x02, 0x00, 0x00, 0x00];
+    const UNBOOTABLE: [u8; 4] = [0x03, 0x00, 0x00, 0x00];
 
     pub(crate) const STATUS_A_PATH: &str =
         "RootfsStatusSlotA-781e084c-a330-417c-b678-38e696380cb9";
     pub(crate) const STATUS_B_PATH: &str =
         "RootfsStatusSlotB-781e084c-a330-417c-b678-38e696380cb9";
 
-    pub fn to_efivar_data(&self, orb: OrbOsPlatform) -> Result<EfiVarData> {
-        let value = match (self, orb) {
-            (Self::Normal, OrbOsPlatform::Pearl) => &Self::PEARL_NORMAL,
-            (Self::UpdateInProcess, OrbOsPlatform::Pearl) => {
-                &Self::PEARL_UPDATE_IN_PROGRESS
-            }
-            (Self::UpdateDone, OrbOsPlatform::Pearl) => &Self::PEARL_UPDATE_DONE,
-            (Self::Unbootable, OrbOsPlatform::Pearl) => &Self::PEARL_UNBOOTABLE,
-            (Self::Normal, OrbOsPlatform::Diamond) => &Self::DIAMOND_NORMAL,
-            (Self::Unbootable, OrbOsPlatform::Diamond) => &Self::DIAMOND_UNBOOTABLE,
-            _ => return Err(Error::InvalidRootFsStatusData),
-        };
-
-        Ok(EfiVarData::new(0x7, value))
+    pub fn to_efivar_data(&self) -> EfiVarData {
+        EfiVarData::new(0x7, [*self as u8, 0x0, 0x0, 0x0])
     }
 
     /// RootFsStatus from EfiVar raw bytes
-    pub fn from_efivar_data(
-        data: &EfiVarData,
-        orb: OrbOsPlatform,
-    ) -> Result<RootFsStatus> {
-        let bytes = data.value();
+    pub fn from_efivar_data(data: &EfiVarData) -> Result<RootFsStatus> {
+        if data.len() != 8 {
+            return Err(Error::InvalidEfiVarLen {
+                expected: 8,
+                actual: data.len(),
+            });
+        }
 
-        match orb {
-            OrbOsPlatform::Pearl if bytes == Self::PEARL_NORMAL => {
-                Ok(RootFsStatus::Normal)
-            }
-
-            OrbOsPlatform::Pearl if bytes == Self::PEARL_UPDATE_IN_PROGRESS => {
-                Ok(RootFsStatus::UpdateInProcess)
-            }
-
-            OrbOsPlatform::Pearl if bytes == Self::PEARL_UPDATE_DONE => {
-                Ok(RootFsStatus::UpdateDone)
-            }
-
-            OrbOsPlatform::Pearl if bytes == Self::PEARL_UNBOOTABLE => {
-                Ok(RootFsStatus::Unbootable)
-            }
-
-            OrbOsPlatform::Diamond if bytes == Self::DIAMOND_NORMAL => {
-                Ok(RootFsStatus::Normal)
-            }
-
-            OrbOsPlatform::Diamond if bytes == Self::DIAMOND_UNBOOTABLE => {
-                Ok(RootFsStatus::Unbootable)
-            }
-
+        match data.value() {
+            val if val == Self::NORMAL => Ok(Self::Normal),
+            val if val == Self::UPDATE_IN_PROGRESS => Ok(Self::UpdateInProcess),
+            val if val == Self::UPDATE_DONE => Ok(Self::UpdateDone),
+            val if val == Self::UNBOOTABLE => Ok(Self::Unbootable),
             _ => Err(Error::InvalidRootFsStatusData),
         }
     }

--- a/slot-ctrl/src/domain.rs
+++ b/slot-ctrl/src/domain.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, str::FromStr};
+use std::{fmt::Display, fs, path::Path, str::FromStr};
 
 use derive_more::Display;
 use efivar::EfiVarData;
@@ -126,21 +126,13 @@ pub enum RootFsStatus {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RetryCounts {
     pub efi_var: EfiRetryCount,
-    pub scratch_reg: Option<ScratchRegRetryCount>,
+    pub sr_rf: ScratchRegRetryCount,
 }
 
 impl Display for RetryCounts {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        const NA: &str = "unavailable in this platform";
-
         writeln!(f, "efi var: {}", &self.efi_var)?;
-
-        // TODO: Remove once the pearl driver is patched
-        write!(f, "scratch register: ")?;
-        match self.scratch_reg {
-            Some(v) => write!(f, "{v}")?,
-            None => write!(f, "{NA}")?,
-        };
+        writeln!(f, "SR_RF: {}", &self.sr_rf)?;
 
         Ok(())
     }
@@ -150,11 +142,32 @@ impl Display for RetryCounts {
 pub struct ScratchRegRetryCount(pub u8);
 
 impl ScratchRegRetryCount {
-    pub(crate) const COUNT_A_PATH: &str =
+    pub(crate) const DIAMOND_REG_PATH_A: &str =
         "sys/devices/platform/bus@0/c360000.pmc/rootfs_retry_count_a";
-    pub(crate) const COUNT_B_PATH: &str =
+    pub(crate) const DIAMOND_REG_PATH_B: &str =
         "sys/devices/platform/bus@0/c360000.pmc/rootfs_retry_count_b";
-    pub(crate) const COUNT_MAX: u8 = 0x3;
+    pub(crate) const PEARL_REG_PATH_A: &str =
+        "sys/devices/platform/c360000.pmc/rootfs_retry_count_a";
+    pub(crate) const PEARL_REG_PATH_B: &str =
+        "sys/devices/platform/c360000.pmc/rootfs_retry_count_b";
+    pub(crate) const SR_RF_COUNT_MAX: u8 = 0x3;
+
+    pub(crate) fn new(sr_rf_path: impl AsRef<Path>) -> Result<Self> {
+        let raw = fs::read_to_string(sr_rf_path)
+            .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
+
+        let hex = raw.trim().strip_prefix("0x").ok_or_else(|| {
+            Error::CouldNotOpenScratchReg(format!(
+                "scratch register retry count in unexpected format: {raw}"
+            ))
+        })?;
+
+        let count = hex
+            .parse::<u8>()
+            .map_err(|e| Error::CouldNotOpenScratchReg(format!("{e}: '{hex}'")))?;
+
+        Ok(ScratchRegRetryCount(count))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Display)]

--- a/slot-ctrl/src/lib.rs
+++ b/slot-ctrl/src/lib.rs
@@ -4,7 +4,7 @@ use domain::{RetryCounts, ScratchRegRetryCount};
 use efivar::{EfiVar, EfiVarDb};
 use orb_info::orb_os_release::OrbOsPlatform;
 use std::{
-    fs,
+    fs::{self},
     path::{Path, PathBuf},
 };
 
@@ -105,7 +105,7 @@ impl OrbSlotCtrl {
         };
 
         let data = status_var.read()?;
-        RootFsStatus::from_efivar_data(&data, self.orb_type)
+        RootFsStatus::from_efivar_data(&data)
     }
 
     /// Set a rootfs status for a certain `slot`.
@@ -115,59 +115,53 @@ impl OrbSlotCtrl {
             Slot::B => &self.status_b,
         };
 
-        status_var.write(&status.to_efivar_data(self.orb_type)?)?;
-
+        status_var.write(&status.to_efivar_data())?;
         Ok(())
     }
 
-    /// Gets both the EFI and the scratch register retry counters
     pub(crate) fn get_retry_counts(&self, slot: Slot) -> Result<RetryCounts> {
-        let (pearl_efi_var, diamond_scratch_register_path) = match slot {
+        let (efi_var_path, scratch_reg_path) = match slot {
             Slot::A => (
                 &self.retry_count_a,
-                self.rootfs.join(ScratchRegRetryCount::DIAMOND_COUNT_A_PATH),
+                self.rootfs.join(ScratchRegRetryCount::COUNT_A_PATH),
             ),
-
             Slot::B => (
                 &self.retry_count_b,
-                self.rootfs.join(ScratchRegRetryCount::DIAMOND_COUNT_B_PATH),
+                self.rootfs.join(ScratchRegRetryCount::COUNT_B_PATH),
             ),
         };
 
-        let (efi_var, scratch_reg) = match self.orb_type {
+        let efi_var_data = &efi_var_path.read()?;
+        let efi_retry_count = EfiRetryCount::from_efivar_data(efi_var_data)?;
+
+        // TODO: Remove the platform segmentation once the pearl driver is patched
+        let reg_retry_count = match self.orb_type {
             OrbOsPlatform::Diamond => {
-                let count = fs::read(diamond_scratch_register_path)
-                    .map_err(|e| Error::CouldNotReadScratchReg(e.to_string()))?;
+                let count = fs::read(scratch_reg_path)
+                    .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
 
                 let count = String::from_utf8(count)
-                    .map_err(|e| Error::CouldNotReadScratchReg(e.to_string()))?;
+                    .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
 
                 let count = count.strip_prefix("0x").ok_or_else(|| {
-                    Error::CouldNotReadScratchReg(format!(
+                    Error::CouldNotOpenScratchReg(format!(
                         "scratch register retry count in unexpected format {count}"
                     ))
                 })?;
 
                 let count = count.trim().parse::<u8>().map_err(|e| {
-                    Error::CouldNotReadScratchReg(format!("{e}: '{count}'"))
+                    Error::CouldNotOpenScratchReg(format!("{e}: '{count}'"))
                 })?;
 
                 let count = ScratchRegRetryCount(count);
-
-                (None, Some(count))
+                Some(count)
             }
-
-            OrbOsPlatform::Pearl => {
-                let efi_var_data = &pearl_efi_var.read()?;
-                let count = EfiRetryCount::from_efivar_data(efi_var_data)?;
-
-                (Some(count), None)
-            }
+            OrbOsPlatform::Pearl => None,
         };
 
         Ok(RetryCounts {
-            efi_var,
-            scratch_reg,
+            efi_var: efi_retry_count,
+            scratch_reg: reg_retry_count,
         })
     }
 
@@ -176,14 +170,15 @@ impl OrbSlotCtrl {
         EfiRetryCount::from_efivar_data(&self.retry_count_max.read()?)
     }
 
-    /// Reset the EFI retry counter to the maximum for the a certain `slot`.
+    /// Reset the EFI retry counter to the maximum for the given `slot`.
     pub(crate) fn reset_efi_retry_count_to_max(&self, slot: Slot) -> Result<()> {
-        if self.orb_type != OrbOsPlatform::Pearl {
-            return Err(Error::UnsupportedOrbType(self.orb_type));
-        }
-
         let max_count = self.get_efi_max_retry_count()?;
-        self.set_retry_count(slot, max_count)
+        self.set_efivar_retry_count(slot, max_count)
+    }
+
+    /// Reset the SR_RF retry counter to the maximum for the given `slot`.
+    pub(crate) fn reset_srrf_retry_count_to_max(&self, slot: Slot) -> Result<()> {
+        self.set_srrf_retry_count(slot, ScratchRegRetryCount::COUNT_MAX)
     }
 
     /// Marks the current slot as working correctly so that
@@ -192,56 +187,67 @@ impl OrbSlotCtrl {
         self.mark_slot_ok(self.get_current_slot()?)
     }
 
+    ///  Marking slot as ok:
+    ///  1) resets the retry count on the efivars
+    ///  2) resets the retry count on SR_RF
+    ///  3) marks the rootfs slot status as Normal
+    ///  4) removes BootChainFwStatus if present
     pub fn mark_slot_ok(&self, slot: Slot) -> Result<()> {
+        self.reset_efi_retry_count_to_max(slot)?;
+        self.reset_srrf_retry_count_to_max(slot)?;
         self.set_rootfs_status(RootFsStatus::Normal, slot)?;
-
-        match self.orb_type {
-            OrbOsPlatform::Pearl => {
-                // We never reach this point in the code if the slot is Unbootable
-                // On Pearl we have 2 more states: UpdateDone + UpdateInProgress
-                // TODO: Remove this once these 2 extra states are removed from edk2
-                // We need this because we use an out of band mechanism for slot integrity.
-                // (nvidia does not use EfiVars for the retry count, yet we created our own
-                // to get around this in Pearl)
-                // No one to ask for context about this -- everyone involved has already left :D
-                self.reset_efi_retry_count_to_max(slot)
-            }
-
-            OrbOsPlatform::Diamond => {
-                if let Ok(efivar) = self.bootchain_fw_status.read() {
-                    // We introduced a change on Diamond EDK2 that made it so that we cannot switch slots if this
-                    // variable is present in userspace. It is typically present with 0x7 EfiVar attributes, and the values 0000,
-                    // which signifies a successful BootChainFw update. We don't know why this is the case,
-                    // but deleting it makes slot switching work. If we don't delete it, orb will power cycle
-                    // successfully but will remain in the same slot.
-                    // Ask @alekseifedotov or @vmenge about this for more context.
-                    println!("BootChainFwStatus efi var found, will remove.");
-                    println!(
-                        "EfiVar to be removed: {:?}\n{efivar}",
-                        self.bootchain_fw_status.path()
-                    );
-                    self.bootchain_fw_status.remove()?;
-                }
-
-                // We don't do anything else here because marking slot as ok is handled on Diamond by:
-                // /opt/nvidia/l4t-rootfs-validation-config
-                // /opt/nvidia/l4t-bootloader-config
-                // Once or if we remove acccess to /dev/mem, the nvidia services will break and we will
-                // need to do it ourselves.
-
-                Ok(())
-            }
-        }
+        self.bootchain_fw_status.remove()?;
+        Ok(())
     }
 
-    fn set_retry_count(&self, slot: Slot, val: EfiRetryCount) -> Result<()> {
+    fn set_efivar_retry_count(&self, slot: Slot, val: EfiRetryCount) -> Result<()> {
         let efivar = match slot {
             Slot::A => &self.retry_count_a,
             Slot::B => &self.retry_count_b,
         };
 
+        // on a cold reboot the efivars will be used to initialize the SR_RF.
+        // the RootfsRetryCountX value is bounded by the max value of SR_RF
+        if val.0 > ScratchRegRetryCount::COUNT_MAX {
+            return Err(Error::ExceedingRetryCount {
+                counter: val.0,
+                max: ScratchRegRetryCount::COUNT_MAX,
+            });
+        }
+
         efivar.write(&val.to_efivar_data())?;
 
         Ok(())
+    }
+
+    fn set_srrf_retry_count(&self, slot: Slot, val: u8) -> Result<()> {
+        // SR_RF retry count is stored in a scratch register
+        // `tegra-pmc` driver exposes control over a sysfs device node
+
+        // TODO: Remove the platform segmentation once the pearl driver is patched
+        match self.orb_type {
+            OrbOsPlatform::Pearl => Ok(()),
+            OrbOsPlatform::Diamond => {
+                if val > ScratchRegRetryCount::COUNT_MAX {
+                    return Err(Error::ExceedingRetryCount {
+                        counter: val,
+                        max: ScratchRegRetryCount::COUNT_MAX,
+                    });
+                }
+
+                let retry_count_path = match slot {
+                    Slot::A => ScratchRegRetryCount::COUNT_A_PATH,
+                    Slot::B => ScratchRegRetryCount::COUNT_B_PATH,
+                };
+
+                fs::write(
+                    self.rootfs.join(retry_count_path),
+                    format!("0x{:x}", val).as_bytes(),
+                )
+                .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
+
+                Ok(())
+            }
+        }
     }
 }

--- a/slot-ctrl/src/lib.rs
+++ b/slot-ctrl/src/lib.rs
@@ -20,9 +20,11 @@ pub struct OrbSlotCtrl {
     next_slot: EfiVar,
     status_a: EfiVar,
     status_b: EfiVar,
-    retry_count_a: EfiVar,
-    retry_count_b: EfiVar,
-    retry_count_max: EfiVar,
+    efi_retry_count_a: EfiVar,
+    efi_retry_count_b: EfiVar,
+    efi_retry_count_max: EfiVar,
+    reg_retry_count_a: PathBuf,
+    reg_retry_count_b: PathBuf,
     bootchain_fw_status: EfiVar,
 }
 
@@ -31,16 +33,29 @@ impl OrbSlotCtrl {
         let rootfs = rootfs.as_ref().to_path_buf();
         let db = EfiVarDb::from_rootfs(&rootfs)?;
 
+        let (reg_path_a, reg_path_b) = match orb_type {
+            OrbOsPlatform::Diamond => (
+                ScratchRegRetryCount::DIAMOND_REG_PATH_A,
+                ScratchRegRetryCount::DIAMOND_REG_PATH_B,
+            ),
+            OrbOsPlatform::Pearl => (
+                ScratchRegRetryCount::PEARL_REG_PATH_A,
+                ScratchRegRetryCount::PEARL_REG_PATH_B,
+            ),
+        };
+
         Ok(Self {
             orb_type,
             rootfs,
-            current_slot: db.get_var(Slot::CURRENT_SLOT_PATH)?,
+            reg_retry_count_a: reg_path_a.into(),
+            reg_retry_count_b: reg_path_b.into(),
             next_slot: db.get_var(Slot::NEXT_SLOT_PATH)?,
+            current_slot: db.get_var(Slot::CURRENT_SLOT_PATH)?,
             status_a: db.get_var(RootFsStatus::STATUS_A_PATH)?,
             status_b: db.get_var(RootFsStatus::STATUS_B_PATH)?,
-            retry_count_a: db.get_var(EfiRetryCount::COUNT_A_PATH)?,
-            retry_count_b: db.get_var(EfiRetryCount::COUNT_B_PATH)?,
-            retry_count_max: db.get_var(EfiRetryCount::COUNT_MAX_PATH)?,
+            efi_retry_count_a: db.get_var(EfiRetryCount::COUNT_A_PATH)?,
+            efi_retry_count_b: db.get_var(EfiRetryCount::COUNT_B_PATH)?,
+            efi_retry_count_max: db.get_var(EfiRetryCount::COUNT_MAX_PATH)?,
             bootchain_fw_status: db.get_var(BootChainFwStatus::STATUS_PATH)?,
         })
     }
@@ -120,54 +135,24 @@ impl OrbSlotCtrl {
     }
 
     pub(crate) fn get_retry_counts(&self, slot: Slot) -> Result<RetryCounts> {
-        let (efi_var_path, scratch_reg_path) = match slot {
-            Slot::A => (
-                &self.retry_count_a,
-                self.rootfs.join(ScratchRegRetryCount::COUNT_A_PATH),
-            ),
-            Slot::B => (
-                &self.retry_count_b,
-                self.rootfs.join(ScratchRegRetryCount::COUNT_B_PATH),
-            ),
+        let (efi_var_path, sr_rf_path) = match slot {
+            Slot::A => (&self.efi_retry_count_a, &self.reg_retry_count_a),
+            Slot::B => (&self.efi_retry_count_b, &self.reg_retry_count_b),
         };
 
         let efi_var_data = &efi_var_path.read()?;
         let efi_retry_count = EfiRetryCount::from_efivar_data(efi_var_data)?;
-
-        // TODO: Remove the platform segmentation once the pearl driver is patched
-        let reg_retry_count = match self.orb_type {
-            OrbOsPlatform::Diamond => {
-                let count = fs::read(scratch_reg_path)
-                    .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
-
-                let count = String::from_utf8(count)
-                    .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
-
-                let count = count.strip_prefix("0x").ok_or_else(|| {
-                    Error::CouldNotOpenScratchReg(format!(
-                        "scratch register retry count in unexpected format {count}"
-                    ))
-                })?;
-
-                let count = count.trim().parse::<u8>().map_err(|e| {
-                    Error::CouldNotOpenScratchReg(format!("{e}: '{count}'"))
-                })?;
-
-                let count = ScratchRegRetryCount(count);
-                Some(count)
-            }
-            OrbOsPlatform::Pearl => None,
-        };
+        let reg_retry_count = ScratchRegRetryCount::new(self.rootfs.join(sr_rf_path))?;
 
         Ok(RetryCounts {
             efi_var: efi_retry_count,
-            scratch_reg: reg_retry_count,
+            sr_rf: reg_retry_count,
         })
     }
 
     /// Get the maximum EFI retry count before fallback.
     pub(crate) fn get_efi_max_retry_count(&self) -> Result<EfiRetryCount> {
-        EfiRetryCount::from_efivar_data(&self.retry_count_max.read()?)
+        EfiRetryCount::from_efivar_data(&self.efi_retry_count_max.read()?)
     }
 
     /// Reset the EFI retry counter to the maximum for the given `slot`.
@@ -178,7 +163,7 @@ impl OrbSlotCtrl {
 
     /// Reset the SR_RF retry counter to the maximum for the given `slot`.
     pub(crate) fn reset_srrf_retry_count_to_max(&self, slot: Slot) -> Result<()> {
-        self.set_srrf_retry_count(slot, ScratchRegRetryCount::COUNT_MAX)
+        self.set_srrf_retry_count(slot, ScratchRegRetryCount::SR_RF_COUNT_MAX)
     }
 
     /// Marks the current slot as working correctly so that
@@ -202,16 +187,16 @@ impl OrbSlotCtrl {
 
     fn set_efivar_retry_count(&self, slot: Slot, val: EfiRetryCount) -> Result<()> {
         let efivar = match slot {
-            Slot::A => &self.retry_count_a,
-            Slot::B => &self.retry_count_b,
+            Slot::A => &self.efi_retry_count_a,
+            Slot::B => &self.efi_retry_count_b,
         };
 
         // on a cold reboot the efivars will be used to initialize the SR_RF.
         // the RootfsRetryCountX value is bounded by the max value of SR_RF
-        if val.0 > ScratchRegRetryCount::COUNT_MAX {
+        if val.0 > ScratchRegRetryCount::SR_RF_COUNT_MAX {
             return Err(Error::ExceedingRetryCount {
                 counter: val.0,
-                max: ScratchRegRetryCount::COUNT_MAX,
+                max: ScratchRegRetryCount::SR_RF_COUNT_MAX,
             });
         }
 
@@ -224,30 +209,24 @@ impl OrbSlotCtrl {
         // SR_RF retry count is stored in a scratch register
         // `tegra-pmc` driver exposes control over a sysfs device node
 
-        // TODO: Remove the platform segmentation once the pearl driver is patched
-        match self.orb_type {
-            OrbOsPlatform::Pearl => Ok(()),
-            OrbOsPlatform::Diamond => {
-                if val > ScratchRegRetryCount::COUNT_MAX {
-                    return Err(Error::ExceedingRetryCount {
-                        counter: val,
-                        max: ScratchRegRetryCount::COUNT_MAX,
-                    });
-                }
-
-                let retry_count_path = match slot {
-                    Slot::A => ScratchRegRetryCount::COUNT_A_PATH,
-                    Slot::B => ScratchRegRetryCount::COUNT_B_PATH,
-                };
-
-                fs::write(
-                    self.rootfs.join(retry_count_path),
-                    format!("0x{:x}", val).as_bytes(),
-                )
-                .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
-
-                Ok(())
-            }
+        if val > ScratchRegRetryCount::SR_RF_COUNT_MAX {
+            return Err(Error::ExceedingRetryCount {
+                counter: val,
+                max: ScratchRegRetryCount::SR_RF_COUNT_MAX,
+            });
         }
+
+        let reg_path = match slot {
+            Slot::A => &self.reg_retry_count_a,
+            Slot::B => &self.reg_retry_count_b,
+        };
+
+        fs::write(
+            self.rootfs.join(reg_path),
+            format!("0x{:x}", val).as_bytes(),
+        )
+        .map_err(|e| Error::CouldNotOpenScratchReg(e.to_string()))?;
+
+        Ok(())
     }
 }

--- a/slot-ctrl/src/program.rs
+++ b/slot-ctrl/src/program.rs
@@ -71,15 +71,18 @@ enum StatusCommands {
     /// Set the rootfs status.
     #[command(name = "set", short_flag = 's')]
     SetRootfsStatus { status: String },
-    /// Get the EFI and scratch regsiter retry counters.
+    /// Get the EFI and scratch register retry counters.
     #[command(name = "retries", short_flag = 'c')]
     GetRetryCounters,
-    /// Set the retry counter to maximum.
+    /// Reset retry counters to maximum.
     #[command(name = "reset", short_flag = 'r')]
-    ResetEfiRetryCounter,
+    ResetRetryCounters,
     /// Get the maximum retry counter.
     #[command(name = "max", short_flag = 'm')]
-    GetEfiMaxRetryCounter,
+    GetMaxRetryCounter,
+    /// Mark the current slot as ok
+    #[command(name = "mark-ok")]
+    MarkSlotOk,
     /// Get a full list of rootfs status variants.
     #[command(name = "list", short_flag = 'l')]
     ListStatusVariants,
@@ -160,12 +163,23 @@ pub fn run(slot_ctrl: &OrbSlotCtrl, cli: Cli) -> Result<String> {
                     slot_ctrl.get_retry_counts(slot)?.to_string()
                 }
 
-                StatusCommands::GetEfiMaxRetryCounter => {
+                StatusCommands::GetMaxRetryCounter => {
                     slot_ctrl.get_efi_max_retry_count()?.to_string()
                 }
 
-                StatusCommands::ResetEfiRetryCounter => {
-                    if let Err(e) = slot_ctrl.reset_efi_retry_count_to_max(slot) {
+                StatusCommands::ResetRetryCounters => {
+                    if let Err(e) = slot_ctrl
+                        .reset_efi_retry_count_to_max(slot)
+                        .and_then(|_| slot_ctrl.reset_srrf_retry_count_to_max(slot))
+                    {
+                        check_running_as_root(e)?;
+                    }
+
+                    empty
+                }
+
+                StatusCommands::MarkSlotOk => {
+                    if let Err(e) = slot_ctrl.mark_slot_ok(slot) {
                         check_running_as_root(e)?;
                     }
 

--- a/slot-ctrl/src/test_utils.rs
+++ b/slot-ctrl/src/test_utils.rs
@@ -1,7 +1,6 @@
 use std::fs;
 
 use crate::{
-    domain::ScratchRegRetryCount,
     program::{self, Cli},
     EfiRetryCount, EfiVarDb, OrbSlotCtrl, RootFsStatus, Slot,
 };
@@ -55,16 +54,28 @@ impl Fixture {
             .write(&next_slot.to_efivar_data())
             .unwrap();
 
-        if orb == OrbOsPlatform::Pearl {
-            db.get_var(EfiRetryCount::COUNT_A_PATH)
-                .unwrap()
-                .write(&EfiRetryCount(efi_retry_count_a).to_efivar_data())
-                .unwrap();
+        db.get_var(EfiRetryCount::COUNT_A_PATH)
+            .unwrap()
+            .write(&EfiRetryCount(efi_retry_count_a).to_efivar_data())
+            .unwrap();
 
-            db.get_var(EfiRetryCount::COUNT_B_PATH)
-                .unwrap()
-                .write(&EfiRetryCount(efi_retry_count_b).to_efivar_data())
-                .unwrap();
+        db.get_var(EfiRetryCount::COUNT_B_PATH)
+            .unwrap()
+            .write(&EfiRetryCount(efi_retry_count_b).to_efivar_data())
+            .unwrap();
+
+        // TODO: Remove platform segmentation once the pearl driver is patched
+        if orb == OrbOsPlatform::Diamond {
+            fs::write(
+                scratch_reg_path.join("rootfs_retry_count_a"),
+                format!("0x{:x}", scratch_reg_retry_count_a),
+            )
+            .unwrap();
+            fs::write(
+                scratch_reg_path.join("rootfs_retry_count_b"),
+                format!("0x{:x}", scratch_reg_retry_count_b),
+            )
+            .unwrap();
         }
 
         db.get_var(EfiRetryCount::COUNT_MAX_PATH)
@@ -74,31 +85,13 @@ impl Fixture {
 
         db.get_var(RootFsStatus::STATUS_A_PATH)
             .unwrap()
-            .write(&status_a.to_efivar_data(orb).unwrap())
+            .write(&status_a.to_efivar_data())
             .unwrap();
 
         db.get_var(RootFsStatus::STATUS_B_PATH)
             .unwrap()
-            .write(&status_b.to_efivar_data(orb).unwrap())
+            .write(&status_b.to_efivar_data())
             .unwrap();
-
-        if orb == OrbOsPlatform::Diamond {
-            fs::write(
-                tempdir
-                    .path()
-                    .join(ScratchRegRetryCount::DIAMOND_COUNT_A_PATH),
-                format!("0x{scratch_reg_retry_count_a}\n"),
-            )
-            .unwrap();
-
-            fs::write(
-                tempdir
-                    .path()
-                    .join(ScratchRegRetryCount::DIAMOND_COUNT_B_PATH),
-                format!("0x{scratch_reg_retry_count_b}\n"),
-            )
-            .unwrap();
-        }
 
         Self {
             _tempdir: tempdir,

--- a/slot-ctrl/src/test_utils.rs
+++ b/slot-ctrl/src/test_utils.rs
@@ -29,17 +29,19 @@ impl Fixture {
         #[builder(default = 3)] efi_retry_count_a: u8,
         #[builder(default = 3)] efi_retry_count_b: u8,
         #[builder(default = 3)] efi_retry_count_max: u8,
-        #[builder(default = 3)] scratch_reg_retry_count_a: u8,
-        #[builder(default = 3)] scratch_reg_retry_count_b: u8,
+        #[builder(default = 3)] sr_rf_retry_count_a: u8,
+        #[builder(default = 3)] sr_rf_retry_count_b: u8,
     ) -> Fixture {
         let tempdir = TempDir::new_in("/tmp").unwrap();
         let db_path = tempdir.path().join("sys/firmware/efi/efivars/");
         fs::create_dir_all(&db_path).unwrap();
 
-        let scratch_reg_path = tempdir
-            .path()
-            .join("sys/devices/platform/bus@0/c360000.pmc/");
-        fs::create_dir_all(&scratch_reg_path).unwrap();
+        let sr_rf_dir = match orb {
+            OrbOsPlatform::Diamond => "sys/devices/platform/bus@0/c360000.pmc/",
+            OrbOsPlatform::Pearl => "sys/devices/platform/c360000.pmc/",
+        };
+        let sr_rf_path = tempdir.path().join(sr_rf_dir);
+        fs::create_dir_all(&sr_rf_path).unwrap();
 
         let db = EfiVarDb::from_rootfs(&tempdir).unwrap();
         let slot_ctrl = OrbSlotCtrl::new(&tempdir, orb).unwrap();
@@ -64,19 +66,16 @@ impl Fixture {
             .write(&EfiRetryCount(efi_retry_count_b).to_efivar_data())
             .unwrap();
 
-        // TODO: Remove platform segmentation once the pearl driver is patched
-        if orb == OrbOsPlatform::Diamond {
-            fs::write(
-                scratch_reg_path.join("rootfs_retry_count_a"),
-                format!("0x{:x}", scratch_reg_retry_count_a),
-            )
-            .unwrap();
-            fs::write(
-                scratch_reg_path.join("rootfs_retry_count_b"),
-                format!("0x{:x}", scratch_reg_retry_count_b),
-            )
-            .unwrap();
-        }
+        fs::write(
+            sr_rf_path.join("rootfs_retry_count_a"),
+            format!("0x{:x}", sr_rf_retry_count_a),
+        )
+        .unwrap();
+        fs::write(
+            sr_rf_path.join("rootfs_retry_count_b"),
+            format!("0x{:x}", sr_rf_retry_count_b),
+        )
+        .unwrap();
 
         db.get_var(EfiRetryCount::COUNT_MAX_PATH)
             .unwrap()

--- a/slot-ctrl/tests/slot_ctrl.rs
+++ b/slot-ctrl/tests/slot_ctrl.rs
@@ -86,79 +86,56 @@ fn it_gets_and_sets_rootfs_status() {
 }
 
 #[test]
-fn it_marks_slot_ok_on_pearl() {
+fn it_marks_slot_ok_pearl() {
     let fx = Fixture::builder()
         .current_slot(Slot::A)
         .status_a(RootFsStatus::UpdateInProcess)
         .efi_retry_count_a(1)
-        .efi_retry_count_max(9)
+        .efi_retry_count_max(3)
         .build(OrbOsPlatform::Pearl);
 
-    // on Pearl marking slot as ok resets retry count and marks slot as Normal
-    let status = fx.run("status get").unwrap();
-    assert_eq!(status, "UpdateInProcess");
-    let status = fx.run("status retries").unwrap();
+    // Setup validation
+    fx.run("bootchain-fw set 0").unwrap();
+    assert_eq!(fx.run("status get").unwrap(), "UpdateInProcess");
+    assert_eq!(fx.run("status max").unwrap(), "3");
     assert_eq!(
-        status,
+        fx.run("status retries").unwrap(),
         "efi var: 1\nscratch register: unavailable in this platform"
     );
-    let status = fx.run("status max").unwrap();
-    assert_eq!(status, "9");
+    assert_eq!(fx.run("bootchain-fw get").unwrap(), "Success");
+
+    // Execution
+    fx.slot_ctrl.mark_slot_ok(Slot::A).unwrap();
+
+    // Assertions
+    assert_eq!(fx.run("status get").unwrap(), "Normal");
+    assert_eq!(
+        fx.run("status retries").unwrap(),
+        "efi var: 3\nscratch register: unavailable in this platform"
+    );
+    assert!(fx.run("bootchain-fw get").is_err());
+}
+
+#[test]
+// TODO: once Pearl also supports SR_RF, consolidate tests
+fn it_marks_slot_ok_diamond() {
+    let fx = Fixture::builder()
+        .current_slot(Slot::A)
+        .status_a(RootFsStatus::UpdateInProcess)
+        .efi_retry_count_a(1)
+        .efi_retry_count_max(3)
+        .scratch_reg_retry_count_a(1)
+        .build(OrbOsPlatform::Diamond);
+
+    assert_eq!(
+        fx.run("status retries").unwrap(),
+        "efi var: 1\nscratch register: 1"
+    );
 
     fx.slot_ctrl.mark_slot_ok(Slot::A).unwrap();
-    let status = fx.run("status get").unwrap();
-    assert_eq!(status, "Normal");
-    let status = fx.run("status retries").unwrap();
+
     assert_eq!(
-        status,
-        "efi var: 9\nscratch register: unavailable in this platform"
-    );
-}
-
-#[test]
-fn it_marks_slot_ok_on_diamond_deletes_bootchain_fw_status_if_present() {
-    // on Diamond marking slot as ok deletes BootChainFwStatus if its there, and change
-    // status to Normal
-    let fx = Fixture::builder()
-        .current_slot(Slot::A)
-        .status_a(RootFsStatus::Normal)
-        .status_b(RootFsStatus::Unbootable)
-        .build(OrbOsPlatform::Diamond);
-
-    let status = fx.run("status -i get").unwrap();
-    assert_eq!(status, "Unbootable");
-
-    fx.run("bootchain-fw set 0").unwrap();
-    let status = fx.run("bootchain-fw get").unwrap();
-    assert_eq!(status, "Success");
-
-    fx.slot_ctrl.mark_slot_ok(Slot::B).unwrap();
-    let failed = fx.run("bootchain-fw get");
-    assert!(failed.is_err());
-
-    let status = fx.run("status -i get").unwrap();
-    assert_eq!(status, "Normal");
-}
-
-#[test]
-fn it_reads_scratch_reg_slot_counters_on_diamond() {
-    let fx = Fixture::builder()
-        .current_slot(Slot::A)
-        .status_a(RootFsStatus::Normal)
-        .status_b(RootFsStatus::Unbootable)
-        .scratch_reg_retry_count_a(6)
-        .scratch_reg_retry_count_b(2)
-        .build(OrbOsPlatform::Diamond);
-
-    let status = fx.run("status retries").unwrap();
-    assert_eq!(
-        status,
-        "efi var: unavailable in this platform\nscratch register: 6"
-    );
-
-    let status = fx.run("status -i retries").unwrap();
-    assert_eq!(
-        status,
-        "efi var: unavailable in this platform\nscratch register: 2"
+        fx.run("status retries").unwrap(),
+        "efi var: 3\nscratch register: 3"
     );
 }

--- a/slot-ctrl/tests/slot_ctrl.rs
+++ b/slot-ctrl/tests/slot_ctrl.rs
@@ -86,22 +86,20 @@ fn it_gets_and_sets_rootfs_status() {
 }
 
 #[test]
-fn it_marks_slot_ok_pearl() {
+fn it_marks_slot_ok() {
     let fx = Fixture::builder()
         .current_slot(Slot::A)
         .status_a(RootFsStatus::UpdateInProcess)
         .efi_retry_count_a(1)
         .efi_retry_count_max(3)
+        .sr_rf_retry_count_a(1)
         .build(OrbOsPlatform::Pearl);
 
     // Setup validation
     fx.run("bootchain-fw set 0").unwrap();
     assert_eq!(fx.run("status get").unwrap(), "UpdateInProcess");
     assert_eq!(fx.run("status max").unwrap(), "3");
-    assert_eq!(
-        fx.run("status retries").unwrap(),
-        "efi var: 1\nscratch register: unavailable in this platform"
-    );
+    assert_eq!(fx.run("status retries").unwrap(), "efi var: 1\nSR_RF: 1\n");
     assert_eq!(fx.run("bootchain-fw get").unwrap(), "Success");
 
     // Execution
@@ -109,35 +107,8 @@ fn it_marks_slot_ok_pearl() {
 
     // Assertions
     assert_eq!(fx.run("status get").unwrap(), "Normal");
-    assert_eq!(
-        fx.run("status retries").unwrap(),
-        "efi var: 3\nscratch register: unavailable in this platform"
-    );
+    assert_eq!(fx.run("status retries").unwrap(), "efi var: 3\nSR_RF: 3\n");
     assert!(fx.run("bootchain-fw get").is_err());
-}
-
-#[test]
-// TODO: once Pearl also supports SR_RF, consolidate tests
-fn it_marks_slot_ok_diamond() {
-    let fx = Fixture::builder()
-        .current_slot(Slot::A)
-        .status_a(RootFsStatus::UpdateInProcess)
-        .efi_retry_count_a(1)
-        .efi_retry_count_max(3)
-        .scratch_reg_retry_count_a(1)
-        .build(OrbOsPlatform::Diamond);
-
-    assert_eq!(
-        fx.run("status retries").unwrap(),
-        "efi var: 1\nscratch register: 1"
-    );
-
-    fx.slot_ctrl.mark_slot_ok(Slot::A).unwrap();
-
-    assert_eq!(
-        fx.run("status retries").unwrap(),
-        "efi var: 3\nscratch register: 3"
-    );
 }
 
 #[test]

--- a/slot-ctrl/tests/slot_ctrl.rs
+++ b/slot-ctrl/tests/slot_ctrl.rs
@@ -139,3 +139,28 @@ fn it_marks_slot_ok_diamond() {
         "efi var: 3\nscratch register: 3"
     );
 }
+
+#[test]
+fn it_marks_slot_ok_deletes_bootchain_fw_status_if_present() {
+    // marking slot as ok deletes BootChainFwStatus if its there, and change
+    // status to Normal
+    let fx = Fixture::builder()
+        .current_slot(Slot::A)
+        .status_a(RootFsStatus::Normal)
+        .status_b(RootFsStatus::Unbootable)
+        .build(OrbOsPlatform::Diamond);
+
+    let status = fx.run("status -i get").unwrap();
+    assert_eq!(status, "Unbootable");
+
+    fx.run("bootchain-fw set 0").unwrap();
+    let status = fx.run("bootchain-fw get").unwrap();
+    assert_eq!(status, "Success");
+
+    fx.slot_ctrl.mark_slot_ok(Slot::B).unwrap();
+    let failed = fx.run("bootchain-fw get");
+    assert!(failed.is_err());
+
+    let status = fx.run("status -i get").unwrap();
+    assert_eq!(status, "Normal");
+}


### PR DESCRIPTION
Motivation:
- forwarding the backing of SR_RF from efvars into Orin
- backporting the handling of SR_RF in xavier from the tegra-pmc driver

`slot-ctrl` infrastructure needs to updated to reflect the two above changes.
Additionally a couple of bugs are fixed 