### PR TITLE
feat(backend-status): backend status v2 endpoint metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8069,6 +8069,7 @@ dependencies = [
  "orb-backend-status-dbus",
  "orb-build-info",
  "orb-connd-dbus",
+ "orb-dogd",
  "orb-endpoints",
  "orb-info",
  "orb-messages 0.0.0 (git+https://github.com/worldcoin/orb-messages?rev=af472fadb57ce55ac63f8f94bd2a0608e62405c7)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ orb-build-info.path = "build-info"
 orb-connd.path = "orb-connd"
 orb-connd-dbus.path = "orb-connd/dbus"
 orb-const-concat.path = "const-concat"
+orb-dogd.path = "orb-dogd"
 orb-endpoints.path = "endpoints"
 orb-header-parsing.path = "header-parsing"
 orb-info = { path = "orb-info", default-features = false }

--- a/orb-backend-status/Cargo.toml
+++ b/orb-backend-status/Cargo.toml
@@ -31,6 +31,7 @@ orb-info = { workspace = true, features = [
 	"orb-name",
 	"orb-token",
 ] }
+orb-dogd.workspace = true
 orb-telemetry = { workspace = true, features = ["otel", "zbus-tracing"] }
 orb-update-agent-dbus.workspace = true
 reqwest = { workspace = true, features = ["json"] }

--- a/orb-backend-status/src/backend/client.rs
+++ b/orb-backend-status/src/backend/client.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use color_eyre::Result;
 use derive_more::From;
 use eyre::Context;
+use orb_dogd::MetricEmitter;
 use orb_info::{OrbId, OrbJabilId, OrbName};
 use reqwest::{Response, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
@@ -44,6 +45,7 @@ impl Drop for StatusClient {
 impl StatusClient {
     #[builder]
     pub fn new(
+        metrics: impl MetricEmitter,
         orb_id: OrbId,
         orb_name: OrbName,
         jabil_id: OrbJabilId,
@@ -130,14 +132,28 @@ impl StatusClient {
                                 ..req
                             };
 
-                            client
+                            let response = client
                                 .post(endpoint.clone())
                                 .json(&req)
                                 .basic_auth(&orb_id, Some(attest_token.clone()))
                                 .send()
                                 .await
                                 .wrap_err("failed to send request")
-                                .map_err(Err::Other)
+                                .map_err(Err::Other);
+
+                            let ok_tag = if response.is_ok() {
+                                "ok:true"
+                            } else {
+                                "ok:false"
+                            };
+
+                            let _ = metrics.count(
+                                "orb.platform.backend_status.client_req",
+                                1,
+                                [ok_tag]
+                            );
+
+                            response
                         };
 
                         let _ = res_tx.send(res);

--- a/orb-backend-status/src/backend/client.rs
+++ b/orb-backend-status/src/backend/client.rs
@@ -12,7 +12,7 @@ use reqwest::{Response, Url};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Extension};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use reqwest_tracing::{OtelName, TracingMiddleware};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::{
     sync::{oneshot, watch},
     task::{AbortHandle, JoinHandle},
@@ -132,6 +132,7 @@ impl StatusClient {
                                 ..req
                             };
 
+                            let start = Instant::now();
                             let response = client
                                 .post(endpoint.clone())
                                 .json(&req)
@@ -140,6 +141,7 @@ impl StatusClient {
                                 .await
                                 .wrap_err("failed to send request")
                                 .map_err(Err::Other);
+                            let elapsed = start.elapsed().as_millis();
 
                             let ok_tag = if response.is_ok() {
                                 "ok:true"
@@ -150,6 +152,12 @@ impl StatusClient {
                             let _ = metrics.count(
                                 "orb.platform.backend_status.client_req",
                                 1,
+                                [ok_tag]
+                            );
+
+                            let _ = metrics.dist(
+                                "orb.platform.backend_status.client_req_duration",
+                                elapsed as f64,
                                 [ok_tag]
                             );
 

--- a/orb-backend-status/src/lib.rs
+++ b/orb-backend-status/src/lib.rs
@@ -20,6 +20,7 @@ use collectors::{
 use color_eyre::eyre::Result;
 use dbus::{intf_impl::BackendStatusImpl, setup_dbus};
 use orb_build_info::{make_build_info, BuildInfo};
+use orb_dogd::MetricEmitter;
 use orb_info::{OrbId, OrbJabilId, OrbName};
 use reqwest::Url;
 use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
@@ -44,6 +45,7 @@ fn boot_id_payload(boot_id: String) -> Result<Payload> {
 
 #[bon::builder(finish_fn = run)]
 pub async fn program(
+    metrics: impl MetricEmitter,
     dbus: zbus::Connection,
     zsession: &ZSession,
     endpoint: Url,
@@ -79,6 +81,7 @@ pub async fn program(
         watch::channel(GlobalConnectivity::NotConnected);
 
     let status_client = StatusClient::builder()
+        .metrics(metrics)
         .orb_id(orb_id)
         .orb_name(orb_name)
         .jabil_id(orb_jabil_id)

--- a/orb-backend-status/src/main.rs
+++ b/orb-backend-status/src/main.rs
@@ -1,5 +1,6 @@
 use color_eyre::eyre::Result;
 use orb_backend_status::backend::os_version::orb_os_version;
+use orb_dogd::DogstatsdClient;
 use orb_endpoints::{v2::Endpoints, Backend};
 use orb_info::{OrbId, OrbJabilId, OrbName};
 use reqwest::Url;
@@ -52,6 +53,7 @@ async fn main() -> Result<()> {
         .await?;
 
     let result = orb_backend_status::program()
+        .metrics(DogstatsdClient::new())
         .dbus(zbus::Connection::session().await?)
         .zsession(&zsession)
         .endpoint(endpoint)

--- a/orb-backend-status/tests/fixture.rs
+++ b/orb-backend-status/tests/fixture.rs
@@ -2,6 +2,7 @@ use async_tempfile::TempDir;
 use color_eyre::Result;
 use dbus_launch::BusType;
 use oes::{ActiveConnections, NetworkInterface};
+use orb_dogd::DogstatsdClient;
 use orb_info::{OrbId, OrbJabilId, OrbName};
 use reqwest::Url;
 use std::{env, path::PathBuf, str::FromStr, time::Duration};
@@ -219,6 +220,7 @@ impl Fixture {
 
         let task = task::spawn(async move {
             let program = orb_backend_status::program()
+                .metrics(DogstatsdClient::new())
                 .dbus(dbus)
                 .zsession(&zsession)
                 .endpoint(endpoint)

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -1,13 +1,16 @@
-use dogstatsd::{Client, DogstatsdError, Options};
+use dogstatsd::Client;
 use flume::Sender;
-use std::thread;
-use tracing::warn;
+use std::{fs, path::Path, thread, time::Duration};
+use tracing::{error, info, warn};
 
 use super::{MetricEmitter, MetricError};
 
 pub struct DogstatsdClient {
     tx: Sender<Metric>,
 }
+
+const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
+const DOGSTATD_BACKOFF: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Metric {
@@ -43,17 +46,45 @@ pub(crate) enum Metric {
     },
 }
 
+impl Default for DogstatsdClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DogstatsdClient {
     /// Connect to the local statsd collector.
     ///
     /// Fails if the underlying socket cannot be bound.
-    pub fn new() -> Result<Self, DogstatsdError> {
+    pub fn new() -> Self {
         let (tx, rx) = flume::unbounded();
 
-        let datadog_options = Options::default();
-        let client = Client::new(datadog_options)?;
-
         thread::spawn(move || {
+            let client = loop {
+                let err_msg =
+                    if fs::exists(Path::new(DOGSTATSD_SOCKET_PATH)).unwrap_or(false) {
+                        info!("datadog-agent socket found, using it for IPC");
+
+                        let opts = dogstatsd::OptionsBuilder::new()
+                            .socket_path(Some(DOGSTATSD_SOCKET_PATH.to_string()))
+                            .build();
+
+                        match Client::new(opts) {
+                            Ok(client) => break client,
+                            Err(e) => format!("failed to create DD client {e}"),
+                        }
+                    } else {
+                        format!("{DOGSTATSD_SOCKET_PATH} not found")
+                    };
+
+                error!(
+                    "{err_msg}. waiting {}s and trying again",
+                    DOGSTATD_BACKOFF.as_secs()
+                );
+
+                thread::sleep(DOGSTATD_BACKOFF);
+            };
+
             while let Ok(metric) = rx.recv() {
                 match metric {
                     Metric::Count { stat, val, tags } => {
@@ -81,7 +112,7 @@ impl DogstatsdClient {
             }
         });
 
-        Ok(Self { tx })
+        Self { tx }
     }
 }
 

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -1,16 +1,10 @@
 use dogstatsd::Client;
-<<<<<<< HEAD
 use flume::Sender;
-||||||| 443f036d
-use dogstatsd::{Client, DogstatsdError, Options};
-use flume::Sender;
+use flume::TrySendError;
 use std::thread;
+use std::{fs, path::Path, time::Duration};
 use tracing::warn;
-=======
-use flume::{Sender, TrySendError};
->>>>>>> 10b36fdc992cf4fac6e1af3f8fef72ab73c95c99
-use std::{fs, path::Path, thread, time::Duration};
-use tracing::{error, info, warn};
+use tracing::{error, info};
 
 use super::{MetricEmitter, MetricError};
 
@@ -19,12 +13,7 @@ pub struct DogstatsdClient {
 }
 
 const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
-<<<<<<< HEAD
-const DOGSTATD_BACKOFF: Duration = Duration::from_secs(3);
-||||||| 443f036d
-=======
 const DOGSTATSD_BACKOFF: Duration = Duration::from_secs(3);
->>>>>>> 10b36fdc992cf4fac6e1af3f8fef72ab73c95c99
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Metric {
@@ -93,7 +82,7 @@ impl DogstatsdClient {
 
                 error!(
                     "{err_msg}. waiting {}s and trying again",
-                    DOGSTATD_BACKOFF.as_secs()
+                    DOGSTATSD_BACKOFF.as_secs()
                 );
 
                 thread::sleep(DOGSTATSD_BACKOFF);


### PR DESCRIPTION
## new
- uses `dogd` shared datadog client to submit success rate and latency distribution metrics for backend status v2 endpoint

## tested
- [x] on diamond dev orb