### PR TITLE
feat(attest): SE050 key migration selection at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8044,6 +8044,7 @@ dependencies = [
  "url",
  "wiremock",
  "zbus",
+ "zbus_systemd",
  "zenorb",
 ]
 

--- a/attest/Cargo.toml
+++ b/attest/Cargo.toml
@@ -39,6 +39,7 @@ tracing.workspace = true
 url = "2.2"
 zbus.workspace = true
 zenorb.workspace = true
+zbus_systemd = { workspace = true, features = ["systemd1"] }
 
 [build-dependencies]
 orb-build-info = { workspace = true, features = ["build-script"] }

--- a/attest/Cargo.toml
+++ b/attest/Cargo.toml
@@ -53,3 +53,6 @@ wiremock = "0.6"
 maintainer-scripts = "debian/"
 assets = [["target/release/orb-attest", "/usr/local/bin/", "755"]]
 systemd-units = [{ unit-name = "worldcoin-attest" }]
+
+[features]
+se050_key_migration = []

--- a/attest/dbus/src/lib.rs
+++ b/attest/dbus/src/lib.rs
@@ -14,6 +14,7 @@ use zbus::interface;
 pub trait AuthTokenManagerT: Send + Sync + 'static {
     fn token(&self) -> zbus::fdo::Result<String>;
     fn force_token_refresh(&mut self, ctxt: zbus::SignalContext<'_>);
+    fn new_keys_active(&self) -> zbus::fdo::Result<bool>;
 }
 
 #[derive(Debug, derive_more::From)]
@@ -37,5 +38,10 @@ impl<T: AuthTokenManagerT> AuthTokenManagerT for AuthTokenManager<T> {
         #[zbus(signal_context)] ctxt: zbus::SignalContext<'_>,
     ) {
         self.0.force_token_refresh(ctxt)
+    }
+
+    #[zbus(property)]
+    fn new_keys_active(&self) -> zbus::fdo::Result<bool> {
+        self.0.new_keys_active()
     }
 }

--- a/attest/debian/orb-attest.worldcoin-attest.service
+++ b/attest/debian/orb-attest.worldcoin-attest.service
@@ -8,6 +8,9 @@ Requires=worldcoin-dbus.service
 After=worldcoin-dbus.service
 After=worldcoin-dbus.socket
 Wants=worldcoin-dbus.socket
+# Soft dependency to not limit in case zenohd fails
+After=zenohd.service
+Wants=zenohd.service
 
 [Service]
 Type=simple

--- a/attest/src/config.rs
+++ b/attest/src/config.rs
@@ -1,11 +1,13 @@
 use eyre::{self, bail};
-use orb_endpoints::{v1, Backend};
+use orb_endpoints::{v1, v2, Backend};
 use orb_info::OrbId;
 use std::str::FromStr;
 
 pub struct Config {
     pub auth_url: url::Url,
     pub ping_url: url::Url,
+    pub keys_challenge_url: url::Url,
+    pub keys_proof_url: url::Url,
 }
 
 impl Config {
@@ -18,11 +20,14 @@ impl Config {
         // Parse the orb_id string into an OrbId
         let orb_id = OrbId::from_str(orb_id).expect("Invalid orb_id format");
 
-        let endpoints = v1::Endpoints::new(backend, &orb_id);
+        let v1 = v1::Endpoints::new(backend, &orb_id);
+        let v2 = v2::Endpoints::new(backend, &orb_id);
 
         Config {
-            auth_url: endpoints.auth,
-            ping_url: endpoints.ping,
+            auth_url: v1.auth,
+            ping_url: v1.ping,
+            keys_challenge_url: v2.keys_challenge,
+            keys_proof_url: v2.keys_proof,
         }
     }
 }

--- a/attest/src/dbus.rs
+++ b/attest/src/dbus.rs
@@ -23,6 +23,7 @@ pub type AuthTokenManagerIface = orb_attest_dbus::AuthTokenManager<AuthTokenMana
 pub struct AuthTokenManager {
     token: Option<String>,
     refresh_token_event: Arc<Notify>,
+    new_keys_active: bool,
 }
 
 impl AuthTokenManager {
@@ -31,11 +32,16 @@ impl AuthTokenManager {
         AuthTokenManager {
             token: None,
             refresh_token_event,
+            new_keys_active: false,
         }
     }
 
     pub fn update_token(&mut self, token: &str) {
         self.token = Some(token.to_string());
+    }
+
+    pub fn set_new_keys_active(&mut self, value: bool) {
+        self.new_keys_active = value;
     }
 }
 
@@ -56,6 +62,10 @@ impl AuthTokenManagerT for AuthTokenManager {
     #[instrument(skip_all)]
     fn force_token_refresh(&mut self, _ctxt: zbus::SignalContext<'_>) {
         self.refresh_token_event.notify_one();
+    }
+
+    fn new_keys_active(&self) -> zbus::fdo::Result<bool> {
+        Ok(self.new_keys_active)
     }
 }
 

--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -92,20 +92,26 @@ pub async fn main() -> eyre::Result<()> {
 
     let (is_online_tx, is_online_rx) = watch::channel(false);
 
-    let zenorb = Zenorb::from_cfg(zenorb::default_cfg())
+    match Zenorb::from_cfg(zenorb::default_cfg())
         .orb_id(orb_id.clone())
         .with_name("attest")
-        .await?;
-
-    let _ = zenorb
-        .receiver(is_online_tx)
-        .querying_subscriber(
-            "connd/oes/active_connections",
-            Duration::from_secs(1),
-            update_is_online,
-        )
-        .run()
-        .await?;
+        .await
+    {
+        Ok(zenorb) => {
+            let _ = zenorb
+                .receiver(is_online_tx)
+                .querying_subscriber(
+                    "connd/oes/active_connections",
+                    Duration::from_secs(1),
+                    update_is_online,
+                )
+                .run()
+                .await?;
+        }
+        Err(e) => {
+            warn!("zenoh not available, connectivity tracking disabled: {e}");
+        }
+    }
 
     let run_fut = run(
         orb_id.as_str(),

--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -45,9 +45,6 @@ const BACKEND_REACHABILITY_RETRY_INTERVAL: std::time::Duration =
 const MIGRATED_IRIS_CODE_PUBKEY: &str = "sss_60000002_0002_0040.bin";
 /// Relative path of legacy iris-code public key blob.
 const LEGACY_IRIS_CODE_PUBKEY: &str = "sss_70000002_0002_0040.bin";
-/// Absolute path of the symlink that always points to the active pubkey.
-const ACTIVE_IRIS_CODE_PUBKEY_LINK: &str =
-    "/usr/persistent/se/keystore/active_iris_code_pubkey.bin";
 
 pub const SYSLOG_IDENTIFIER: &str = "worldcoin-attest";
 
@@ -73,7 +70,11 @@ pub async fn main() -> eyre::Result<()> {
     )
     .await;
 
-    update_iris_code_pubkey_symlink(new_keys_active);
+    if new_keys_active {
+        info!("using {MIGRATED_IRIS_CODE_PUBKEY} as a signup key");
+    } else {
+        info!("using {LEGACY_IRIS_CODE_PUBKEY} as a signup key");
+    }
 
     iface_ref
         .get_mut()
@@ -214,6 +215,12 @@ async fn startup_key_selection(
         return false;
     }
 
+    // TODO: drop when other parts are ready, ORBS-1618, ORBS-1620
+    if cfg!(not(feature = "se050_key_migration")) {
+        warn!("skipping se050 migration due to feature flag");
+        return false;
+    }
+
     // Wait for connectivity: ensures the 60 s activation window is spent on
     // actual key-state probes, not wasted on network unreachability.
     wait_for_backend_reachable(orb_id, auth_url).await;
@@ -244,7 +251,6 @@ async fn startup_key_selection(
     // backend has swapped the registered public key and migration is complete.
     let deadline = tokio::time::Instant::now() + KEY_ACTIVATION_POLL_TIMEOUT;
     loop {
-        sleep(KEY_ACTIVATION_POLL_INTERVAL).await;
         if remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
             info!("backend now accepts migrated keys");
             return true;
@@ -252,6 +258,7 @@ async fn startup_key_selection(
         if tokio::time::Instant::now() >= deadline {
             break;
         }
+        sleep(KEY_ACTIVATION_POLL_INTERVAL).await;
     }
 
     warn!(
@@ -259,30 +266,6 @@ async fn startup_key_selection(
         KEY_ACTIVATION_POLL_TIMEOUT.as_secs()
     );
     false
-}
-
-/// Write (or replace) a relative symlink at [`ACTIVE_IRIS_CODE_PUBKEY_LINK`]
-/// pointing to the appropriate public-key blob for the active SE050 key set.
-fn update_iris_code_pubkey_symlink(new_keys_active: bool) {
-    let target = if new_keys_active {
-        MIGRATED_IRIS_CODE_PUBKEY
-    } else {
-        LEGACY_IRIS_CODE_PUBKEY
-    };
-
-    // Remove existing symlink/file so we can replace it atomically.
-    let _ = std::fs::remove_file(ACTIVE_IRIS_CODE_PUBKEY_LINK);
-
-    // TODO: Check Phillip's PR with hardening, once it in, we have to take care of permissions here
-    // and share common group with priv-orb-core to allow it to read the file.
-    if let Err(e) = std::os::unix::fs::symlink(target, ACTIVE_IRIS_CODE_PUBKEY_LINK) {
-        warn!(
-            "failed to create iris-code pubkey symlink {ACTIVE_IRIS_CODE_PUBKEY_LINK} \
-             -> {target}: {e}"
-        );
-    } else {
-        info!("iris-code pubkey symlink: {ACTIVE_IRIS_CODE_PUBKEY_LINK} -> {target}");
-    }
 }
 
 /// Return proovenly working static token, or error if the token was rejected by the backend.

--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -32,6 +32,23 @@ const BUILD_INFO: BuildInfo = make_build_info!();
 
 const HTTP_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
 
+/// How long to poll for migrated key activation after proof submission.
+const KEY_ACTIVATION_POLL_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(60);
+const KEY_ACTIVATION_POLL_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5);
+/// How long to wait between retries while waiting for the backend to become reachable.
+const BACKEND_REACHABILITY_RETRY_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(5);
+
+/// Relative path of migrated iris-code public key blob.
+const MIGRATED_IRIS_CODE_PUBKEY: &str = "sss_60000002_0002_0040.bin";
+/// Relative path of legacy iris-code public key blob.
+const LEGACY_IRIS_CODE_PUBKEY: &str = "sss_70000002_0002_0040.bin";
+/// Absolute path of the symlink that always points to the active pubkey.
+const ACTIVE_IRIS_CODE_PUBKEY_LINK: &str =
+    "/usr/persistent/se/keystore/active_iris_code_pubkey.bin";
+
 pub const SYSLOG_IDENTIFIER: &str = "worldcoin-attest";
 
 #[allow(clippy::missing_errors_doc)]
@@ -46,6 +63,30 @@ pub async fn main() -> eyre::Result<()> {
     let iface_ref = setup_dbus(force_refresh_token.clone())
         .await
         .wrap_err("Initialization failed")?;
+
+    // Determine which SE050 key set is active before starting the token loop.
+    let new_keys_active = startup_key_selection(
+        orb_id.as_str(),
+        &config.auth_url,
+        &config.keys_challenge_url,
+        &config.keys_proof_url,
+    )
+    .await;
+
+    update_iris_code_pubkey_symlink(new_keys_active);
+
+    iface_ref
+        .get_mut()
+        .await
+        .0
+        .set_new_keys_active(new_keys_active);
+    iface_ref
+        .get_mut()
+        .await
+        .new_keys_active_changed(iface_ref.signal_context())
+        .await
+        .wrap_err("failed to send new_keys_active_changed signal")?;
+
     let conn = iface_ref.signal_context().connection().clone();
 
     let (is_online_tx, is_online_rx) = watch::channel(false);
@@ -87,6 +128,161 @@ pub async fn main() -> eyre::Result<()> {
             .map(|r| r.wrap_err("dbus monitor task terminated abnormally")?)
     )?;
     Ok(())
+}
+
+/// Returns `true` if `worldcoin-se050-provision.service` is in the `active`
+/// state, meaning SE050 has migrated keys.
+async fn se050_provision_service_active() -> bool {
+    use zbus_systemd::systemd1::{ManagerProxy, UnitProxy};
+
+    let Ok(conn) = zbus::Connection::system().await else {
+        warn!("SE050: failed to connect to system D-Bus");
+        return false;
+    };
+    let Ok(manager) = ManagerProxy::new(&conn).await else {
+        warn!("SE050: failed to create systemd ManagerProxy");
+        return false;
+    };
+    // GetUnit errors if the unit has never been loaded — treat as not active.
+    let Ok(unit_path) = manager
+        .get_unit("worldcoin-se050-provision.service".to_owned())
+        .await
+    else {
+        warn!("SE050: worldcoin-se050-provision.service not found in systemd");
+        return false;
+    };
+    let builder = match UnitProxy::builder(&conn).path(unit_path) {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("SE050: invalid unit object path from systemd: {e}");
+            return false;
+        }
+    };
+    let Ok(unit) = builder.build().await else {
+        warn!("SE050: failed to create systemd UnitProxy");
+        return false;
+    };
+    unit.active_state().await.ok().as_deref() == Some("active")
+}
+
+/// Block until the token-challenge endpoint returns any response (success or
+/// server error). Retries indefinitely on network/connect errors — the caller
+/// cannot do anything useful without backend connectivity.
+async fn wait_for_backend_reachable(orb_id: &str, auth_url: &Url) {
+    let tokenchallenge_url = auth_url
+        .join("tokenchallenge")
+        .expect("auth_url must have a path");
+    loop {
+        match remote_api::Challenge::request(orb_id, &tokenchallenge_url).await {
+            Ok(_) | Err(remote_api::ChallengeError::ServerReturnedError(..)) => {
+                info!("backend reachable");
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    "backend not reachable ({e}), retrying in {}s",
+                    BACKEND_REACHABILITY_RETRY_INTERVAL.as_secs()
+                );
+                sleep(BACKEND_REACHABILITY_RETRY_INTERVAL).await;
+            }
+        }
+    }
+}
+
+/// Determine which SE050 key set is active.
+///
+/// 1. Service check: if `worldcoin-se050-provision.service` is not active,
+///    SE050 has no migrated keys → return `false` immediately.
+/// 2. Wait until the backend is reachable (challenge endpoint responds).
+/// 3. Backend check: attempt a full challenge→sign(migrated)→token round-trip.
+///    If the backend returns a valid token, it already has the migrated key
+///    registered → return `true`.
+/// 4. Submit the NXP-attested proof so the backend registers the migrated key.
+/// 5. Poll the same backend round-trip until it succeeds or [`KEY_ACTIVATION_POLL_TIMEOUT`]
+///    elapses. "Activation" means the backend accepted the migrated key and
+///    returned a valid token.
+async fn startup_key_selection(
+    orb_id: &str,
+    auth_url: &Url,
+    keys_challenge_url: &Url,
+    keys_proof_url: &Url,
+) -> bool {
+    // Service check: worldcoin-se050-provision.service encodes the answer to
+    // "does this Orb have migrated keys?" — it runs before us and stays active.
+    if !se050_provision_service_active().await {
+        info!("worldcoin-se050-provision.service not active, using legacy keys");
+        return false;
+    }
+
+    // Wait for connectivity: ensures the 60 s activation window is spent on
+    // actual key-state probes, not wasted on network unreachability.
+    wait_for_backend_reachable(orb_id, auth_url).await;
+
+    // Backend check: does the backend already accept the migrated key?
+    if remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
+        info!("backend already accepts migrated keys");
+        return true;
+    }
+
+    // Submit proof to register the migrated public key with the backend.
+    info!("migrated keys not yet accepted by backend, submitting key proof");
+    match remote_api::submit_proof(orb_id, keys_challenge_url, keys_proof_url).await {
+        Ok(()) => {
+            info!(
+                "key proof submitted, polling for backend activation (up to {}s)",
+                KEY_ACTIVATION_POLL_TIMEOUT.as_secs()
+            );
+        }
+        Err(e) => {
+            warn!("key proof submission failed: {e}; proceeding with legacy keys");
+            return false;
+        }
+    }
+
+    // Poll until the backend accepts a token signed with the migrated key.
+    // This is the definitive test: if the token endpoint returns 200, the
+    // backend has swapped the registered public key and migration is complete.
+    let deadline = tokio::time::Instant::now() + KEY_ACTIVATION_POLL_TIMEOUT;
+    loop {
+        sleep(KEY_ACTIVATION_POLL_INTERVAL).await;
+        if remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
+            info!("backend now accepts migrated keys");
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+    }
+
+    warn!(
+        "backend did not accept migrated keys after {}s; proceeding with legacy keys",
+        KEY_ACTIVATION_POLL_TIMEOUT.as_secs()
+    );
+    false
+}
+
+/// Write (or replace) a relative symlink at [`ACTIVE_IRIS_CODE_PUBKEY_LINK`]
+/// pointing to the appropriate public-key blob for the active SE050 key set.
+fn update_iris_code_pubkey_symlink(new_keys_active: bool) {
+    let target = if new_keys_active {
+        MIGRATED_IRIS_CODE_PUBKEY
+    } else {
+        LEGACY_IRIS_CODE_PUBKEY
+    };
+
+    // Remove existing symlink/file so we can replace it atomically.
+    let _ = std::fs::remove_file(ACTIVE_IRIS_CODE_PUBKEY_LINK);
+
+    // TODO: Check Phillip's PR with hardening, once it in, we have to take care of permissions here
+    // and share common group with priv-orb-core to allow it to read the file.
+    if let Err(e) = std::os::unix::fs::symlink(target, ACTIVE_IRIS_CODE_PUBKEY_LINK) {
+        warn!(
+            "failed to create iris-code pubkey symlink {ACTIVE_IRIS_CODE_PUBKEY_LINK} \
+             -> {target}: {e}"
+        );
+    } else {
+        info!("iris-code pubkey symlink: {ACTIVE_IRIS_CODE_PUBKEY_LINK} -> {target}");
+    }
 }
 
 /// Return proovenly working static token, or error if the token was rejected by the backend.

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -253,15 +253,15 @@ impl Challenge {
         elapsed > (self.duration / 2)
     }
 
-    /// Try to sign the challenge using SE050. Could fail for multiple reasons,
-    /// it is probably a good idea to retry signing.
-    #[tracing::instrument]
-    pub fn sign(&self) -> Result<Signature, SignError> {
+    /// Try to sign the challenge with an arbitrary signing binary.
+    ///
+    /// Unlike [`sign`], this does NOT update `SIGNING_FAILURE_ERROR_COUNT` or
+    /// trigger an MCU powercycle. Use it for probing only.
+    pub fn sign_with_binary(&self, binary: &str) -> Result<Signature, SignError> {
         let digest = digest(&digest::SHA256, &self.challenge);
-
         let encoded = BASE64.encode(digest.as_ref());
 
-        let command = Command::new("orb-sign-attestation")
+        let command = Command::new(binary)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -280,40 +280,21 @@ impl Challenge {
 
         // TODO check errkind
         if !output.status.success() {
-            event!(Level::ERROR, sign_tool_log = ?sign_tool_log, orb_sign_attestation_success = output.status.success(), orb_sign_attestation_code = output.status.code());
+            event!(Level::WARN, sign_tool_log = ?sign_tool_log, binary, exit_code = output.status.code());
             return match output.status.code() {
                 Some(127) => Err(SignError::NoSignBinary),
-                Some(err @ 1 /* sign failed */)
-                | Some(err @ 2 /* signature timeout */)
-                | Some(err @ 7 /* communication error */) => {
-                    let mut lock = SIGNING_FAILURE_ERROR_COUNT.write().unwrap();
-                    *lock += 1;
-                    if *lock == SIGNING_FAILURE_ERROR_COUNT_THRESHOLD {
-                        if let Err(err) = powercycle_security_mcu() {
-                            error!("Failed to powercycle Security MCU: {err}")
-                        } else {
-                            info!(
-                                "Powercycled Security MCU, trying to reset stuck se050."
-                            );
-                        }
-                    }
-                    match err {
-                        1 => Err(SignError::SignFailed),
-                        2 => Err(SignError::Timeout),
-                        7 => Err(SignError::CommunicationError),
-                        _ => unreachable!(),
-                    }
-                }
+                Some(1) => Err(SignError::SignFailed),
+                Some(2) => Err(SignError::Timeout),
                 Some(3) => Err(SignError::NotProvisioned),
                 Some(4) => Err(SignError::BadInput),
                 Some(5) => Err(SignError::InternalError),
                 Some(6) => Err(SignError::LockFailed),
+                Some(7) => Err(SignError::CommunicationError),
                 Some(code) => Err(SignError::NonZeroExitCode(code)),
                 None => Err(SignError::TerminatedBySignal),
             };
-        } else {
-            *SIGNING_FAILURE_ERROR_COUNT.write().unwrap() = Saturating(0);
         }
+
         Ok(Signature {
             signature: BASE64.decode(&output.stdout).map_err(|e| {
                 SignError::BadOutput(
@@ -322,6 +303,34 @@ impl Challenge {
                 )
             })?,
         })
+    }
+
+    /// Try to sign the challenge using SE050. Could fail for multiple reasons,
+    /// it is probably a good idea to retry signing.
+    ///
+    /// On repeated SE050 communication failures, triggers a Security MCU
+    /// powercycle to recover the stuck SE050.
+    #[tracing::instrument]
+    pub fn sign(&self) -> Result<Signature, SignError> {
+        let result = self.sign_with_binary("orb-sign-attestation");
+        match &result {
+            Err(e) if e.requires_security_mcu_cooldown() => {
+                let mut lock = SIGNING_FAILURE_ERROR_COUNT.write().unwrap();
+                *lock += 1;
+                if *lock == SIGNING_FAILURE_ERROR_COUNT_THRESHOLD {
+                    if let Err(err) = powercycle_security_mcu() {
+                        error!("Failed to powercycle Security MCU: {err}")
+                    } else {
+                        info!("Powercycled Security MCU, trying to reset stuck se050.");
+                    }
+                }
+            }
+            Ok(_) => {
+                *SIGNING_FAILURE_ERROR_COUNT.write().unwrap() = Saturating(0);
+            }
+            _ => {}
+        }
+        result
     }
 }
 
@@ -653,6 +662,245 @@ fn error_cause(e: &RefreshTokenError) -> &'static str {
 
         RefreshTokenError::JoinError(_) => "JoinError",
     }
+}
+
+/// Errors that can occur during SE050 key proof submission.
+#[derive(Debug, thiserror::Error)]
+pub enum ProofError {
+    #[error("failed to get keys challenge: {0}")]
+    ChallengeRequest(#[source] reqwest::Error),
+    #[error("keys challenge: server returned {0}: {1}")]
+    ChallengeServerError(reqwest::StatusCode, String),
+    #[error("failed to parse keys challenge response: {0}")]
+    ChallengeJsonParseFailed(#[source] reqwest::Error),
+    #[error("invalid base64 in server nonce: {0}")]
+    InvalidNonce(#[source] data_encoding::DecodeError),
+    #[error("read-keys-with-attest failed: {0}")]
+    ReadKeysFailed(String),
+    #[error("sign tool error during proof: {0}")]
+    SignFailed(#[source] SignError),
+    #[error("failed to serialize proof payload: {0}")]
+    SerializeFailed(#[source] serde_json::Error),
+    #[error("failed to submit proof: {0}")]
+    ProofRequest(#[source] reqwest::Error),
+    #[error("proof submission: server returned {0}: {1}")]
+    ProofServerError(reqwest::StatusCode, String),
+}
+
+#[derive(serde::Deserialize)]
+struct KeysChallengeResponse {
+    server_nonce: String,
+}
+
+#[derive(serde::Serialize)]
+struct ProofPayload {
+    orb_id: String,
+    server_nonce: String,
+    attested_keys: serde_json::Value,
+    signature: String,
+}
+
+/// Verify that the **backend** accepts the migrated SE050 key set for token
+/// issuance by performing a full challenge → sign (migrated) → token
+/// round-trip.
+///
+/// Returns `true` only if the backend returns a valid token. A `false` result
+/// may mean the backend hasn't registered the migrated key yet (proof not yet
+/// submitted or not yet processed), or that the SE050 hardware doesn't have
+/// the migrated key at all.
+///
+/// Does NOT update `SIGNING_FAILURE_ERROR_COUNT` or trigger an MCU powercycle.
+#[tracing::instrument]
+pub async fn try_token_with_migrated_key(orb_id: &str, auth_url: &Url) -> bool {
+    let tokenchallenge_url = match auth_url.join("tokenchallenge") {
+        Ok(u) => u,
+        Err(e) => {
+            warn!("migrated key probe: failed to build challenge URL: {e}");
+            return false;
+        }
+    };
+    let token_url = match auth_url.join("token") {
+        Ok(u) => u,
+        Err(e) => {
+            warn!("migrated key probe: failed to build token URL: {e}");
+            return false;
+        }
+    };
+
+    let challenge = match Challenge::request(orb_id, &tokenchallenge_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("migrated key probe: challenge request failed: {e}");
+            return false;
+        }
+    };
+
+    let challenge_clone = challenge.clone();
+    let sig = match tokio::task::spawn_blocking(move || {
+        challenge_clone.sign_with_binary("orb-sign-attestation-migrated")
+    })
+    .await
+    {
+        Ok(Ok(sig)) => sig,
+        Ok(Err(e)) => {
+            warn!("migrated key probe: signing failed: {e}");
+            return false;
+        }
+        Err(e) => {
+            warn!("migrated key probe: spawn_blocking panicked: {e}");
+            return false;
+        }
+    };
+
+    match Token::request(&token_url, orb_id, &challenge, &sig).await {
+        Ok(_) => true,
+        Err(e) => {
+            warn!("migrated key probe: token request failed (backend not yet activated): {e}");
+            false
+        }
+    }
+}
+
+/// Submit an NXP-attested key proof to the backend, proving the SE050 holds
+/// the new migrated key set (0x6000000X).
+///
+/// Flow:
+/// 1. POST `keys_challenge_url` → receive 16-byte `server_nonce`
+/// 2. Pipe raw nonce bytes to `read-keys-with-attest` → receive attested keys JSON
+/// 3. Sign `compact_json(attested_keys)` with `orb-sign-attestation-legacy`
+/// 4. POST `keys_proof_url` with the assembled payload
+#[tracing::instrument]
+pub async fn submit_proof(
+    orb_id: &str,
+    keys_challenge_url: &Url,
+    keys_proof_url: &Url,
+) -> Result<(), ProofError> {
+    let client = crate::client::client();
+
+    // 1. Get challenge nonce
+    let resp = client
+        .post(keys_challenge_url.clone())
+        .json(&serde_json::json!({"orbId": orb_id}))
+        .send()
+        .await
+        .map_err(ProofError::ChallengeRequest)?;
+
+    let status = resp.status();
+    if status.is_client_error() || status.is_server_error() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ProofError::ChallengeServerError(status, body));
+    }
+
+    let challenge: KeysChallengeResponse = resp
+        .json()
+        .await
+        .map_err(ProofError::ChallengeJsonParseFailed)?;
+
+    let nonce_bytes = BASE64
+        .decode(challenge.server_nonce.as_bytes())
+        .map_err(ProofError::InvalidNonce)?;
+
+    // 2. Run read-keys-with-attest with nonce on stdin
+    let server_nonce = challenge.server_nonce.clone();
+    let attested_keys_json =
+        tokio::task::spawn_blocking(move || -> Result<String, ProofError> {
+            let command = Command::new("read-keys-with-attest")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .spawn()
+                .map_err(|e| {
+                    ProofError::ReadKeysFailed(format!("spawn failed: {e}"))
+                })?;
+
+            command
+                .stdin
+                .as_ref()
+                .expect("child should have stdin")
+                .write_all(&nonce_bytes)
+                .map_err(|e| {
+                    ProofError::ReadKeysFailed(format!("write failed: {e}"))
+                })?;
+
+            let output = command
+                .wait_with_output()
+                .map_err(|e| ProofError::ReadKeysFailed(format!("wait failed: {e}")))?;
+
+            if !output.status.success() {
+                return Err(ProofError::ReadKeysFailed(format!(
+                    "exited with {:?}",
+                    output.status.code()
+                )));
+            }
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        })
+        .await
+        .map_err(|e| ProofError::ReadKeysFailed(format!("task panic: {e}")))??;
+
+    // Parse and re-serialize to compact JSON for deterministic signature input
+    let attested_keys: serde_json::Value = serde_json::from_str(&attested_keys_json)
+        .map_err(|e| ProofError::ReadKeysFailed(format!("JSON parse failed: {e}")))?;
+    let attested_keys_compact =
+        serde_json::to_string(&attested_keys).map_err(ProofError::SerializeFailed)?;
+
+    // 3. Sign compact JSON of attested_keys with legacy attestation key
+    let sign_digest = digest(&digest::SHA256, attested_keys_compact.as_bytes());
+    let digest_b64 = BASE64.encode(sign_digest.as_ref());
+
+    let sig_b64 = tokio::task::spawn_blocking(move || -> Result<String, ProofError> {
+        let command = Command::new("orb-sign-attestation-legacy")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| ProofError::SignFailed(SignError::SpawnFailed(e)))?;
+
+        writeln!(
+            command.stdin.as_ref().expect("child should have stdin"),
+            "{digest_b64}"
+        )
+        .map_err(|e| ProofError::SignFailed(SignError::WriteFailed(e)))?;
+
+        let output = command
+            .wait_with_output()
+            .map_err(|e| ProofError::SignFailed(SignError::ReadFailed(e)))?;
+
+        if !output.status.success() {
+            return Err(ProofError::SignFailed(match output.status.code() {
+                Some(127) => SignError::NoSignBinary,
+                Some(3) => SignError::NotProvisioned,
+                Some(6) => SignError::LockFailed,
+                _ => SignError::SignFailed,
+            }));
+        }
+
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    })
+    .await
+    .map_err(|e| ProofError::ReadKeysFailed(format!("task panic: {e}")))??;
+
+    // 4. Submit proof
+    let payload = ProofPayload {
+        orb_id: orb_id.to_string(),
+        server_nonce,
+        attested_keys,
+        signature: sig_b64,
+    };
+
+    let resp = client
+        .post(keys_proof_url.clone())
+        .json(&payload)
+        .send()
+        .await
+        .map_err(ProofError::ProofRequest)?;
+
+    let status = resp.status();
+    if status.is_client_error() || status.is_server_error() {
+        let body = resp.text().await.unwrap_or_default();
+        return Err(ProofError::ProofServerError(status, body));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/endpoints/src/v2.rs
+++ b/endpoints/src/v2.rs
@@ -5,6 +5,8 @@ use crate::{concat_urls, Backend, OrbId};
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub struct Endpoints {
     pub status: Url,
+    pub keys_challenge: Url,
+    pub keys_proof: Url,
 }
 
 impl Endpoints {
@@ -16,12 +18,11 @@ impl Endpoints {
             Backend::Local => todo!(),
         };
 
+        let base = format!("https://fleet.{subdomain}.worldcoin.org/api/v2/orbs/");
         Self {
-            status: concat_urls(
-                &format!("https://fleet.{subdomain}.worldcoin.org/api/v2/orbs/"),
-                orb_id,
-                "status",
-            ),
+            status: concat_urls(&base, orb_id, "status"),
+            keys_challenge: concat_urls(&base, orb_id, "keys/challenge"),
+            keys_proof: concat_urls(&base, orb_id, "keys/proof"),
         }
     }
 }
@@ -43,6 +44,14 @@ mod test {
         assert_eq!(
             prod.status.as_str(),
             "https://fleet.orb.worldcoin.org/api/v2/orbs/ea2ea744/status"
+        );
+        assert_eq!(
+            stage.keys_challenge.as_str(),
+            "https://fleet.stage.orb.worldcoin.org/api/v2/orbs/ea2ea744/keys/challenge"
+        );
+        assert_eq!(
+            prod.keys_proof.as_str(),
+            "https://fleet.orb.worldcoin.org/api/v2/orbs/ea2ea744/keys/proof"
         );
     }
 

--- a/orb-info/src/orb_token.rs
+++ b/orb-info/src/orb_token.rs
@@ -100,6 +100,10 @@ mod tests {
         fn force_token_refresh(&mut self, _ctxt: zbus::SignalContext<'_>) {
             // no-op
         }
+
+        fn new_keys_active(&self) -> zbus::fdo::Result<bool> {
+            Ok(false)
+        }
     }
 
     // using `dbus_launch` ensures that all tests use their own isolated dbus, and that they can't influence each other.


### PR DESCRIPTION
On startup, check whether `worldcoin-se050-provision.service` is active (via systemd D-Bus) to decide which key set to use. If migrated keys are present, wait for the backend to become reachable, then attempt a token round-trip with the migrated key. If the backend does not yet have the key registered, submit an NXP-attested proof and poll for up to 60 s until the backend accepts the migrated key.

Expose the result as `new_keys_active` on the `AuthTokenManager1` D-Bus interface


Added feature flag to skip migration phase from current release until issues are resolved
```
2026-06-16T20:01:37.160597Z  INFO orb_attest: worldcoin-se050-provision.service not active, using legacy keys
```

with feature flag on test orb with migrated keys:
```
2026-06-16T20:35:50.174936Z  INFO orb_attest: backend already accepts migrated keys

```
