### PR TITLE
chore(update-agent): remove the no-sig build flavor

### DIFF
--- a/update-agent/Cargo.toml
+++ b/update-agent/Cargo.toml
@@ -12,7 +12,8 @@ rust-version.workspace = true
 
 [features]
 can-update-test = []
-# If provided, we skip manifest signature verification
+# If provided, we skip manifest signature verification. This is intended for
+# functional tests only; it is not exposed as an Orb build flavor.
 skip-manifest-signature-verification = [
 	"orb-update-agent-core/skip-manifest-signature-verification",
 ]
@@ -81,7 +82,6 @@ orb-build-info = { workspace = true, features = ["build-script"] }
 
 [package.metadata.orb]
 unsupported_targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
-flavors = [{ name = "no-sig", features = ["skip-manifest-signature-verification"] }]
 
 [package.metadata.deb]
 maintainer-scripts = "debian/"

--- a/update-agent/core/Cargo.toml
+++ b/update-agent/core/Cargo.toml
@@ -11,7 +11,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-# If provided, we skip manifest signature verification
+# If provided, we skip manifest signature verification. This is intended for
+# functional tests only.
 skip-manifest-signature-verification = []
 
 [dependencies]


### PR DESCRIPTION
removing the "no-sig" build flavor to make it clearer that the feature is only used inside functional testing. Currently there are false reports happening that this is a vulnerability.
Leaving the relevant code in update-agent for the time being to enable the e2e testing feature. 
- future plan may be to give access to only the stage manifest signing KMS key from the CI so we sign the manifest during the test. Additional item as moving the test to kata-containers
