### PR TITLE
feat: allow brightness control for Booster LEDs in mcu-util

### DIFF
--- a/mcu-util/src/main.rs
+++ b/mcu-util/src/main.rs
@@ -284,8 +284,11 @@ enum Leds {
     Blue,
     #[clap(action)]
     White,
-    #[clap(action)]
-    Booster,
+    Booster {
+        /// White booster LED brightness in thousandths.
+        #[clap(default_value_t = 50, value_parser = clap::value_parser!(u32).range(0..=1000))]
+        brightness: u32,
+    },
 }
 
 /// Optics position

--- a/mcu-util/src/orb/main_board.rs
+++ b/mcu-util/src/orb/main_board.rs
@@ -599,19 +599,17 @@ impl MainBoard {
     }
 
     pub async fn front_leds(&mut self, leds: Leds) -> Result<()> {
-        if let Leds::Booster = leds {
+        if let Leds::Booster { brightness } = leds {
             match self
                 .send(McuPayload::ToMain(
                     main_messaging::jetson_to_mcu::Payload::WhiteLedsBrightness(
-                        main_messaging::WhiteLeDsBrightness {
-                            brightness: 50, /* thousandth, so 0.5% */
-                        },
+                        main_messaging::WhiteLeDsBrightness { brightness },
                     ),
                 ))
                 .await
             {
                 Ok(CommonAckError::Success) => {
-                    info!("🚀 Booster LEDs enabled");
+                    info!("🚀 Booster LEDs enabled at {} / 1000", brightness);
                 }
                 Ok(e) => {
                     return Err(eyre!("Error enabling booster LEDs: ack {:?}", e));
@@ -670,7 +668,7 @@ impl MainBoard {
         // turn off all LEDs after 3 seconds
         tokio::time::sleep(Duration::from_millis(3000)).await;
 
-        if let Leds::Booster = leds {
+        if let Leds::Booster { .. } = leds {
             match self
                 .send(McuPayload::ToMain(
                     main_messaging::jetson_to_mcu::Payload::WhiteLedsBrightness(


### PR DESCRIPTION
## Summary
- add booster LED brightness as a positional `mcu-util` argument with a default value of `50`
- pass the selected brightness through to the dedicated `WhiteLedsBrightness` MCU payload
- keep the existing 3-second auto-off behavior after the test command completes

## Test plan
- [x] Run `nix shell nixpkgs#protobuf -c cargo check -p orb-mcu-util`
- [x] Build `orb-mcu-util` for `aarch64-unknown-linux-gnu`
- [x] Verify the uploaded Orb binary reports `orb-mcu-util 0.7.3 65318071-modified`