### PR TITLE
chore(ci): ignore RUSTSEC-2026-0098

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,15 +2483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "coreaudio-rs"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2898,7 +2889,7 @@ checksum = "a9711031e209dc1306d66985363b4397d4c7b911597580340b93c9729b55f6eb"
 dependencies = [
  "bitvec",
  "deku_derive",
- "no_std_io2",
+ "no_std_io2 0.8.1",
  "rustversion",
 ]
 
@@ -6300,25 +6291,25 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libflate"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249fa21ba2b59e8cbd69e722f5b31e1b466db96c937ae3de23e8b99ead0d1383"
+checksum = "cd96e993e5f3368b0cb8497dae6c860c22af8ff18388c61c6c0b86c58d86b5df"
 dependencies = [
  "adler32",
- "core2",
  "crc32fast",
  "dary_heap",
  "libflate_lz77",
+ "no_std_io2 0.9.3",
 ]
 
 [[package]]
 name = "libflate_lz77"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+checksum = "ff7a10e427698aef6eef269482776debfef63384d30f13aad39a1a95e0e098fd"
 dependencies = [
- "core2",
  "hashbrown 0.16.0",
+ "no_std_io2 0.9.3",
  "rle-decode-fast",
 ]
 
@@ -7305,6 +7296,15 @@ name = "no_std_io2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
 dependencies = [
  "memchr",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,8 @@ ignore = [
 	{ id = "RUSTSEC-2026-0049", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
 	# rand 0.8.5 is a transitive dep; unsound only under rare conditions (custom logger + thread_rng + trace logging)
 	{ id = "RUSTSEC-2026-0097", reason = "transitive dep, unsound only under rare conditions with custom logger accessing rand::rng(), upgrade blocked by upstream" },
+	{ id = "RUSTSEC-2026-0098", reason = "low impact, only works if the cert was issued invalidly" },
+	{ id = "RUSTSEC-2026-0099", reason = "duplicate of above" },
 ]
 unmaintained = "workspace" # only warn for direct dependencies (not transitive ones)
 version = 2


### PR DESCRIPTION
from @eth44:
> it's fine because it already requires a valid certificate according to the advisory