### PR TITLE
fix(devcontainer): properly mount nix.conf in the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		// Keep the rust target directory in a persistent docker volume instead of bind mount
 		"source=${localWorkspaceFolderBasename}-rust-target-vol,target=${containerWorkspaceFolder}/target,type=volume",
 		"source=${localEnv:HOME}/.aws,target=/home/ubuntu/.aws,type=bind",
-		"source=${localEnv:HOME}/.config/nix,target=${localEnv:HOME}/.config/nix,type=bind"
+		"source=${localEnv:HOME}/.config/nix,target=/home/ubuntu/.config/nix,type=bind"
 	],
 	// "overrideCommand": false, // Broken in devcontainer cli qwq https://github.com/devcontainers/cli/issues/816
 	"postCreateCommand": ".devcontainer/postCreateCommand.sh"


### PR DESCRIPTION
The container user is ubuntu. `nix.conf` was not properly getting mounted -> `nix develop` was failing