### PR TITLE
feat(zorb): query

### DIFF
--- a/zenorb/src/zoci.rs
+++ b/zenorb/src/zoci.rs
@@ -5,6 +5,7 @@ use color_eyre::{
 use serde::{de::DeserializeOwned, Serialize};
 use std::{any::type_name, borrow::Cow, str::Split};
 use zenoh::{
+    bytes::Encoding,
     query::{Query, ReplyError},
     sample::Sample,
 };
@@ -65,7 +66,7 @@ pub trait ZociQueryExt {
 
     fn payload_str<'de>(&'de self) -> Result<Cow<'de, str>>;
 
-    /// Replies with a JSON-serialized success payload on the query's key expression.
+    /// Replies with a JSON-serialized success or error payload on the query's key expression.
     ///
     /// This avoids repeating `query.key_expr().clone()` at call sites.
     async fn res<A, E>(&self, value: Result<A, E>) -> Result<()>
@@ -151,13 +152,17 @@ impl ZociQueryExt for Query {
                 let payload = serde_json::to_vec(&value)?;
 
                 self.reply(self.key_expr().clone(), payload)
+                    .encoding(Encoding::APPLICATION_JSON)
                     .await
                     .map_err(|e| eyre!("{e}"))?;
             }
 
             Err(value) => {
                 let payload = serde_json::to_vec(&value)?;
-                self.reply_err(payload).await.map_err(|e| eyre!("{e}"))?;
+                self.reply_err(payload)
+                    .encoding(Encoding::APPLICATION_JSON)
+                    .await
+                    .map_err(|e| eyre!("{e}"))?;
             }
         }
 
@@ -171,6 +176,7 @@ impl ZociQueryExt for Query {
         let payload = serde_json::to_vec(&value)?;
 
         self.reply(self.key_expr().clone(), payload)
+            .encoding(Encoding::APPLICATION_JSON)
             .await
             .map_err(|e| eyre!("{e}"))?;
 
@@ -183,7 +189,10 @@ impl ZociQueryExt for Query {
     {
         let payload = serde_json::to_vec(&value)?;
 
-        self.reply_err(payload).await.map_err(|e| eyre!("{e}"))?;
+        self.reply_err(payload)
+            .encoding(Encoding::APPLICATION_JSON)
+            .await
+            .map_err(|e| eyre!("{e}"))?;
 
         Ok(())
     }

--- a/zorb/src/main.rs
+++ b/zorb/src/main.rs
@@ -34,6 +34,7 @@ struct Cli {
 #[derive(Subcommand)]
 enum Cmd {
     /// Publish a message to a key expression
+    #[command(visible_alias = "p")]
     Pub {
         /// The key expression to publish to
         keyexpr: String,
@@ -42,9 +43,19 @@ enum Cmd {
     },
 
     /// Subscribe to a key expression
+    #[command(visible_alias = "s")]
     Sub {
         /// The key expression to subscribe to
         keyexpr: String,
+    },
+
+    /// Query a key expression
+    #[command(visible_alias = "q")]
+    Query {
+        /// The key expression to query
+        keyexpr: String,
+        /// Optional payload
+        payload: Option<String>,
     },
 
     /// Execute a command when a message is received
@@ -120,7 +131,7 @@ async fn main() -> Result<()> {
         }
 
         Cmd::Sub { keyexpr } => {
-            println!("Subscribing to {keyexpr}");
+            println!("{} :: subscribing to {keyexpr}", color::timestamp());
 
             let rx = zenorb
                 .declare_subscriber(&keyexpr)
@@ -157,7 +168,74 @@ async fn main() -> Result<()> {
                     }
 
                     other => {
-                        println!("received message with unsupported encoding {other}")
+                        println!(
+                            "{} :: received message with unsupported encoding {other}",
+                            color::timestamp()
+                        )
+                    }
+                }
+            }
+        }
+
+        Cmd::Query { keyexpr, payload } => {
+            println!("{} :: querying {keyexpr}", color::timestamp());
+
+            let rx = zenorb
+                .get(&keyexpr)
+                .payload(payload.unwrap_or_default())
+                .await
+                .map_err(|e| eyre!("{e}"))?;
+
+            loop {
+                let reply = match rx.recv_async().await {
+                    Err(e) => {
+                        println!("{} :: query ended with: \"{e}\"", color::timestamp());
+                        break;
+                    }
+
+                    Ok(reply) => reply,
+                };
+
+                let result = reply.into_result();
+
+                let (encoding, payload) = match &result {
+                    Ok(v) => (v.encoding(), v.payload()),
+                    Err(e) => (e.encoding(), e.payload()),
+                };
+
+                match encoding {
+                    &Encoding::TEXT_PLAIN => {
+                        let txt = payload.try_to_string()?;
+                        println!(
+                            "{} {} :: {txt}",
+                            color::timestamp(),
+                            color::key_expr(&keyexpr)
+                        );
+                    }
+
+                    &Encoding::TEXT_JSON | &Encoding::APPLICATION_JSON => {
+                        let txt = payload.try_to_string()?;
+                        println!(
+                            "{} {} :: {}",
+                            color::timestamp(),
+                            color::key_expr(&keyexpr),
+                            color::json(&txt)
+                        );
+                    }
+
+                    &Encoding::ZENOH_BYTES => {
+                        println!(
+                            "{} {} :: could not deserialize",
+                            color::timestamp(),
+                            color::key_expr(&keyexpr)
+                        );
+                    }
+
+                    other => {
+                        println!(
+                            "{} :: received message with unsupported encoding {other}",
+                            color::timestamp()
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## changes
- zoci extension response methods will now apply `APPLICATION_JSON` encoding by default

## new
- ability to send queries with `zorb`

example
```bash
zorb query mytopic optionalpayload
zorb q **/job/wifi_list
zorb q **/job/wifi_remove mywifiprofile
```

<img width="2858" height="572" alt="image" src="https://github.com/user-attachments/assets/baa80ccf-3b5c-47c6-961c-0c0ad5338e2b" />
