### PR TITLE
fix: add restart to jobs-agent and supervisor

### DIFF
--- a/orb-jobs-agent/debian/worldcoin-jobs-agent.service
+++ b/orb-jobs-agent/debian/worldcoin-jobs-agent.service
@@ -6,6 +6,7 @@ After=worldcoin-dbus.socket
 Wants=worldcoin-dbus.socket
 After=zenohd.service
 Requires=zenohd.service
+StartLimitIntervalSec=0
 
 [Service]
 Environment="HOME=/home/worldcoin"
@@ -16,6 +17,7 @@ Environment=RUST_BACKTRACE=1
 ExecStart=/usr/local/bin/orb-jobs-agent
 SyslogIdentifier=worldcoin-jobs-agent
 Restart=always
+RestartSec=3
 SupplementaryGroups=systemd-journal
 IPAccounting=yes
 SupplementaryGroups=zenohd

--- a/supervisor/debian/orb-supervisor.worldcoin-supervisor.service
+++ b/supervisor/debian/orb-supervisor.worldcoin-supervisor.service
@@ -4,6 +4,7 @@ After=worldcoin-dbus.socket
 Wants=worldcoin-dbus.socket
 After=zenohd.service
 Requires=zenohd.service
+StartLimitIntervalSec=0
 
 [Service]
 Type=dbus
@@ -11,6 +12,8 @@ BusName=org.worldcoin.OrbSupervisor1
 SyslogIdentifier=worldcoin-supervisor
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
 ExecStart=/usr/local/bin/orb-supervisor
+Restart=always
+RestartSec=3
 SupplementaryGroups=zenohd
 
 [Install]


### PR DESCRIPTION
Otherwise both services can miss zenoh

```
May 19 15:55:33 localhost.localdomain systemd[1]: Started Worldcoin Orb Jobs Agent.
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Starting jobs agent: Args { config: None, orb_id: None, orb_platform: None, orb_token: None, relay_host: None, relay_namespace: Some("jobs"), target_service_id: Some("job-server") }
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: conecting to zenoh
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Using ZID: f75cc2a8423f94ce40bad58668c42add
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Can not create a new UnixSocketStream link bound to "/run/zenohd/zenohd.sock": No such file or directory (os error 2) at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-link-unixsock_stream-1.7.2/src/unicast.rs:228.
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Unable to connect to unixsock-stream//run/zenohd/zenohd.sock! Can not create a new UnixSocketStream link bound to "/run/zenohd/zenohd.sock": No such file or directory (os error 2) at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-link-unixsock_stream-1.7.2/src/unicast.rs:228.
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Unable to connect to any of [unixsock-stream//run/zenohd/zenohd.sock]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.7.2/src/net/runtime/orchestrator.rs:374.
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: close session
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Error:
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]:    0: Unable to connect to any of [unixsock-stream//run/zenohd/zenohd.sock]!  at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zenoh-1.7.2/src/net/runtime/orchestrator.rs:374.
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Location:
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]:    /home/runner/work/orb-software/orb-software/zenorb/src/session.rs:44
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]:   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ BACKTRACE ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]:    1: __libc_start_main<unknown>
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]:       at <unknown source file>:<unknown line>
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
May 19 15:55:33 localhost.localdomain worldcoin-jobs-agent[1312]: Run with RUST_BACKTRACE=full to include source snippets.
May 19 15:55:33 localhost.localdomain systemd[1]: worldcoin-jobs-agent.service: Main process exited, code=exited, status=1/FAILURE
May 19 15:55:33 localhost.localdomain systemd[1]: worldcoin-jobs-agent.service: Failed with result 'exit-code'.
May 19 15:55:33 localhost.localdomain systemd[1]: worldcoin-jobs-agent.service: Scheduled restart job, restart counter is at 6.
May 19 15:55:33 localhost.localdomain systemd[1]: Stopped Worldcoin Orb Jobs Agent.
May 19 15:55:33 localhost.localdomain systemd[1]: worldcoin-jobs-agent.service: Start request repeated too quickly.
May 19 15:55:33 localhost.localdomain systemd[1]: worldcoin-jobs-agent.service: Failed with result 'exit-code'.
May 19 15:55:33 localhost.localdomain systemd[1]: Failed to start Worldcoin Orb Jobs Agent.
```