### PR TITLE
feat(orb-dogd): standardized crate for pushing metrics to datadog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8369,6 +8369,7 @@ name = "orb-dogd"
 version = "0.1.0"
 dependencies = [
  "dogstatsd",
+ "eyre",
  "flume",
  "thiserror 2.0.17",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8365,6 +8365,16 @@ name = "orb-const-concat"
 version = "0.0.0"
 
 [[package]]
+name = "orb-dogd"
+version = "0.1.0"
+dependencies = [
+ "dogstatsd",
+ "flume",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
 name = "orb-endpoints"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
 	"orb-connd",
 	"orb-connd/dbus",
 	"orb-core/agent-iroh",
+	"orb-dogd",
 	"orb-info",
 	"orb-jobs-agent",
 	"ota-backend",

--- a/orb-dogd/Cargo.toml
+++ b/orb-dogd/Cargo.toml
@@ -15,6 +15,7 @@ testing = []
 
 [dependencies]
 dogstatsd.workspace = true
+eyre.workspace = true
 flume.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/orb-dogd/Cargo.toml
+++ b/orb-dogd/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "orb-dogd"
+version = "0.1.0"
+description = "Standardized statsd setup for the orb"
+authors = ["Theodore Sfikas <sfikastheo@users.noreply.github.com>"]
+
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+rust-version.workspace = true
+publish = false
+
+[features]
+testing = []
+
+[dependencies]
+dogstatsd.workspace = true
+flume.workspace = true
+thiserror.workspace = true
+tracing.workspace = true

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -1,0 +1,63 @@
+use dogstatsd::{Client, DogstatsdError, Options};
+use flume::{Sender, TrySendError};
+use std::thread;
+use tracing::error;
+
+use super::{Metric, MetricEmitter, MetricError};
+
+pub struct DogstatsdClient {
+    tx: Sender<Metric>,
+}
+
+impl DogstatsdClient {
+    /// Bind the UDP socket and spawn the consumer thread,
+    /// propagating metrics to the metric collector
+    ///
+    /// Fails if [`Client::new`] fails (socket bind / permission).
+    /// The worker runs until all [`Sender`]s are dropped.
+    pub fn new() -> Result<Self, DogstatsdError> {
+        let (tx, rx) = flume::bounded(1024);
+
+        let datadog_options = Options::default();
+        let client = Client::new(datadog_options)?;
+
+        thread::spawn(move || {
+            while let Ok(metric) = rx.recv() {
+                match metric {
+                    Metric::Count { stat, val, tags } => {
+                        if let Err(e) = client.count(stat, val, tags) {
+                            error!("emitting metric failed with: {e}");
+                        }
+                    }
+                    Metric::Gauge { stat, val, tags } => {
+                        if let Err(e) = client.gauge(stat, val.to_string(), tags) {
+                            error!("emitting metric failed with: {e}");
+                        }
+                    }
+                    Metric::Histogram { stat, val, tags } => {
+                        if let Err(e) = client.histogram(stat, val.to_string(), tags) {
+                            error!("emitting metric failed with: {e}");
+                        }
+                    }
+                    Metric::Distribution { stat, val, tags } => {
+                        if let Err(e) = client.distribution(stat, val.to_string(), tags) {
+                            error!("emitting metric failed with: {e}");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Self { tx })
+    }
+}
+
+impl MetricEmitter for DogstatsdClient {
+    fn emit(&self, metric: Metric) -> Result<(), MetricError> {
+        match self.tx.try_send(metric) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Full(e)) => Err(MetricError::ChannelFull(e)),
+            Err(TrySendError::Disconnected(e)) => Err(MetricError::ChannelClosed(e)),
+        }
+    }
+}

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -1,22 +1,54 @@
 use dogstatsd::{Client, DogstatsdError, Options};
-use flume::{Sender, TrySendError};
+use flume::Sender;
 use std::thread;
-use tracing::error;
+use tracing::warn;
 
-use super::{Metric, MetricEmitter, MetricError};
+use super::{MetricEmitter, MetricError};
 
 pub struct DogstatsdClient {
     tx: Sender<Metric>,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum Metric {
+    /// Counter delta; Used by:
+    /// [`MetricEmitter::count`] and [`MetricEmitter::incr`]
+    Count {
+        stat: String,
+        val: i64,
+        tags: Vec<String>,
+    },
+    /// Last point-in-time value;
+    /// Used by: [`MetricEmitter::gauge`]
+    Gauge {
+        stat: String,
+        val: f64,
+        tags: Vec<String>,
+    },
+    /// Metric aggregated by the **local Datadog agent**.
+    /// Percentiles are per-host only;
+    /// Used by [`MetricEmitter::hist`].
+    Histogram {
+        stat: String,
+        val: f64,
+        tags: Vec<String>,
+    },
+    /// Raw metrics are aggregated by the **Datadog's backend**.
+    /// Supports global percentiles and post-hoc tag splits.
+    /// Used by [`MetricEmitter::dist`].
+    Distribution {
+        stat: String,
+        val: f64,
+        tags: Vec<String>,
+    },
+}
+
 impl DogstatsdClient {
-    /// Bind the UDP socket and spawn the consumer thread,
-    /// propagating metrics to the metric collector
+    /// Connect to the local statsd collector.
     ///
-    /// Fails if [`Client::new`] fails (socket bind / permission).
-    /// The worker runs until all [`Sender`]s are dropped.
+    /// Fails if the underlying socket cannot be bound.
     pub fn new() -> Result<Self, DogstatsdError> {
-        let (tx, rx) = flume::bounded(1024);
+        let (tx, rx) = flume::unbounded();
 
         let datadog_options = Options::default();
         let client = Client::new(datadog_options)?;
@@ -26,22 +58,23 @@ impl DogstatsdClient {
                 match metric {
                     Metric::Count { stat, val, tags } => {
                         if let Err(e) = client.count(stat, val, tags) {
-                            error!("emitting metric failed with: {e}");
+                            warn!("emitting metric failed with: {e}");
                         }
                     }
                     Metric::Gauge { stat, val, tags } => {
                         if let Err(e) = client.gauge(stat, val.to_string(), tags) {
-                            error!("emitting metric failed with: {e}");
+                            warn!("emitting metric failed with: {e}");
                         }
                     }
                     Metric::Histogram { stat, val, tags } => {
                         if let Err(e) = client.histogram(stat, val.to_string(), tags) {
-                            error!("emitting metric failed with: {e}");
+                            warn!("emitting metric failed with: {e}");
                         }
                     }
                     Metric::Distribution { stat, val, tags } => {
-                        if let Err(e) = client.distribution(stat, val.to_string(), tags) {
-                            error!("emitting metric failed with: {e}");
+                        if let Err(e) = client.distribution(stat, val.to_string(), tags)
+                        {
+                            warn!("emitting metric failed with: {e}");
                         }
                     }
                 }
@@ -53,11 +86,88 @@ impl DogstatsdClient {
 }
 
 impl MetricEmitter for DogstatsdClient {
-    fn emit(&self, metric: Metric) -> Result<(), MetricError> {
-        match self.tx.try_send(metric) {
-            Ok(()) => Ok(()),
-            Err(TrySendError::Full(e)) => Err(MetricError::ChannelFull(e)),
-            Err(TrySendError::Disconnected(e)) => Err(MetricError::ChannelClosed(e)),
-        }
+    fn count<S, I>(&self, stat: S, val: i64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Count {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.tx
+            .send(metric)
+            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
+
+        Ok(())
+    }
+
+    fn incr<S, I>(&self, stat: S, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Count {
+            stat: stat.into(),
+            val: 1,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.tx
+            .send(metric)
+            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
+
+        Ok(())
+    }
+
+    fn gauge<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Gauge {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.tx
+            .send(metric)
+            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
+
+        Ok(())
+    }
+
+    fn hist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Histogram {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.tx
+            .send(metric)
+            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
+
+        Ok(())
+    }
+
+    fn dist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Distribution {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.tx
+            .send(metric)
+            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
+
+        Ok(())
     }
 }

--- a/orb-dogd/src/lib.rs
+++ b/orb-dogd/src/lib.rs
@@ -1,8 +1,8 @@
-//! sync, drop-on-overflow statsd client.
+//! Standardized statsd client interface.
 //!
-//! [`MetricEmitter::emit`] queues a metric onto a bounded channel and returns
-//! immediately. A background worker (see [`DogstatsdClient`]) drains the
-//! channel and performs the UDP send to the metric collector.
+//! [`MetricEmitter`] is an abstraction trait bounding the API;
+//! [`DogstatsdClient`] is used for the default  implementation.
+//! Test implementations are gated behind the `testing` feature.
 #![forbid(unsafe_code)]
 
 mod dd;
@@ -12,98 +12,43 @@ pub use dogstatsd::DogstatsdError;
 #[cfg(any(test, feature = "testing"))]
 pub mod test;
 
-/// Failure of [`MetricEmitter::emit`].
-///
-/// Wraps the underlying channel's send error so the choice of channel
-/// implementation stays an internal detail of this crate.
+/// Empty tag set.
+pub const NO_TAGS: [&str; 0] = [];
+
+/// Failure from a [`MetricEmitter`] method.
 #[derive(thiserror::Error, Debug)]
-pub enum MetricError {
-    /// Channel at capacity. The rejected [`Metric`] is returned so
-    /// callers may retry or drop.
-    #[error("channel is at capacity")]
-    ChannelFull(Metric),
-    /// Consumer is closed. Every subsequent `emit` will also
-    /// fail with this variant.
-    #[error("channel is closed")]
-    ChannelClosed(Metric),
-}
+#[error(transparent)]
+pub struct MetricError(#[from] pub eyre::Report);
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum Metric {
-    /// Counter delta; Used by:
-    /// [`MetricEmitter::count`] and [`MetricEmitter::incr`]
-    Count {
-        stat: String,
-        val: i64,
-        tags: Vec<String>,
-    },
-    /// Last point-in-time value;
-    /// Used by: [`MetricEmitter::gauge`]
-    Gauge {
-        stat: String,
-        val: f64,
-        tags: Vec<String>,
-    },
-    /// Metric aggregated by the **local Datadog agent**.
-    /// Percentiles are per-host only;
-    /// Used by [`MetricEmitter::hist`].
-    Histogram {
-        stat: String,
-        val: f64,
-        tags: Vec<String>,
-    },
-    /// Raw metrics are aggregated by the **Datadog's backend**.
-    /// Supports global percentiles and post-hoc tag splits.
-    /// Used by [`MetricEmitter::dist`].
-    Distribution {
-        stat: String,
-        val: f64,
-        tags: Vec<String>,
-    },
-}
-
-/// Sink for [`Metric`]s.
+/// Statsd-style metric sink.
 pub trait MetricEmitter: Send + Sync + 'static {
-    /// Queue `metric` for publishing
-    fn emit(&self, metric: Metric) -> Result<(), MetricError>;
+    /// Counter delta
+    fn count<S, I>(&self, stat: S, val: i64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>;
 
-    fn count(&self, stat: &str, val: i64, tags: &[&str]) -> Result<(), MetricError> {
-        self.emit(Metric::Count {
-            stat: stat.to_owned(),
-            val,
-            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
-        })
-    }
+    /// Single increment of a counter
+    fn incr<S, I>(&self, stat: S, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>;
 
-    fn gauge(&self, stat: &str, val: f64, tags: &[&str]) -> Result<(), MetricError> {
-        self.emit(Metric::Gauge {
-            stat: stat.to_owned(),
-            val,
-            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
-        })
-    }
+    /// Last point-in-time value;
+    fn gauge<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>;
 
-    fn incr(&self, stat: &str, tags: &[&str]) -> Result<(), MetricError> {
-        self.emit(Metric::Count {
-            stat: stat.to_owned(),
-            val: 1,
-            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
-        })
-    }
+    /// Metric aggregated by the **local Datadog agent**.
+    fn hist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>;
 
-    fn hist(&self, stat: &str, val: f64, tags: &[&str]) -> Result<(), MetricError> {
-        self.emit(Metric::Histogram {
-            stat: stat.to_owned(),
-            val,
-            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
-        })
-    }
-
-    fn dist(&self, stat: &str, val: f64, tags: &[&str]) -> Result<(), MetricError> {
-        self.emit(Metric::Distribution {
-            stat: stat.to_owned(),
-            val,
-            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
-        })
-    }
+    /// Metrics are aggregated by the **Datadog's backend**.
+    fn dist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>;
 }

--- a/orb-dogd/src/lib.rs
+++ b/orb-dogd/src/lib.rs
@@ -1,0 +1,109 @@
+//! sync, drop-on-overflow statsd client.
+//!
+//! [`MetricEmitter::emit`] queues a metric onto a bounded channel and returns
+//! immediately. A background worker (see [`DogstatsdClient`]) drains the
+//! channel and performs the UDP send to the metric collector.
+#![forbid(unsafe_code)]
+
+mod dd;
+pub use dd::DogstatsdClient;
+pub use dogstatsd::DogstatsdError;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod test;
+
+/// Failure of [`MetricEmitter::emit`].
+///
+/// Wraps the underlying channel's send error so the choice of channel
+/// implementation stays an internal detail of this crate.
+#[derive(thiserror::Error, Debug)]
+pub enum MetricError {
+    /// Channel at capacity. The rejected [`Metric`] is returned so
+    /// callers may retry or drop.
+    #[error("channel is at capacity")]
+    ChannelFull(Metric),
+    /// Consumer is closed. Every subsequent `emit` will also
+    /// fail with this variant.
+    #[error("channel is closed")]
+    ChannelClosed(Metric),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Metric {
+    /// Counter delta; Used by:
+    /// [`MetricEmitter::count`] and [`MetricEmitter::incr`]
+    Count {
+        stat: String,
+        val: i64,
+        tags: Vec<String>,
+    },
+    /// Last point-in-time value;
+    /// Used by: [`MetricEmitter::gauge`]
+    Gauge {
+        stat: String,
+        val: f64,
+        tags: Vec<String>,
+    },
+    /// Metric aggregated by the **local Datadog agent**.
+    /// Percentiles are per-host only;
+    /// Used by [`MetricEmitter::hist`].
+    Histogram {
+        stat: String,
+        val: f64,
+        tags: Vec<String>,
+    },
+    /// Raw metrics are aggregated by the **Datadog's backend**.
+    /// Supports global percentiles and post-hoc tag splits.
+    /// Used by [`MetricEmitter::dist`].
+    Distribution {
+        stat: String,
+        val: f64,
+        tags: Vec<String>,
+    },
+}
+
+/// Sink for [`Metric`]s.
+pub trait MetricEmitter: Send + Sync + 'static {
+    /// Queue `metric` for publishing
+    fn emit(&self, metric: Metric) -> Result<(), MetricError>;
+
+    fn count(&self, stat: &str, val: i64, tags: &[&str]) -> Result<(), MetricError> {
+        self.emit(Metric::Count {
+            stat: stat.to_owned(),
+            val,
+            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
+        })
+    }
+
+    fn gauge(&self, stat: &str, val: f64, tags: &[&str]) -> Result<(), MetricError> {
+        self.emit(Metric::Gauge {
+            stat: stat.to_owned(),
+            val,
+            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
+        })
+    }
+
+    fn incr(&self, stat: &str, tags: &[&str]) -> Result<(), MetricError> {
+        self.emit(Metric::Count {
+            stat: stat.to_owned(),
+            val: 1,
+            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
+        })
+    }
+
+    fn hist(&self, stat: &str, val: f64, tags: &[&str]) -> Result<(), MetricError> {
+        self.emit(Metric::Histogram {
+            stat: stat.to_owned(),
+            val,
+            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
+        })
+    }
+
+    fn dist(&self, stat: &str, val: f64, tags: &[&str]) -> Result<(), MetricError> {
+        self.emit(Metric::Distribution {
+            stat: stat.to_owned(),
+            val,
+            tags: tags.iter().map(|t| (*t).to_owned()).collect(),
+        })
+    }
+}

--- a/orb-dogd/src/test.rs
+++ b/orb-dogd/src/test.rs
@@ -5,11 +5,12 @@
 
 use std::sync::{Arc, Mutex};
 
-use super::{Metric, MetricEmitter, MetricError};
+use super::dd::Metric;
+use super::{MetricEmitter, MetricError};
 
-/// In-memory recorder for [`Metric`]s. Cheap to [`Clone`] — clones share the
-/// same record buffer, so a test can keep a handle for assertions while
-/// passing another clone into the code under test.
+/// Counts emitted metrics. Clones share the same record buffer, so a test
+/// can keep a handle for assertions while passing another clone into the
+/// code under test.
 #[derive(Clone, Default)]
 pub struct MetricRecorder {
     records: Arc<Mutex<Vec<Metric>>>,
@@ -20,14 +21,89 @@ impl MetricRecorder {
         Self::default()
     }
 
-    /// Snapshot of every [`Metric`] emitted so far.
-    pub fn records(&self) -> Vec<Metric> {
+    /// Number of metrics emitted so far.
+    pub fn len(&self) -> usize {
+        self.records.lock().expect("mutex poisoned").len()
+    }
+
+    /// Whether any metric has been emitted yet.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[cfg(test)]
+    pub(crate) fn records(&self) -> Vec<Metric> {
         self.records.lock().expect("mutex poisoned").clone()
     }
 }
 
 impl MetricEmitter for MetricRecorder {
-    fn emit(&self, metric: Metric) -> Result<(), MetricError> {
+    fn count<S, I>(&self, stat: S, val: i64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Count {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.records.lock().expect("mutex poisoned").push(metric);
+        Ok(())
+    }
+
+    fn incr<S, I>(&self, stat: S, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Count {
+            stat: stat.into(),
+            val: 1,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.records.lock().expect("mutex poisoned").push(metric);
+        Ok(())
+    }
+
+    fn gauge<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Gauge {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.records.lock().expect("mutex poisoned").push(metric);
+        Ok(())
+    }
+
+    fn hist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Histogram {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.records.lock().expect("mutex poisoned").push(metric);
+        Ok(())
+    }
+
+    fn dist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Distribution {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
         self.records.lock().expect("mutex poisoned").push(metric);
         Ok(())
     }
@@ -38,54 +114,87 @@ impl MetricEmitter for MetricRecorder {
 pub struct MetricSinkhole;
 
 impl MetricEmitter for MetricSinkhole {
-    fn emit(&self, _: Metric) -> Result<(), MetricError> {
+    fn count<S, I>(&self, _: S, _: i64, _: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        Ok(())
+    }
+
+    fn incr<S, I>(&self, _: S, _: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        Ok(())
+    }
+
+    fn gauge<S, I>(&self, _: S, _: f64, _: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        Ok(())
+    }
+
+    fn hist<S, I>(&self, _: S, _: f64, _: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        Ok(())
+    }
+
+    fn dist<S, I>(&self, _: S, _: f64, _: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::NO_TAGS;
+
     use super::*;
 
     #[test]
     fn count_records_count_variant() {
         let r = MetricRecorder::new();
-        r.count("topic", 3, &["k:v"]).unwrap();
+        r.count("topic", 3, NO_TAGS).unwrap();
         assert_eq!(
             r.records(),
             vec![Metric::Count {
                 stat: "topic".to_owned(),
                 val: 3,
-                tags: vec!["k:v".to_owned()],
+                tags: vec![],
             }],
         );
     }
 
-    /// Validates the cross-thread contract of [`MetricEmitter`]:
-    /// many threads emit concurrently through a shared `Arc<dyn MetricEmitter>`,
-    /// and every emission lands in the shared record buffer.
-    ///
-    /// Compiling this test relies on `MetricEmitter: Send + Sync + 'static`
-    /// and on [`MetricRecorder`]'s internal `Arc<Mutex<_>>` (so every clone
-    /// observes the same buffer).
+    /// Many threads emit concurrently through a shared recorder, and every
+    /// emission lands in the shared record buffer.
     #[test]
     fn recorder_collects_emissions_across_threads() {
         const THREADS: usize = 8;
         const PER_THREAD: usize = 8;
 
         let recorder = MetricRecorder::new();
-        let emitter: Arc<dyn MetricEmitter> = Arc::new(recorder.clone());
+        let emitter = Arc::new(recorder.clone());
 
         std::thread::scope(|s| {
             for _ in 0..THREADS {
                 s.spawn(|| {
                     for _ in 0..PER_THREAD {
-                        emitter.count("topic", 1, &[]).unwrap();
+                        emitter.count("topic", 1, ["k:v"]).unwrap();
                     }
                 });
             }
         });
 
-        assert_eq!(recorder.records().len(), THREADS * PER_THREAD);
+        assert_eq!(recorder.len(), THREADS * PER_THREAD);
     }
 }

--- a/orb-dogd/src/test.rs
+++ b/orb-dogd/src/test.rs
@@ -1,0 +1,91 @@
+//! Test purposed [`MetricEmitter`] implementations.
+//!
+//! Gated behind the `testing` feature; intended for `dev-dependencies` of
+//! crates that want to assert on emitted metrics.
+
+use std::sync::{Arc, Mutex};
+
+use super::{Metric, MetricEmitter, MetricError};
+
+/// In-memory recorder for [`Metric`]s. Cheap to [`Clone`] — clones share the
+/// same record buffer, so a test can keep a handle for assertions while
+/// passing another clone into the code under test.
+#[derive(Clone, Default)]
+pub struct MetricRecorder {
+    records: Arc<Mutex<Vec<Metric>>>,
+}
+
+impl MetricRecorder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of every [`Metric`] emitted so far.
+    pub fn records(&self) -> Vec<Metric> {
+        self.records.lock().expect("mutex poisoned").clone()
+    }
+}
+
+impl MetricEmitter for MetricRecorder {
+    fn emit(&self, metric: Metric) -> Result<(), MetricError> {
+        self.records.lock().expect("mutex poisoned").push(metric);
+        Ok(())
+    }
+}
+
+/// [`MetricEmitter`] that drops every metric on the floor. Useful when test
+/// code requires some emitter but assertions don't care what was emitted.
+pub struct MetricSinkhole;
+
+impl MetricEmitter for MetricSinkhole {
+    fn emit(&self, _: Metric) -> Result<(), MetricError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_records_count_variant() {
+        let r = MetricRecorder::new();
+        r.count("topic", 3, &["k:v"]).unwrap();
+        assert_eq!(
+            r.records(),
+            vec![Metric::Count {
+                stat: "topic".to_owned(),
+                val: 3,
+                tags: vec!["k:v".to_owned()],
+            }],
+        );
+    }
+
+    /// Validates the cross-thread contract of [`MetricEmitter`]:
+    /// many threads emit concurrently through a shared `Arc<dyn MetricEmitter>`,
+    /// and every emission lands in the shared record buffer.
+    ///
+    /// Compiling this test relies on `MetricEmitter: Send + Sync + 'static`
+    /// and on [`MetricRecorder`]'s internal `Arc<Mutex<_>>` (so every clone
+    /// observes the same buffer).
+    #[test]
+    fn recorder_collects_emissions_across_threads() {
+        const THREADS: usize = 8;
+        const PER_THREAD: usize = 8;
+
+        let recorder = MetricRecorder::new();
+        let emitter: Arc<dyn MetricEmitter> = Arc::new(recorder.clone());
+
+        std::thread::scope(|s| {
+            for _ in 0..THREADS {
+                s.spawn(|| {
+                    for _ in 0..PER_THREAD {
+                        emitter.count("topic", 1, &[]).unwrap();
+                    }
+                });
+            }
+        });
+
+        assert_eq!(recorder.records().len(), THREADS * PER_THREAD);
+    }
+}


### PR DESCRIPTION
after following @vmenge commands semi-religiously, this might do?

Main points:
- fire and forgets mentality on metrics
- default implementation spins a thread hosting the interaction between dogstatsd <-> process. 
- [testing] feature hosts implementations for mocking the MetricsEmitter & for testing the process logic from a recorder 