### PR TITLE
feat: add datadog timing metrics

### DIFF
--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -47,6 +47,13 @@ pub(crate) enum Metric {
         val: f64,
         tags: Vec<String>,
     },
+    /// Milliseconds latency value; emits Datadog's `|ms` type.
+    /// Used by [`MetricEmitter::timing`].
+    Timing {
+        stat: String,
+        val: i64,
+        tags: Vec<String>,
+    },
 }
 
 impl Default for DogstatsdClient {
@@ -108,6 +115,11 @@ impl DogstatsdClient {
                     Metric::Distribution { stat, val, tags } => {
                         if let Err(e) = client.distribution(stat, val.to_string(), tags)
                         {
+                            warn!("emitting metric failed with: {e}");
+                        }
+                    }
+                    Metric::Timing { stat, val, tags } => {
+                        if let Err(e) = client.timing(stat, val, tags) {
                             warn!("emitting metric failed with: {e}");
                         }
                     }
@@ -191,5 +203,22 @@ impl MetricEmitter for DogstatsdClient {
             tags: tags.into_iter().map(Into::into).collect(),
         };
         self.emit(metric)
+    }
+
+    fn timing<S, I>(&self, stat: S, val: i64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Timing {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.tx
+            .send(metric)
+            .map_err(|_| eyre::eyre!("metrics worker has died"))?;
+
+        Ok(())
     }
 }

--- a/orb-dogd/src/lib.rs
+++ b/orb-dogd/src/lib.rs
@@ -51,4 +51,11 @@ pub trait MetricEmitter: Send + Sync + 'static {
     where
         S: Into<String>,
         I: IntoIterator<Item: Into<String>>;
+
+    /// Latency in milliseconds; emits Datadog's `|ms` type, which the
+    /// backend treats as a timing-flavored histogram.
+    fn timing<S, I>(&self, stat: S, val: i64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>;
 }

--- a/orb-dogd/src/test.rs
+++ b/orb-dogd/src/test.rs
@@ -107,6 +107,20 @@ impl MetricEmitter for MetricRecorder {
         self.records.lock().expect("mutex poisoned").push(metric);
         Ok(())
     }
+
+    fn timing<S, I>(&self, stat: S, val: i64, tags: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        let metric = Metric::Timing {
+            stat: stat.into(),
+            val,
+            tags: tags.into_iter().map(Into::into).collect(),
+        };
+        self.records.lock().expect("mutex poisoned").push(metric);
+        Ok(())
+    }
 }
 
 /// [`MetricEmitter`] that drops every metric on the floor. Useful when test
@@ -147,6 +161,14 @@ impl MetricEmitter for MetricSinkhole {
     }
 
     fn dist<S, I>(&self, _: S, _: f64, _: I) -> Result<(), MetricError>
+    where
+        S: Into<String>,
+        I: IntoIterator<Item: Into<String>>,
+    {
+        Ok(())
+    }
+
+    fn timing<S, I>(&self, _: S, _: i64, _: I) -> Result<(), MetricError>
     where
         S: Into<String>,
         I: IntoIterator<Item: Into<String>>,


### PR DESCRIPTION
It is required to use the datadog crate in orb-core