### PR TITLE
feat(update-agent)!: mark the target slot status UIP

### DIFF
--- a/slot-ctrl/src/lib.rs
+++ b/slot-ctrl/src/lib.rs
@@ -99,9 +99,16 @@ impl OrbSlotCtrl {
             .or_else(|_| self.get_current_slot())
     }
 
-    /// Set the slot for the next boot.
+    /// Sets the slot for the next boot:
+    /// 1) Marks the target slot as `NORMAL` if it was `UNBOOTABLE`
+    /// 2) Resets the retry counts for the target slot to the max value
+    /// 3) Sets the target slot in the `next_slot` EFI variable
     pub fn set_next_boot_slot(&self, slot: Slot) -> Result<()> {
-        self.mark_slot_ok(slot)?;
+        let rootfs_status = self.get_rootfs_status(slot)?;
+        if rootfs_status == RootFsStatus::Unbootable {
+            self.set_rootfs_status(RootFsStatus::Normal, slot)?
+        }
+        self.reset_retry_counts_to_max(slot)?;
         self.next_slot.write(&slot.to_efivar_data())?;
 
         Ok(())
@@ -155,15 +162,13 @@ impl OrbSlotCtrl {
         EfiRetryCount::from_efivar_data(&self.efi_retry_count_max.read()?)
     }
 
-    /// Reset the EFI retry counter to the maximum for the given `slot`.
-    pub(crate) fn reset_efi_retry_count_to_max(&self, slot: Slot) -> Result<()> {
+    /// For a given slot, reset both the EFI and SR_RF retry counters
+    /// to the maximum value (0x3).
+    pub fn reset_retry_counts_to_max(&self, slot: Slot) -> Result<()> {
         let max_count = self.get_efi_max_retry_count()?;
-        self.set_efivar_retry_count(slot, max_count)
-    }
-
-    /// Reset the SR_RF retry counter to the maximum for the given `slot`.
-    pub(crate) fn reset_srrf_retry_count_to_max(&self, slot: Slot) -> Result<()> {
-        self.set_srrf_retry_count(slot, ScratchRegRetryCount::SR_RF_COUNT_MAX)
+        self.set_efivar_retry_count(slot, max_count)?;
+        self.set_srrf_retry_count(slot, ScratchRegRetryCount::SR_RF_COUNT_MAX)?;
+        Ok(())
     }
 
     /// Marks the current slot as working correctly so that
@@ -178,8 +183,7 @@ impl OrbSlotCtrl {
     ///  3) marks the rootfs slot status as Normal
     ///  4) removes BootChainFwStatus if present
     pub fn mark_slot_ok(&self, slot: Slot) -> Result<()> {
-        self.reset_efi_retry_count_to_max(slot)?;
-        self.reset_srrf_retry_count_to_max(slot)?;
+        self.reset_retry_counts_to_max(slot)?;
         self.set_rootfs_status(RootFsStatus::Normal, slot)?;
         self.bootchain_fw_status.remove()?;
         Ok(())

--- a/slot-ctrl/src/program.rs
+++ b/slot-ctrl/src/program.rs
@@ -168,10 +168,7 @@ pub fn run(slot_ctrl: &OrbSlotCtrl, cli: Cli) -> Result<String> {
                 }
 
                 StatusCommands::ResetRetryCounters => {
-                    if let Err(e) = slot_ctrl
-                        .reset_efi_retry_count_to_max(slot)
-                        .and_then(|_| slot_ctrl.reset_srrf_retry_count_to_max(slot))
-                    {
+                    if let Err(e) = slot_ctrl.reset_retry_counts_to_max(slot) {
                         check_running_as_root(e)?;
                     }
 

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -331,6 +331,16 @@ fn run(args: &Args) -> eyre::Result<()> {
         bail!("no connection to dbus supervisor, bailing");
     }
 
+    // before starting to update components, set the rootfs status for the target slot
+    slot_ctrl
+        .set_rootfs_status(
+            orb_slot_ctrl::RootFsStatus::UpdateInProcess,
+            target_slot.into(),
+        )
+        .wrap_err_with(|| {
+            format!("failed to set the rootfs status for the target slot {target_slot}")
+        })?;
+
     // Set overall status to Installing before starting component installations
     if let Some(iface) = &update_iface
         && let Err(e) = interfaces::update_dbus_progress(
@@ -811,8 +821,10 @@ fn finalize_normal_update(
         if data.value() == &EFI_OS_REQUEST_CAPSULE_UPDATE[4..] {
             debug!("Capsule update detected");
             slot_ctrl
-                .mark_slot_ok(target_slot.into())
-                .unwrap_or_else(|e| warn!("{e:#}"));
+                .reset_retry_counts_to_max(target_slot.into())
+                .wrap_err_with(|| {
+                    format!("failed to reset retry counter for the target slot {target_slot}")
+                })?;
             return Ok(());
         }
     } else {


### PR DESCRIPTION
Bringing back some of the logic removed in https://github.com/worldcoin/orb-software/pull/529 :) 
Breaking changes:
- Setting the next boot slot, only changes the rootfs status, if that is  `unbootable`. The change is done in order to enable utilizing the other statuses in EDK & initramfs
- Marking the slot as ok is the only function which sets the status as `normal` no matter the current status, and it is meant to be used with `worldcoin-update-verifier`
- Encapsulated the logic of resetting `SR_RF` & the efivars which back it up in one function.  I do not see why it would be seperate

`update-agent` is setting the `rootfs` status in `update-in-progress`. This will get changed to `update_done` by EDK.
In the next boot, in the happy path, verifier sets everything back to `normal`