### PR TITLE
chore: move dogstatsd as a workspace depedency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "0.11.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cb25c17d5e77ecf625128ddbdad4bec9972d4d82e222218b38da375f5d0cf7"
+checksum = "0b3be8a0f8e1659c64dc0edac3216d9e07459967d0331bd3c906640f5a605da4"
 dependencies = [
  "chrono",
  "retry",
@@ -10158,7 +10158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -10178,7 +10178,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -12104,7 +12104,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ console-subscriber = "0.4"
 dashmap = "5.5.3"
 data-encoding = "2.3"
 dbus-launch = "0.2.0"
+dogstatsd = "0.12.3"
 ed25519-dalek = { version = "2.1.1", default-features = false, features = ["std"] }
 escargot = "0.5.15"
 eyre = "0.6.12"

--- a/orb-connd/Cargo.toml
+++ b/orb-connd/Cargo.toml
@@ -22,7 +22,7 @@ clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
 dashmap.workspace = true
 derive_more = { workspace = true, default-features = false, features = ["display"] }
-dogstatsd = "0.11"
+dogstatsd.workspace = true
 flume.workspace = true
 futures.workspace = true
 hex.workspace = true

--- a/update-agent/core/Cargo.toml
+++ b/update-agent/core/Cargo.toml
@@ -16,7 +16,7 @@ skip-manifest-signature-verification = []
 
 [dependencies]
 base64.workspace = true
-dogstatsd = "0.11.1"
+dogstatsd.workspace = true
 ed25519-dalek.workspace = true
 gpt.workspace = true
 hex-literal.workspace = true


### PR DESCRIPTION
moved `dogstatsd` into workspace since more crates are expected to start using it