### PR TITLE
chore: use unix socket for zenoh transport

### DIFF
--- a/orb-backend-status/debian/worldcoin-backend-status.service
+++ b/orb-backend-status/debian/worldcoin-backend-status.service
@@ -14,6 +14,7 @@ SyslogIdentifier=worldcoin-backend-status
 ExecStart=/usr/local/bin/orb-backend-status
 Restart=always
 RestartSec=10s
+SupplementaryGroups=zenohd
 
 [Install]
 WantedBy=multi-user.target

--- a/orb-backend-status/src/main.rs
+++ b/orb-backend-status/src/main.rs
@@ -46,9 +46,7 @@ async fn main() -> Result<()> {
         OrbJabilId("unknown".to_string())
     });
 
-    // Zenoh
-    let cfg = zenorb::client_cfg(7447);
-    let zsession = zenorb::Zenorb::from_cfg(cfg)
+    let zsession = zenorb::Zenorb::from_cfg(zenorb::default_cfg())
         .orb_id(orb_id.clone())
         .with_name("orb-backend-status")
         .await?;

--- a/orb-connd/debian/worldcoin-connd.service
+++ b/orb-connd/debian/worldcoin-connd.service
@@ -18,6 +18,7 @@ ExecStart=/usr/local/bin/orb-connd
 SyslogIdentifier=worldcoin-connd
 Restart=always
 RestartSec=3
+SupplementaryGroups=zenohd
 
 [Install]
 WantedBy=multi-user.target

--- a/orb-connd/src/main.rs
+++ b/orb-connd/src/main.rs
@@ -100,7 +100,7 @@ fn connectivity_daemon() -> Result<()> {
             }
         };
 
-        let zenoh = Zenorb::from_cfg(zenorb::client_cfg(7447))
+        let zenoh = Zenorb::from_cfg(zenorb::default_cfg())
             .orb_id(OrbId::read().await?)
             .with_name("connd")
             .await?;

--- a/orb-connd/tests/docker/Dockerfile
+++ b/orb-connd/tests/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN ZENOH_VERSION="1.7.2" && \
     rm -rf /var/lib/apt/lists/* /tmp/zenoh.zip /tmp/zenoh && \
     zenohd --version
 
-RUN mkdir -p /run/integration-tests
+RUN mkdir -p /run/integration-tests /run/zenohd
 
 COPY zenohd.json5 /etc/zenohd.json5
 

--- a/orb-connd/tests/docker/docker-entry.sh
+++ b/orb-connd/tests/docker/docker-entry.sh
@@ -21,7 +21,9 @@ chown "$TARGET_UID:$TARGET_GID" /run/integration-tests/socket
 chmod 660 /run/integration-tests/socket
 
 echo "starting zenoh"
-zenohd --config=/etc/zenohd.json5 &
+# The test process connects through the host-side bind mount, so create the
+# socket with the host UID/GID instead of container root ownership.
+runuser -u host -- zenohd --config=/etc/zenohd.json5 &
 
 mkdir -p /etc/NetworkManager/system-connections
 chown root:root /etc/NetworkManager/system-connections

--- a/orb-connd/tests/docker/zenohd.json5
+++ b/orb-connd/tests/docker/zenohd.json5
@@ -1,7 +1,7 @@
 {
   "mode": "router",
   "listen": {
-    "endpoints": ["tcp/0.0.0.0:7447"]
+    "endpoints": ["unixsock-stream//run/zenohd/zenohd.sock"]
   },
   "timestamping": {
     "enabled": {

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -29,12 +29,18 @@ use orb_info::{
 };
 use prelude::future::Callback;
 use speare::mini;
-use std::{env, path::PathBuf, str::FromStr, time::Duration};
+use std::{
+    env,
+    os::unix::fs::FileTypeExt,
+    path::{Path, PathBuf},
+    str::FromStr,
+    time::Duration,
+};
 use test_utils::docker::{self, Container};
 use tokio::{fs, time};
 use tokio_util::sync::CancellationToken;
 use zbus::Address;
-use zenorb::Zenorb;
+use zenorb::{zenoh, Zenorb};
 
 #[allow(dead_code)]
 pub struct Fixture {
@@ -49,7 +55,7 @@ pub struct Fixture {
     pub secure_storage_cancel_token: CancellationToken,
     pub platform: OrbOsPlatform,
     zsession: Zenorb,
-    router_port: u16,
+    router_socket: PathBuf,
     pub orb_id: String,
     pub connd_path: PathBuf,
 }
@@ -89,7 +95,7 @@ impl Fixture {
             let _ = orb_telemetry::TelemetryConfig::new().init();
         }
 
-        let (container, router_port) =
+        let (container, router_socket) =
             setup_container(TempDir::new().await.unwrap()).await;
 
         let sysfs = container.tempdir.dir_path().join("sysfs");
@@ -195,7 +201,7 @@ impl Fixture {
             arrange_cb.call(ctx).await;
         }
         let orb_id = OrbId::from_str("ea2ea744").unwrap();
-        let zsession = Zenorb::from_cfg(zenorb::client_cfg(router_port))
+        let zsession = Zenorb::from_cfg(zenoh_socket_cfg(&router_socket))
             .orb_id(orb_id.clone())
             .with_name("connd")
             .await
@@ -244,7 +250,7 @@ impl Fixture {
             usr_persistent,
             secure_storage,
             secure_storage_cancel_token: cancel_token,
-            router_port,
+            router_socket,
             zsession,
             orb_id: orb_id.to_string(),
             platform,
@@ -266,12 +272,12 @@ impl Fixture {
 
         time::sleep(Duration::from_secs(1)).await;
 
-        let (container, zenohport) =
+        let (container, router_socket) =
             setup_container(self.container.tempdir.try_clone().await.unwrap()).await;
 
         time::sleep(Duration::from_secs(1)).await;
 
-        self.router_port = zenohport;
+        self.router_socket = router_socket;
         self.container = container;
 
         let dbus_socket = self.container.tempdir.dir_path().join("socket");
@@ -302,6 +308,13 @@ impl Fixture {
             }
         };
 
+        let orb_id = OrbId::from_str(&self.orb_id).unwrap();
+        let zsession = Zenorb::from_cfg(zenoh_socket_cfg(&self.router_socket))
+            .orb_id(orb_id)
+            .with_name("connd")
+            .await
+            .unwrap();
+
         let speare = program()
             .os_release(OrbOsRelease {
                 release_type: OrbRelease::Dev,
@@ -321,12 +334,13 @@ impl Fixture {
             .session_bus(self.conn.clone())
             .connect_timeout(Duration::from_secs(1))
             .profile_storage(profile_storage)
-            .zenoh(&self.zsession)
+            .zenoh(&zsession)
             .mcu_util(default_mock_mcu_util_cli())
             .run()
             .await
             .unwrap();
 
+        self.zsession = zsession;
         self.nm = nm;
         self.speare = speare;
         self.secure_storage_cancel_token = cancel_token;
@@ -341,7 +355,7 @@ impl Fixture {
     }
 }
 
-async fn setup_container(tempdir: TempDir) -> (Container, u16) {
+async fn setup_container(tempdir: TempDir) -> (Container, PathBuf) {
     let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let docker_ctx = crate_dir.join("tests").join("docker");
     let dockerfile = crate_dir.join("tests").join("docker").join("Dockerfile");
@@ -351,17 +365,18 @@ async fn setup_container(tempdir: TempDir) -> (Container, u16) {
     let uid = unsafe { libc::geteuid() };
     let gid = unsafe { libc::getegid() };
 
-    let zenohport = portpicker::pick_unused_port().expect("No ports free");
     let nm_profiles_dir = tempdir.dir_path().join("system-connections");
+    let zenoh_dir = tempdir.dir_path().join("zenohd");
     fs::create_dir_all(&nm_profiles_dir).await.unwrap();
+    fs::create_dir_all(&zenoh_dir).await.unwrap();
 
     let target_uid = format!("TARGET_UID={uid}");
     let target_gid = format!("TARGET_GID={gid}");
-    let zenoh_mapping = format!("-p={zenohport}:7447");
     let nm_profiles_volume = format!(
         "{}:/etc/NetworkManager/system-connections",
         nm_profiles_dir.display()
     );
+    let zenoh_volume = format!("{}:/run/zenohd", zenoh_dir.display());
 
     let container = docker::run_with(
         tag,
@@ -374,13 +389,46 @@ async fn setup_container(tempdir: TempDir) -> (Container, u16) {
             &target_gid,
             "-v",
             &nm_profiles_volume,
-            &zenoh_mapping,
+            "-v",
+            &zenoh_volume,
         ],
         tempdir,
     )
     .await;
 
-    (container, zenohport)
+    let router_socket = zenoh_dir.join("zenohd.sock");
+    wait_for_zenoh_socket(&router_socket).await;
+
+    (container, router_socket)
+}
+
+fn zenoh_socket_cfg(socket: &Path) -> zenoh::Config {
+    let mut cfg = zenoh::Config::default();
+    let endpoint = format!("unixsock-stream/{}", socket.display());
+    let endpoints = serde_json::to_string(&[endpoint]).unwrap();
+
+    cfg.insert_json5("mode", r#""client""#).unwrap();
+    cfg.insert_json5("connect/endpoints", &endpoints).unwrap();
+    cfg.insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+
+    cfg
+}
+
+async fn wait_for_zenoh_socket(socket: &Path) {
+    for _ in 0..50 {
+        if fs::metadata(socket)
+            .await
+            .map(|metadata| metadata.file_type().is_socket())
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        time::sleep(Duration::from_millis(100)).await;
+    }
+
+    panic!("zenoh socket was not created at {}", socket.display());
 }
 
 fn default_mockmmcli() -> MockMMCli {

--- a/orb-jobs-agent/debian/worldcoin-jobs-agent.service
+++ b/orb-jobs-agent/debian/worldcoin-jobs-agent.service
@@ -17,6 +17,7 @@ ExecStart=/usr/local/bin/orb-jobs-agent
 SyslogIdentifier=worldcoin-jobs-agent
 Restart=always
 SupplementaryGroups=systemd-journal
+SupplementaryGroups=zenohd
 
 [Install]
 WantedBy=multi-user.target

--- a/orb-jobs-agent/src/main.rs
+++ b/orb-jobs-agent/src/main.rs
@@ -29,7 +29,7 @@ async fn run(args: &Args) -> Result<()> {
     let connection = zbus::Connection::session().await?;
 
     info!("conecting to zenoh");
-    let zenorb = Zenorb::from_cfg(zenorb::client_cfg(settings.zenoh_port))
+    let zenorb = Zenorb::from_cfg(zenorb::default_cfg())
         .orb_id(settings.orb_id.clone())
         .with_name("jobs-agent")
         .await?;

--- a/zenorb/Cargo.toml
+++ b/zenorb/Cargo.toml
@@ -16,7 +16,10 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-zenoh = { workspace = true, default-features = false, features = ["transport_tcp", "transport_unixsock-stream"] }
+zenoh = { workspace = true, default-features = false, features = [
+	"transport_tcp",
+	"transport_unixsock-stream",
+] }
 
 [dev-dependencies]
 portpicker = "0.1.1"

--- a/zenorb/Cargo.toml
+++ b/zenorb/Cargo.toml
@@ -16,7 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-zenoh = { workspace = true, default-features = false, features = ["transport_tcp"] }
+zenoh = { workspace = true, default-features = false, features = ["transport_tcp", "transport_unixsock-stream"] }
 
 [dev-dependencies]
 portpicker = "0.1.1"

--- a/zenorb/src/lib.rs
+++ b/zenorb/src/lib.rs
@@ -12,8 +12,11 @@ pub use zenoh;
 pub fn default_cfg() -> zenoh::Config {
     let mut cfg = zenoh::Config::default();
     cfg.insert_json5("mode", r#""client""#).unwrap();
-    cfg.insert_json5("connect/endpoints", r#"["unixsock-stream//run/zenohd/zenohd.sock"]"#)
-        .unwrap();
+    cfg.insert_json5(
+        "connect/endpoints",
+        r#"["unixsock-stream//run/zenohd/zenohd.sock"]"#,
+    )
+    .unwrap();
     cfg.insert_json5("scouting/multicast/enabled", "false")
         .unwrap();
 

--- a/zenorb/src/lib.rs
+++ b/zenorb/src/lib.rs
@@ -9,6 +9,17 @@ pub use sender::Sender;
 pub use session::Zenorb;
 pub use zenoh;
 
+pub fn default_cfg() -> zenoh::Config {
+    let mut cfg = zenoh::Config::default();
+    cfg.insert_json5("mode", r#""client""#).unwrap();
+    cfg.insert_json5("connect/endpoints", r#"["unixsock-stream//tmp/zenohd.sock"]"#)
+        .unwrap();
+    cfg.insert_json5("scouting/multicast/enabled", "false")
+        .unwrap();
+
+    cfg
+}
+
 pub fn client_cfg(port: u16) -> zenoh::Config {
     let mut cfg = zenoh::Config::default();
     cfg.insert_json5("mode", r#""client""#).unwrap();

--- a/zenorb/src/lib.rs
+++ b/zenorb/src/lib.rs
@@ -12,7 +12,7 @@ pub use zenoh;
 pub fn default_cfg() -> zenoh::Config {
     let mut cfg = zenoh::Config::default();
     cfg.insert_json5("mode", r#""client""#).unwrap();
-    cfg.insert_json5("connect/endpoints", r#"["unixsock-stream//tmp/zenohd.sock"]"#)
+    cfg.insert_json5("connect/endpoints", r#"["unixsock-stream//run/zenohd/zenohd.sock"]"#)
         .unwrap();
     cfg.insert_json5("scouting/multicast/enabled", "false")
         .unwrap();


### PR DESCRIPTION
## about
changes the `zenorb` and `jobs-agent`, `update-agent` and `connd` to use a unix socket to communicate with zenoh

## why
- allows us to use `IPAccounting` from systemd to measure ingress/egress bytes from a service without worrying about local traffic influencing numbers
- theoretically more secure as only services in `zenohd` will be able to talk to zenoh once we remove the binding to `127.0.0.1` in the future