### PR TITLE
chore(hil): disable vim mode in the shell

### DIFF
--- a/nix/machines/home-hil.nix
+++ b/nix/machines/home-hil.nix
@@ -26,9 +26,6 @@ in
     autosuggestion.enable = true;
     enableCompletion = true;
     oh-my-zsh.enable = true;
-    initContent = lib.mkOrder 1000 ''
-      set -o vi
-    '';
   };
   programs.starship = {
     enable = true;


### PR DESCRIPTION
Disable the vim-mode in the shell by default