### PR TITLE
fix(dogd): use a bounded channel

### DIFF
--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -1,5 +1,5 @@
 use dogstatsd::Client;
-use flume::Sender;
+use flume::{Sender, TrySendError};
 use std::{fs, path::Path, thread, time::Duration};
 use tracing::{error, info, warn};
 
@@ -10,7 +10,7 @@ pub struct DogstatsdClient {
 }
 
 const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
-const DOGSTATD_BACKOFF: Duration = Duration::from_secs(3);
+const DOGSTATSD_BACKOFF: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Metric {
@@ -57,7 +57,7 @@ impl DogstatsdClient {
     ///
     /// Fails if the underlying socket cannot be bound.
     pub fn new() -> Self {
-        let (tx, rx) = flume::unbounded();
+        let (tx, rx) = flume::bounded(512);
 
         thread::spawn(move || {
             let client = loop {
@@ -79,10 +79,10 @@ impl DogstatsdClient {
 
                 error!(
                     "{err_msg}. waiting {}s and trying again",
-                    DOGSTATD_BACKOFF.as_secs()
+                    DOGSTATSD_BACKOFF.as_secs()
                 );
 
-                thread::sleep(DOGSTATD_BACKOFF);
+                thread::sleep(DOGSTATSD_BACKOFF);
             };
 
             while let Ok(metric) = rx.recv() {
@@ -114,6 +114,14 @@ impl DogstatsdClient {
 
         Self { tx }
     }
+
+    fn emit(&self, metric: Metric) -> Result<(), MetricError> {
+        self.tx.try_send(metric).map_err(|e| match e {
+            TrySendError::Full(_) => eyre::eyre!("transport channel is full: {e:#?}"),
+            TrySendError::Disconnected(_) => eyre::eyre!("worker has died: {e:#?}"),
+        })?;
+        Ok(())
+    }
 }
 
 impl MetricEmitter for DogstatsdClient {
@@ -127,11 +135,7 @@ impl MetricEmitter for DogstatsdClient {
             val,
             tags: tags.into_iter().map(Into::into).collect(),
         };
-        self.tx
-            .send(metric)
-            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
-
-        Ok(())
+        self.emit(metric)
     }
 
     fn incr<S, I>(&self, stat: S, tags: I) -> Result<(), MetricError>
@@ -144,11 +148,7 @@ impl MetricEmitter for DogstatsdClient {
             val: 1,
             tags: tags.into_iter().map(Into::into).collect(),
         };
-        self.tx
-            .send(metric)
-            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
-
-        Ok(())
+        self.emit(metric)
     }
 
     fn gauge<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
@@ -161,11 +161,7 @@ impl MetricEmitter for DogstatsdClient {
             val,
             tags: tags.into_iter().map(Into::into).collect(),
         };
-        self.tx
-            .send(metric)
-            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
-
-        Ok(())
+        self.emit(metric)
     }
 
     fn hist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
@@ -178,11 +174,7 @@ impl MetricEmitter for DogstatsdClient {
             val,
             tags: tags.into_iter().map(Into::into).collect(),
         };
-        self.tx
-            .send(metric)
-            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
-
-        Ok(())
+        self.emit(metric)
     }
 
     fn dist<S, I>(&self, stat: S, val: f64, tags: I) -> Result<(), MetricError>
@@ -195,10 +187,6 @@ impl MetricEmitter for DogstatsdClient {
             val,
             tags: tags.into_iter().map(Into::into).collect(),
         };
-        self.tx
-            .send(metric)
-            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
-
-        Ok(())
+        self.emit(metric)
     }
 }


### PR DESCRIPTION
- use a bounded channel since we moved the client initialization to the worker thread to avoid the extreme case of an unbounded memory leak
- use again an `emit` function DRY