### PR TITLE
fix(orb-jobs-agent): flaky test

### DIFF
--- a/orb-jobs-agent/tests/common/fixture.rs
+++ b/orb-jobs-agent/tests/common/fixture.rs
@@ -133,23 +133,26 @@ impl JobAgentFixture {
                                 let jqueue = jqueue.clone();
                                 task::spawn(async move {
                                     println!("[DEBUG] Task spawned, checking status: {}", update.status);
-                                    match JobExecutionStatus::try_from(update.status).unwrap() {
+                                    let status = update.status;
+                                    let job_execution_id = update.job_execution_id.clone();
+
+                                    // Record the update before signaling completion
+                                    execution_updates.lock().await.push(update);
+                                    println!("[DEBUG] Update pushed to execution_updates");
+
+                                    match JobExecutionStatus::try_from(status).unwrap() {
                                         | JobExecutionStatus::Succeeded
                                         | JobExecutionStatus::Failed
                                         | JobExecutionStatus::Cancelled
                                         | JobExecutionStatus::FailedUnsupported => {
                                             println!("[DEBUG] Calling jqueue.handled()");
-                                            jqueue.handled(&update.job_execution_id).await;
+                                            jqueue.handled(&job_execution_id).await;
                                             println!("[DEBUG] jqueue.handled() completed");
                                         }
                                         _ => {
                                             println!("[DEBUG] Status not terminal, skipping handled()");
                                         },
                                     };
-
-                                    let mut updates = execution_updates.lock().await;
-                                    updates.push(update);
-                                    println!("[DEBUG] Update pushed to execution_updates");
                                 }); }
                         }
 


### PR DESCRIPTION
In the fake fleet-cmdr server inside `JobAgentFixture`, terminal `JobExecutionUpdates` were handled in the wrong order: `jqueue.handled()` was called before the update was pushed to execution_updates. Since `handled()` is what unblocks `wait_for_completion()`, tests could wake up and immediately read `execution_updates` before the update had landed, resulting in an empty vec and an index-out-of-bounds panic.


Fixed by recording the update in execution_updates first, then calling `jqueue.handled()`. 