### PR TITLE
chore(connd): tiny log for sanity check when scanning wifi

### DIFF
--- a/orb-connd/src/service/zoci.rs
+++ b/orb-connd/src/service/zoci.rs
@@ -137,6 +137,7 @@ pub async fn wifi_list(connd: ConndService, query: Query) -> Result<()> {
 }
 
 pub async fn wifi_scan(connd: ConndService, query: Query) -> Result<()> {
+    info!("scanning for wifi access points");
     let response = connd
         .wifi_scan()
         .await


### PR DESCRIPTION
should help as a sanity check to make sure zoci queries are actually hitting `orb-connd`