### PR TITLE
fix: replace eclipse url with github releases

### DIFF
--- a/orb-connd/tests/docker/Dockerfile
+++ b/orb-connd/tests/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN ZENOH_VERSION="1.7.2" && \
     else \
         ARCH="x86_64"; \
     fi && \
-    wget -O /tmp/zenoh.zip "https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip&r=1" && \
+    wget -O /tmp/zenoh.zip "https://github.com/eclipse-zenoh/zenoh/releases/download/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip" && \
     unzip /tmp/zenoh.zip -d /tmp/zenoh && \
     apt-get update && \
     printf '%s\n' '#!/bin/sh' 'exit 0' > /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl && \

--- a/zenorb/tests/Dockerfile
+++ b/zenorb/tests/Dockerfile
@@ -14,7 +14,7 @@ RUN ZENOH_VERSION="1.7.2" && \
     else \
         ARCH="x86_64"; \
     fi && \
-    wget -O /tmp/zenoh.zip "https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip&r=1" && \
+    wget -O /tmp/zenoh.zip "https://github.com/eclipse-zenoh/zenoh/releases/download/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip" && \
     unzip /tmp/zenoh.zip -d /tmp/zenoh && \
     apt-get update && \
     dpkg -i /tmp/zenoh/zenohd_${ZENOH_VERSION}_${DEB_ARCH}.deb /tmp/zenoh/zenoh-plugin-storage-manager_${ZENOH_VERSION}_${DEB_ARCH}.deb || \


### PR DESCRIPTION
Eclipse URL was rate-limiting the download request!

```[debian.zip&r=1](https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/1.7.2/zenoh-1.7.2-x86_64-unknown-linux-gnu-debian.zip&r=1)
    #7 0.143 Resolving www.eclipse.org (www.eclipse.org)... 198.41.30.198
    #7 0.261 Connecting to www.eclipse.org (www.eclipse.org)|198.41.30.198|:443... connected.
    #7 0.353 HTTP request sent, awaiting response... 429 Too Many Requests
    #7 0.383 2026-04-20 11:04:41 ERROR 429: Too Many Requests.
    #7 0.383 
    #7 0.392 Reading package lists...
    #7 0.398 Building dependency tree...
    #7 0.399 Reading state information...
    #7 0.405 0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
    #7 0.407 /bin/sh: 1: zenohd: not found
    #7 ERROR: process "/bin/sh -c ZENOH_VERSION=\"1.7.2\" &&     DEB_ARCH=$(dpkg --print-architecture) &&     if [ \"$DEB_ARCH\" = \"arm64\" ]; then         ARCH=\"aarch64\";     else         ARCH=\"x86_64\";     fi &&     wget -O /tmp/zenoh.zip \"https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip&r=1\" &&     unzip /tmp/zenoh.zip -d /tmp/zenoh &&     apt-get update &&     printf '%s\\n' '#!/bin/sh' 'exit 0' > /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl &&     dpkg -i /tmp/zenoh/zenohd_${ZENOH_VERSION}_${DEB_ARCH}.deb /tmp/zenoh/zenoh-plugin-storage-manager_${ZENOH_VERSION}_${DEB_ARCH}.deb ||     apt-get install -f -y --no-install-recommends &&     rm -f /usr/local/bin/systemctl &&     rm -rf /var/lib/apt/lists/* /tmp/zenoh.zip /tmp/zenoh &&     zenohd --version" did not complete successfully: exit code: 127
    ------
     > [3/9] RUN ZENOH_VERSION="1.7.2" &&     DEB_ARCH=$(dpkg --print-architecture) &&     if [ "$DEB_ARCH" = "arm64" ]; then         ARCH="aarch64";     else         ARCH="x86_64";     fi &&     wget -O /tmp/zenoh.zip "https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip&r=1" &&     unzip /tmp/zenoh.zip -d /tmp/zenoh &&     apt-get update &&     printf '%s\n' '#!/bin/sh' 'exit 0' > /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl &&     dpkg -i /tmp/zenoh/zenohd_${ZENOH_VERSION}_${DEB_ARCH}.deb /tmp/zenoh/zenoh-plugin-storage-manager_${ZENOH_VERSION}_${DEB_ARCH}.deb ||     apt-get install -f -y --no-install-recommends &&     rm -f /usr/local/bin/systemctl &&     rm -rf /var/lib/apt/lists/* /tmp/zenoh.zip /tmp/zenoh &&     zenohd --version:
    0.134 --2026-04-20 11:04:41--  https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/1.7.2/zenoh-1.7.2-x86_64-unknown-linux-gnu-debian.zip&r=1
    connected.
    0.353 HTTP request sent, awaiting response... 429 Too Many Requests
    0.383 2026-04-20 11:04:41 ERROR 429: Too Many Requests.
    0.383 
    0.392 Reading package lists...
    0.398 Building dependency tree...
    0.399 Reading state information...
    0.405 0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
    0.407 /bin/sh: 1: zenohd: not found
    ------
    Dockerfile:13
    --------------------
      12 |     
      13 | >>> RUN ZENOH_VERSION="1.7.2" && \
      14 | >>>     DEB_ARCH=$(dpkg --print-architecture) && \
      15 | >>>     if [ "$DEB_ARCH" = "arm64" ]; then \
      16 | >>>         ARCH="aarch64"; \
      17 | >>>     else \
      18 | >>>         ARCH="x86_64"; \
      19 | >>>     fi && \
      20 | >>>     wget -O /tmp/zenoh.zip "https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip&r=1" && \
      21 | >>>     unzip /tmp/zenoh.zip -d /tmp/zenoh && \
      22 | >>>     apt-get update && \
      23 | >>>     printf '%s\n' '#!/bin/sh' 'exit 0' > /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl && \
      24 | >>>     dpkg -i /tmp/zenoh/zenohd_${ZENOH_VERSION}_${DEB_ARCH}.deb /tmp/zenoh/zenoh-plugin-storage-manager_${ZENOH_VERSION}_${DEB_ARCH}.deb || \
      25 | >>>     apt-get install -f -y --no-install-recommends && \
      26 | >>>     rm -f /usr/local/bin/systemctl && \
      27 | >>>     rm -rf /var/lib/apt/lists/* /tmp/zenoh.zip /tmp/zenoh && \
      28 | >>>     zenohd --version
      29 |     
    --------------------
    ERROR: failed to build: failed to solve: process "/bin/sh -c ZENOH_VERSION=\"1.7.2\" &&     DEB_ARCH=$(dpkg --print-architecture) &&     if [ \"$DEB_ARCH\" = \"arm64\" ]; then         ARCH=\"aarch64\";     else         ARCH=\"x86_64\";     fi &&     wget -O /tmp/zenoh.zip \"https://www.eclipse.org/downloads/download.php?file=/zenoh/zenoh/${ZENOH_VERSION}/zenoh-${ZENOH_VERSION}-${ARCH}-unknown-linux-gnu-debian.zip&r=1\" &&     unzip /tmp/zenoh.zip -d /tmp/zenoh &&     apt-get update &&     printf '%s\\n' '#!/bin/sh' 'exit 0' > /usr/local/bin/systemctl && chmod +x /usr/local/bin/systemctl &&     dpkg -i /tmp/zenoh/zenohd_${ZENOH_VERSION}_${DEB_ARCH}.deb /tmp/zenoh/zenoh-plugin-storage-manager_${ZENOH_VERSION}_${DEB_ARCH}.deb ||     apt-get install -f -y --no-install-recommends &&     rm -f /usr/local/bin/systemctl &&     rm -rf /var/lib/apt/lists/* /tmp/zenoh.zip /tmp/zenoh &&     zenohd --version" did not complete successfully: exit code: 127

    Location: /home/runner/work/orb-software/orb-software/test-utils/src/docker.rs:25

    Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
    Run with RUST_BACKTRACE=full to include source snippets.```