### PR TITLE
feat: loosen hil rts dir permissions

### DIFF
--- a/nix/machines/hil-common.nix
+++ b/nix/machines/hil-common.nix
@@ -211,6 +211,7 @@ in
     users.users.${ghRunnerUser} = {
       isNormalUser = true;
       description = "User for github actions runner";
+      homeMode = "0711";
       extraGroups = [
         "wheel"
         "plugdev"
@@ -343,6 +344,9 @@ in
 
         serviceOverrides = {
           Environment = ''"PATH=/run/wrappers/bin:/run/current-system/sw/bin"''; # fixes missing sudo
+          # Override the NixOS github-runner module's UMask=0066 so artifacts
+          # downloaded into ~/rts are readable by the worldcoin user.
+          UMask = lib.mkForce "0022";
 
           # Undo NixOS sandboxing
           CapabilityBoundingSet = [


### PR DESCRIPTION
We need it to access RTSs as the worldcoin user.

homeMode makes the homedir drwx--x--x to allow ls
umask makes all files created by the gh-runner readable by user users

```
ls -lah ~/rts/
total 11G
drwx--x--x 6 gh-runner-user users 4.0K May 15 11:29 .
drwx--x--x 5 gh-runner-user users 4.0K May  4 11:11 ..
-rw-r--r-- 1 gh-runner-user users 5.1G May 15 11:28 2026-05-12-main-0-g3990400-diamond-25750643265-rts-diamond-dev.tar.zstd
-rw-r--r-- 1 gh-runner-user users 5.1G May 15 11:29 2026-05-14-main-0-gd1a4c38-diamond-25868449999-rts-diamond-dev.tar.zstd
```