### PR TITLE
chore(se050-reprovision): update CA binary name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8687,6 +8687,7 @@ dependencies = [
  "orb-const-concat",
  "orb-endpoints",
  "orb-info",
+ "orb-se050",
  "orb-security-utils",
  "orb-telemetry",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ members = [
 	"qr-link",
 	"s3-helpers",
 	"se050",
-	"security-utils",
 	"se050-reprovision",
+	"security-utils",
 	"seek-camera/sys",
 	"seek-camera/wrapper",
 	"slot-ctrl",
@@ -209,6 +209,8 @@ orb-info = { path = "orb-info", default-features = false }
 orb-io-utils.path = "io-utils"
 orb-mcu-interface.path = "mcu-interface"
 orb-s3-helpers.path = "s3-helpers"
+orb-se050.path = "se050"
+orb-se050-reprovision.path = "orb-se050-reprovision"
 orb-secure-storage-ca = { path = "optee/secure-storage/ca", default-features = false }
 orb-security-utils.path = "security-utils"
 orb-slot-ctrl.path = "slot-ctrl"

--- a/se050-reprovision/Cargo.toml
+++ b/se050-reprovision/Cargo.toml
@@ -23,6 +23,7 @@ orb-build-info.workspace = true
 orb-const-concat.workspace = true
 orb-endpoints.workspace = true
 orb-info = { workspace = true, features = ["serde"] }
+orb-se050.workspace = true
 orb-security-utils = { workspace = true, features = ["reqwest"] }
 orb-telemetry.workspace = true
 rand.workspace = true

--- a/se050-reprovision/src/cli.rs
+++ b/se050-reprovision/src/cli.rs
@@ -12,6 +12,7 @@ use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio_util::io::{CopyToBytes, SinkWriter, StreamReader};
+use tracing::debug;
 
 const CLI_TIMEOUT: Duration = Duration::from_millis(10_000);
 
@@ -23,6 +24,7 @@ pub struct CliOutput {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct KeyInfo {
     /// PEM format
     pub key: String,
@@ -90,6 +92,7 @@ pub async fn call(cfg: CliStrategy, nonce: Nonce) -> Result<CliOutput> {
         .await
         .wrap_err("timed out while calling cli")?
         .wrap_err("error while calling cli")?;
+    debug!("cli output: {output}");
 
     serde_json::from_str(&output).wrap_err("failed to deserialize CLI output")
 }

--- a/se050-reprovision/src/lib.rs
+++ b/se050-reprovision/src/lib.rs
@@ -30,8 +30,7 @@ pub async fn run(mut cfg: Config) -> Result<()> {
     cfg.rng.fill(&mut nonce);
     let output = crate::cli::call(cfg.cli_strat, nonce)
         .await
-        .wrap_err("failed to call cli");
-    let output = output?;
+        .wrap_err("failed to call cli")?;
     info!("cli output: {output:?}");
 
     Ok(())

--- a/se050-reprovision/src/main.rs
+++ b/se050-reprovision/src/main.rs
@@ -6,6 +6,8 @@ use orb_endpoints::Backend;
 use orb_se050_reprovision::{cli::CliStrategy, Config, BUILD_INFO};
 use rand::{rngs::StdRng, SeedableRng};
 
+const CA_BINARY: &str = "/usr/bin/read-keys-with-attest";
+
 #[derive(Debug, Parser)]
 #[clap(version = BUILD_INFO.version, about)]
 pub struct Args {}
@@ -17,9 +19,7 @@ impl Args {
                 .default_reqwest_client()?
                 .from_backend(backend)
                 .build(),
-            cli_strat: CliStrategy::Process(PathBuf::from(
-                "/usr/local/bin/orb-se050-reprovision-ca",
-            )),
+            cli_strat: CliStrategy::Process(PathBuf::from(CA_BINARY)),
             rng: StdRng::from_entropy(),
         })
     }


### PR DESCRIPTION
small tweak to adjust the CA's name, and to log the CA output *before* it gets deserialized.