### PR TITLE
feat(gondor): cleanup gondor invocations

### DIFF
--- a/hil/src/commands/ota/mod.rs
+++ b/hil/src/commands/ota/mod.rs
@@ -109,16 +109,29 @@ impl Ota {
             })?;
         info!("System time synchronized");
 
-        info!("Starting OTA via gondor-calls-for-ota");
-        let start_timestamp =
-            system::kickoff_update_agent_for_ota(&session, &self.target_version)
-                .await
-                .inspect_err(|e| {
-                    println!("OTA_RESULT=FAILED");
-                    println!("OTA_ERROR=OTA_KICKOFF_FAILED: {e}");
-                })?;
+        info!("Starting OTA");
+        let orb_id = orb_config
+            .orb_id
+            .as_deref()
+            .wrap_err("orb-id is required to kick off OTA")?;
+        let host = self
+            .remote
+            .hostname
+            .as_deref()
+            .wrap_err("--hostname (orb IP) is required to kick off OTA")?;
+        let start_timestamp = system::kickoff_update_agent_for_ota(
+            &session,
+            &self.target_version,
+            orb_id,
+            host,
+        )
+        .await
+        .inspect_err(|e| {
+            println!("OTA_RESULT=FAILED");
+            println!("OTA_ERROR=OTA_KICKOFF_FAILED: {e}");
+        })?;
         info!(
-            "gondor-calls-for-ota completed, start timestamp: {}",
+            "OTA kickoff completed, start timestamp: {}",
             start_timestamp
         );
 

--- a/hil/src/commands/ota/system.rs
+++ b/hil/src/commands/ota/system.rs
@@ -4,8 +4,6 @@ use color_eyre::{
     Result,
 };
 
-const GONDOR_CALLS_FOR_OTA_PATH: &str = "/usr/local/bin/gondor-calls-for-ota";
-
 /// Reboot the Orb device using orb-mcu-util and shutdown
 pub async fn reboot_orb(session: &RemoteSession) -> Result<()> {
     session
@@ -66,40 +64,35 @@ fn parse_slot_from_output(output: &str) -> Result<String> {
     Ok(format!("slot_{slot_letter}"))
 }
 
-/// Kick off the update-agent flow for OTA using gondor-calls-for-ota.
-///
-/// The target is passed through verbatim; gondor itself handles stripping any
-/// `-{platform}-{release}` suffix, rewriting `/etc/os-release`, and restarting
-/// the update agent.
+/// Kick off the update-agent flow for OTA.
 pub async fn kickoff_update_agent_for_ota(
     session: &RemoteSession,
     target_version: &str,
+    orb_id: &str,
+    orb_ip: &str,
 ) -> Result<String> {
     let start_timestamp = get_current_timestamp(session).await?;
 
-    let escaped_target = shell_single_quote_escape(target_version.trim());
-    let command =
-        format!("TERM=dumb sudo {GONDOR_CALLS_FOR_OTA_PATH} '{escaped_target}'");
-    let result = session
-        .execute_command(&command)
+    let payload = serde_json::json!({
+        "version": target_version.trim(),
+        "restart": true,
+    })
+    .to_string();
+
+    let output = tokio::process::Command::new("zorb")
+        .args(["-o", orb_id, "-r", orb_ip])
+        .args(["query", "supervisor/job/gondor", &payload])
+        .output()
         .await
-        .wrap_err("Failed to execute gondor-calls-for-ota")?;
+        .wrap_err("failed to spawn zorb on the runner")?;
 
     ensure!(
-        result.is_success(),
-        "gondor-calls-for-ota failed: {}",
-        if result.stderr.trim().is_empty() {
-            result.stdout.trim()
-        } else {
-            result.stderr.trim()
-        }
+        output.status.success(),
+        "failed to trigger OTA: {}",
+        String::from_utf8_lossy(&output.stderr).trim()
     );
 
     Ok(start_timestamp)
-}
-
-fn shell_single_quote_escape(value: &str) -> String {
-    value.replace('\'', "'\"'\"'")
 }
 
 /// Wait for system time to be synchronized via NTP/chrony
@@ -206,12 +199,6 @@ pub async fn get_current_timestamp(session: &RemoteSession) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn shell_single_quote_escape_escapes_correctly() {
-        let escaped = shell_single_quote_escape("abc'def");
-        assert_eq!(escaped, "abc'\"'\"'def");
-    }
 
     #[test]
     fn parse_chrony_reference_id_returns_id_when_synced() {

--- a/orb-info/Cargo.toml
+++ b/orb-info/Cargo.toml
@@ -27,7 +27,7 @@ orb-token = [
 serde = ["dep:serde"]
 
 [dependencies]
-derive_more.workspace = true
+derive_more = { workspace = true, features = ["display", "from_str"] }
 hex = { workspace = true, optional = true }
 orb-attest-dbus = { workspace = true, optional = true }
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/orb-info/src/orb_os_release.rs
+++ b/orb-info/src/orb_os_release.rs
@@ -1,4 +1,4 @@
-use derive_more::Display;
+use derive_more::{Display, FromStr};
 use std::collections::HashMap;
 use thiserror::Error;
 
@@ -20,7 +20,7 @@ pub enum ReadErr {
     UnknownPlatformType(String),
 }
 
-#[derive(Display, Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Display, FromStr, Debug, Clone, PartialEq, Eq, Copy)]
 pub enum OrbOsPlatform {
     #[display("diamond")]
     Diamond,
@@ -29,29 +29,29 @@ pub enum OrbOsPlatform {
     Pearl,
 }
 
-#[derive(Display, Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Display, FromStr, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OrbRelease {
-    #[display("dev")]
-    Dev,
-    #[display("service")]
-    Service,
-    #[display("prod")]
-    Prod,
-    #[display("stage")]
-    Stage,
     #[display("analysis")]
     Analysis,
+    #[display("dev")]
+    Dev,
+    #[display("prod")]
+    Prod,
+    #[display("service")]
+    Service,
+    #[display("stage")]
+    Stage,
 }
 
 impl OrbRelease {
     pub fn as_str(&self) -> &str {
         use OrbRelease::*;
         match self {
-            Dev => "dev",
-            Service => "service",
-            Stage => "staging",
-            Prod => "prod",
             Analysis => "analysis",
+            Dev => "dev",
+            Prod => "prod",
+            Service => "service",
+            Stage => "stage",
         }
     }
 }

--- a/supervisor/src/main.rs
+++ b/supervisor/src/main.rs
@@ -3,7 +3,7 @@ use clap::{
     Parser,
 };
 use color_eyre::eyre::WrapErr as _;
-use orb_info::OrbId;
+use orb_info::{orb_os_release::OrbOsRelease, OrbId};
 use orb_supervisor::startup::{Application, Settings};
 use tracing::debug;
 use zenorb::Zenorb;
@@ -44,6 +44,9 @@ async fn main() -> color_eyre::Result<()> {
         debug!(?settings, "starting supervisor with settings");
 
         let orb_id = OrbId::read().await.wrap_err("failed to read orb id")?;
+        let os_release = OrbOsRelease::read()
+            .await
+            .wrap_err("failed to read orb os release metadata")?;
         let zenorb = Zenorb::from_cfg(zenorb::default_cfg())
             .orb_id(orb_id)
             .with_name("supervisor")
@@ -54,7 +57,7 @@ async fn main() -> color_eyre::Result<()> {
             .await
             .wrap_err("failed to build supervisor")?;
 
-        application.run().await
+        application.run(os_release).await
     }
     .await;
     telemetry.flush().await;

--- a/supervisor/src/startup.rs
+++ b/supervisor/src/startup.rs
@@ -1,7 +1,8 @@
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use color_eyre::eyre::WrapErr as _;
 use futures::{future::TryFutureExt as _, FutureExt as _};
+use orb_info::orb_os_release::OrbOsRelease;
 use tracing::debug;
 use zbus::{Connection, ConnectionBuilder};
 use zenorb::Zenorb;
@@ -12,8 +13,11 @@ use crate::{
     proxies::core::{
         SIGNUP_PROXY_DEFAULT_OBJECT_PATH, SIGNUP_PROXY_DEFAULT_WELL_KNOWN_NAME,
     },
-    tasks,
-    tasks::zoci::GONDOR_BIN,
+    tasks::{
+        self,
+        update::UPDATE_AGENT_SERVICE,
+        zoci::{ZociContext, UPDATE_AGENT_VERSION},
+    },
 };
 
 pub const DBUS_WELL_KNOWN_NAME: &str = "org.worldcoin.OrbSupervisor1";
@@ -42,7 +46,6 @@ pub struct Settings {
     pub well_known_name: String,
     pub download_throttle: Duration,
     pub stop_core_after_signup: Duration,
-    pub gondor_bin: PathBuf,
 }
 
 impl Settings {
@@ -57,7 +60,6 @@ impl Settings {
             well_known_name: DBUS_WELL_KNOWN_NAME.to_string(),
             download_throttle: DEFAULT_DURATION_TO_ALLOW_DOWNLOADS,
             stop_core_after_signup: DURATION_TO_STOP_CORE_AFTER_LAST_SIGNUP,
-            gondor_bin: PathBuf::from(GONDOR_BIN),
         }
     }
 }
@@ -149,15 +151,22 @@ impl Application {
     }
 
     /// Runs `Application` by spawning its constituent tasks.
-    pub async fn run(self) -> color_eyre::Result<()> {
+    pub async fn run(self, os_release: OrbOsRelease) -> color_eyre::Result<()> {
         let signup_started_task =
             tasks::spawn_signup_started_task(&self.settings, &self.session_connection)
                 .await?;
 
-        let _ =
-            tasks::spawn_zoci_receiver(&self.zenorb, self.settings.gondor_bin.clone())
-                .await
-                .wrap_err("failed to spawn zoci receiver")?;
+        let _ = tasks::spawn_zoci_receiver(
+            &self.zenorb,
+            ZociContext {
+                os_release,
+                system_conn: self.system_connection.clone(),
+                update_agent_unit: UPDATE_AGENT_SERVICE,
+                target_version_env: UPDATE_AGENT_VERSION,
+            },
+        )
+        .await
+        .wrap_err("failed to spawn zoci receiver")?;
 
         let ((),) = tokio::try_join!(
             // All tasks are joined here

--- a/supervisor/src/tasks/update.rs
+++ b/supervisor/src/tasks/update.rs
@@ -10,6 +10,8 @@ use zbus_systemd::systemd1;
 
 use crate::consts::WORLDCOIN_CORE_UNIT_NAME;
 
+pub const UPDATE_AGENT_SERVICE: &str = "worldcoin-update-agent.service";
+
 /// Calculates the instant that is `stop_core_after_signup` after the last signup event.
 fn calculate_stop_deadline(
     last_signup_started_event: Instant,
@@ -94,7 +96,7 @@ pub fn spawn_start_update_agent_after_core_shutdown_task(
         }
         info!("calling `org.freedesktop.systemd1.Manager.StartUnit` to start update agent");
         proxy
-            .start_unit("worldcoin-update-agent.service".into(), "replace".into())
+            .start_unit(UPDATE_AGENT_SERVICE.into(), "replace".into())
             .await
             .map(|_| {})
             .map_err(Into::into)

--- a/supervisor/src/tasks/zoci.rs
+++ b/supervisor/src/tasks/zoci.rs
@@ -24,7 +24,7 @@ impl TryFrom<&Query> for UpdateRequest {
             Ok(req) => Ok(req),
             Err(_) => Ok(UpdateRequest {
                 version: query.payload_str()?.into_owned(),
-                restart: false,
+                restart: true,
             }),
         }
     }
@@ -114,7 +114,7 @@ async fn trigger_update(ctx: &ZociContext, query: &Query) -> Result<()> {
     );
 
     info!(
-        "`gondor` handler executing with: version={} & restart={}",
+        "`gondor` handler executing with: version={} & restart-service={}",
         version, update_to.restart
     );
 

--- a/supervisor/src/tasks/zoci.rs
+++ b/supervisor/src/tasks/zoci.rs
@@ -1,77 +1,168 @@
-use std::{borrow::Cow, path::PathBuf};
-
-use color_eyre::{
-    eyre::{eyre, WrapErr},
-    Result,
-};
+use color_eyre::Result;
+use orb_info::orb_os_release::{OrbOsPlatform, OrbOsRelease, OrbRelease};
 use serde::Deserialize;
-use tokio::process::Command;
+use std::borrow::Cow;
 use tokio::task::JoinHandle;
-use tracing::{field, info, instrument, warn, Span};
+use tracing::{info, instrument, warn};
+use zbus_systemd::systemd1::ManagerProxy;
 use zenorb::{zenoh::query::Query, zoci::ZociQueryExt, Zenorb};
 
+pub const UPDATE_AGENT_VERSION: &str = "ORB_UPDATE_AGENT_VERSION_OVERWRITE";
+
 #[derive(Deserialize)]
-struct GondorRequest {
-    version: String,
+struct UpdateRequest {
+    pub version: String,
     #[serde(default)]
-    no_restart: bool,
+    pub restart: bool,
 }
 
-pub const GONDOR_BIN: &str = "/usr/local/bin/gondor-calls-for-ota";
+impl TryFrom<&Query> for UpdateRequest {
+    type Error = color_eyre::Report;
+
+    fn try_from(query: &Query) -> Result<Self> {
+        match query.json::<UpdateRequest>() {
+            Ok(req) => Ok(req),
+            Err(_) => Ok(UpdateRequest {
+                version: query.payload_str()?.into_owned(),
+                restart: false,
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ZociContext {
+    pub os_release: OrbOsRelease,
+    pub system_conn: zbus::Connection,
+    pub update_agent_unit: &'static str,
+    pub target_version_env: &'static str,
+}
 
 pub async fn spawn_zoci_receiver(
     zenorb: &Zenorb,
-    gondor_bin: PathBuf,
+    ctx: ZociContext,
 ) -> Result<Vec<JoinHandle<()>>> {
     zenorb
-        .receiver(gondor_bin)
-        .queryable("job/gondor", gondor)
+        .receiver(ctx)
+        .queryable("job/gondor", run_handler)
         .run()
         .await
 }
 
-#[instrument(
-    skip(query),
-    fields(key_expr = %query.key_expr(), version = field::Empty, no_restart = field::Empty),
-)]
-async fn gondor(gondor_bin: PathBuf, query: Query) -> Result<()> {
-    let response = async {
-        let (version, no_restart): (Cow<'_, str>, bool) =
-            match query.json::<GondorRequest>() {
-                Ok(req) => (Cow::Owned(req.version), req.no_restart),
-                Err(_) => (query.payload_str()?, false),
-            };
+async fn export_update_version(
+    conn: &zbus::Connection,
+    var: &str,
+    value: &str,
+) -> Result<()> {
+    let manager = ManagerProxy::new(conn).await?;
+    manager
+        .set_environment(vec![format!("{var}={value}")])
+        .await?;
+    Ok(())
+}
 
-        Span::current().record("version", version.as_ref());
-        Span::current().record("no_restart", no_restart);
+async fn restart_unit(conn: &zbus::Connection, unit: &str) -> Result<()> {
+    let manager = ManagerProxy::new(conn).await?;
+    let _job_path = manager.restart_unit(unit.into(), "replace".into()).await?;
+    Ok(())
+}
 
-        info!(
-            "received gondor query for version {version} (no_restart={no_restart}), running {}",
-            gondor_bin.display()
-        );
-
-        let mut cmd = Command::new(&gondor_bin);
-        cmd.arg(version.as_ref());
-        if no_restart {
-            cmd.arg("--no-restart");
-        }
-        let output = cmd.output().await.wrap_err("failed to spawn gondor")?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(eyre!("gondor failed: {stderr}"));
-        }
-
-        info!("gondor succeeded for version {version}");
-        Ok::<_, color_eyre::Report>(())
+/// Returns a [`Cow<'_, str>`] of the expected release version
+///
+/// if the provided version matches the expected version format of `*-<platform>-<release>`, it is
+/// returned as is; If the suffix validation fails, the proper suffix is concatenated to `version`
+/// using metadata retrieved from the running system
+fn derive_version(
+    target: &str,
+    platform: OrbOsPlatform,
+    release: OrbRelease,
+) -> Cow<'_, str> {
+    let mut suffix = target.rsplitn(3, '-');
+    let already_suffixed = matches!(
+        (suffix.next(), suffix.next(), suffix.next()),
+        (Some(r), Some(p), Some(rest))
+            if !rest.is_empty()
+                && r.parse::<OrbRelease>().is_ok()
+                && p.parse::<OrbOsPlatform>().is_ok()
+    );
+    if already_suffixed {
+        target.into()
+    } else {
+        format!("{target}-{platform}-{release}").into()
     }
-    .await
-    .map_err(|e| {
-        warn!("gondor handler failed: {e}");
+}
+
+async fn run_handler(ctx: ZociContext, query: Query) -> Result<()> {
+    let response = trigger_update(&ctx, &query).await.map_err(|e| {
+        warn!("`gondor` handler failed: {e}");
         e.to_string()
     });
 
     query.res(response).await?;
 
     Ok(())
+}
+
+#[instrument(skip(ctx, query))]
+async fn trigger_update(ctx: &ZociContext, query: &Query) -> Result<()> {
+    let update_to = UpdateRequest::try_from(query)?;
+
+    let version = derive_version(
+        &update_to.version,
+        ctx.os_release.orb_os_platform_type,
+        ctx.os_release.release_type,
+    );
+
+    info!(
+        "`gondor` handler executing with: version={} & restart={}",
+        version, update_to.restart
+    );
+
+    export_update_version(&ctx.system_conn, ctx.target_version_env, &version).await?;
+
+    if update_to.restart {
+        restart_unit(&ctx.system_conn, ctx.update_agent_unit).await?;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_when_input_carries_a_valid_suffix() {
+        assert_eq!(
+            derive_version(
+                "to-0.0.0-abcabc-diamond-stage",
+                OrbOsPlatform::Diamond,
+                OrbRelease::Prod,
+            )
+            .as_ref(),
+            "to-0.0.0-abcabc-diamond-stage",
+        );
+    }
+
+    #[test]
+    fn appends_suffix_when_missing() {
+        assert_eq!(
+            derive_version("to-main", OrbOsPlatform::Diamond, OrbRelease::Prod)
+                .as_ref(),
+            "to-main-diamond-prod",
+        );
+    }
+
+    #[test]
+    fn appends_when_last_two_segments_do_not_parse_as_enums() {
+        assert_eq!(
+            derive_version(
+                "to-feature-foo-bar",
+                OrbOsPlatform::Diamond,
+                OrbRelease::Prod,
+            )
+            .as_ref(),
+            "to-feature-foo-bar-diamond-prod",
+        );
+    }
 }

--- a/supervisor/tests/it/helpers.rs
+++ b/supervisor/tests/it/helpers.rs
@@ -1,8 +1,16 @@
-use std::{io, str::FromStr, time::Duration};
+use std::{
+    io,
+    str::FromStr,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use dbus_launch::{BusType, Daemon};
 use once_cell::sync::Lazy;
-use orb_info::OrbId;
+use orb_info::{
+    orb_os_release::{OrbOsPlatform, OrbOsRelease, OrbRelease},
+    OrbId,
+};
 use orb_supervisor::startup::{Application, Settings};
 use tokio::task::JoinHandle;
 use zbus::{
@@ -62,6 +70,17 @@ pub async fn spawn_supervisor_service(
     Lazy::force(&TRACING);
     let application = Application::build(settings.clone(), zenorb).await?;
     Ok(application)
+}
+
+/// Fixture `OrbOsRelease` for tests — Diamond/Prod, fixed version metadata.
+pub fn fixture_os_release() -> OrbOsRelease {
+    OrbOsRelease {
+        release_type: OrbRelease::Prod,
+        orb_os_platform_type: OrbOsPlatform::Diamond,
+        orb_os_version: "7.0.0".to_string(),
+        expected_main_mcu_version: "v3.0.15".to_string(),
+        expected_sec_mcu_version: "v3.0.15".to_string(),
+    }
 }
 
 /// A self-contained `Zenorb` that doesn't connect to anything. Suitable for tests
@@ -169,7 +188,16 @@ pub async fn start_signup_service_and_send_signal(
     Ok(())
 }
 
-struct Manager;
+/// Shared handle to record calls captured by the mock `org.freedesktop.systemd1.Manager`.
+#[derive(Clone, Default)]
+pub struct SystemdCaptured {
+    pub set_environment: Arc<Mutex<Vec<Vec<String>>>>,
+    pub restart_unit: Arc<Mutex<Vec<String>>>,
+}
+
+pub struct Manager {
+    captured: SystemdCaptured,
+}
 
 #[interface(name = "org.freedesktop.systemd1.Manager")]
 impl Manager {
@@ -197,6 +225,33 @@ impl Manager {
     ) -> fdo::Result<OwnedObjectPath> {
         tracing::debug!(name, _mode, "StopUnit called");
         OwnedObjectPath::try_from("/org/freedesktop/systemd1/job/1234")
+            .map_err(move |_| fdo::Error::UnknownObject(name))
+    }
+
+    #[zbus(name = "SetEnvironment")]
+    async fn set_environment(&self, assignments: Vec<String>) -> fdo::Result<()> {
+        tracing::debug!(?assignments, "SetEnvironment called");
+        self.captured
+            .set_environment
+            .lock()
+            .unwrap()
+            .push(assignments);
+        Ok(())
+    }
+
+    #[zbus(name = "RestartUnit")]
+    async fn restart_unit(
+        &self,
+        name: String,
+        _mode: String,
+    ) -> fdo::Result<OwnedObjectPath> {
+        tracing::debug!(name, _mode, "RestartUnit called");
+        self.captured
+            .restart_unit
+            .lock()
+            .unwrap()
+            .push(name.clone());
+        OwnedObjectPath::try_from("/org/freedesktop/systemd1/job/4242")
             .map_err(move |_| fdo::Error::UnknownObject(name))
     }
 }
@@ -233,10 +288,14 @@ impl CoreService {
 
 pub async fn start_interfaces(
     dbus_instances: &DbusInstances,
-) -> zbus::Result<zbus::Connection> {
+) -> zbus::Result<(zbus::Connection, SystemdCaptured)> {
+    let captured = SystemdCaptured::default();
+    let manager = Manager {
+        captured: captured.clone(),
+    };
     let conn = zbus::ConnectionBuilder::address(dbus_instances.system.address())?
         .name(zbus_systemd::systemd1::ManagerProxy::DESTINATION.unwrap())?
-        .serve_at(zbus_systemd::systemd1::ManagerProxy::PATH.unwrap(), Manager)?
+        .serve_at(zbus_systemd::systemd1::ManagerProxy::PATH.unwrap(), manager)?
         .serve_at(WORLDCOIN_CORE_SERVICE_OBJECT_PATH, CoreService)?
         .serve_at(
             WORLDCOIN_CORE_SERVICE_OBJECT_PATH,
@@ -246,5 +305,5 @@ pub async fn start_interfaces(
         )?
         .build()
         .await?;
-    Ok(conn)
+    Ok((conn, captured))
 }

--- a/supervisor/tests/it/main.rs
+++ b/supervisor/tests/it/main.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, time::Duration};
+use std::time::Duration;
 
 use tap::TapFallible;
 use tracing::error;
@@ -15,7 +15,8 @@ async fn supervisor_disallows_downloads_if_signup_started_received(
 
     let application =
         helpers::spawn_supervisor_service(settings.clone(), zenorb).await?;
-    let _application_handle = tokio::spawn(application.run());
+    let _application_handle =
+        tokio::spawn(application.run(helpers::fixture_os_release()));
 
     let update_agent_proxy =
         helpers::make_update_agent_proxy(&settings, &dbus_instances).await?;
@@ -53,14 +54,15 @@ async fn supervisor_stops_orb_core_when_update_permission_is_requested(
     let application =
         helpers::spawn_supervisor_service(settings.clone(), zenorb).await?;
 
-    let _application_handle = tokio::spawn(application.run());
+    let _application_handle =
+        tokio::spawn(application.run(helpers::fixture_os_release()));
 
     // Let the stop-core deadline elapse so the shutdown task is willing to fire immediately.
     tokio::time::sleep(helpers::TEST_STOP_CORE_AFTER_SIGNUP * 2).await;
 
     let update_agent_proxy =
         helpers::make_update_agent_proxy(&settings, &dbus_instances).await?;
-    let system_conn = helpers::start_interfaces(&dbus_instances).await?;
+    let (system_conn, _captured) = helpers::start_interfaces(&dbus_instances).await?;
 
     let request_update_permission_task = tokio::task::spawn(async move {
         update_agent_proxy.request_update_permission().await
@@ -103,148 +105,42 @@ async fn application_serves_gondor_zoci_handler_end_to_end() -> color_eyre::Resu
     let (_router, supervisor_zenorb, client_zenorb) =
         helpers::spawn_zenoh_router_and_clients("supervisor", "test-client").await?;
 
-    let mut settings = helpers::make_settings(&dbus_instances);
-    settings.gondor_bin = PathBuf::from("/bin/true");
+    let (_system_conn, captured) = helpers::start_interfaces(&dbus_instances).await?;
 
+    let settings = helpers::make_settings(&dbus_instances);
     let application =
         helpers::spawn_supervisor_service(settings, supervisor_zenorb).await?;
-    let _application_handle = tokio::spawn(application.run());
+    let _application_handle =
+        tokio::spawn(application.run(helpers::fixture_os_release()));
 
     // Give Application::run a beat to register its zoci queryable on the router.
-    tokio::time::sleep(Duration::from_millis(300)).await;
-
-    // Each payload shape the handler must accept. /bin/true ignores argv, so
-    // these only prove the parser/dispatcher didn't reject the payload — they
-    // do NOT verify that --no-restart actually reaches the binary.
-    let payloads = [
-        ("plain-string", "v1.0.0"),
-        (
-            "json-with-no-restart-true",
-            r#"{"version":"v1.0.0","no_restart":true}"#,
-        ),
-        ("json-default", r#"{"version":"v1.0.0"}"#),
-        (
-            "json-with-no-restart-false",
-            r#"{"version":"v1.0.0","no_restart":false}"#,
-        ),
-        // Starts with `{` but isn't valid JSON — handler falls back to treating
-        // the whole payload as the version string.
-        ("malformed-json-falls-back", "{not-json"),
-    ];
-
-    for (label, payload) in payloads {
-        let reply = client_zenorb
-            .command_raw("supervisor/job/gondor", payload)
-            .await?;
-
-        if let Err(reply_err) = reply {
-            let body =
-                String::from_utf8_lossy(&reply_err.payload().to_bytes()).into_owned();
-            panic!("{label}: expected success reply, got error: {body}");
-        }
-    }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn gondor_zoci_handler_reports_binary_failure() -> color_eyre::Result<()> {
-    let dbus_instances = helpers::launch_dbuses().await??;
-
-    let (_router, supervisor_zenorb, client_zenorb) =
-        helpers::spawn_zenoh_router_and_clients("supervisor", "test-client").await?;
-
-    // /bin/false always exits non-zero, so the handler should surface that as
-    // an error reply regardless of payload shape.
-    let mut settings = helpers::make_settings(&dbus_instances);
-    settings.gondor_bin = PathBuf::from("/bin/false");
-
-    let application =
-        helpers::spawn_supervisor_service(settings, supervisor_zenorb).await?;
-    let _application_handle = tokio::spawn(application.run());
-
     tokio::time::sleep(Duration::from_millis(300)).await;
 
     let reply = client_zenorb
         .command_raw(
             "supervisor/job/gondor",
-            r#"{"version":"v1.0.0","no_restart":true}"#,
+            r#"{"version":"to-main","restart":true}"#,
         )
         .await?;
-
-    assert!(
-        reply.is_err(),
-        "expected error reply when gondor binary exits non-zero"
-    );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn gondor_zoci_handler_passes_argv_through() -> color_eyre::Result<()> {
-    use std::os::unix::fs::PermissionsExt;
-
-    let dbus_instances = helpers::launch_dbuses().await??;
-
-    let (_router, supervisor_zenorb, client_zenorb) =
-        helpers::spawn_zenoh_router_and_clients("supervisor", "test-client").await?;
-
-    // Fake gondor that appends one line per argv element plus a "---"
-    // record separator to a sibling log, so we can assert what argv each
-    // payload shape produced.
-    let tmp = tempfile::tempdir()?;
-    let log_path = tmp.path().join("argv.log");
-    let script_path = tmp.path().join("fake-gondor");
-    let script = format!(
-        "#!/usr/bin/env bash\nfor a in \"$@\"; do echo \"$a\" >> {p}; done\necho '---' >> {p}\n",
-        p = log_path.display(),
-    );
-    std::fs::write(&script_path, script)?;
-    std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755))?;
-
-    let mut settings = helpers::make_settings(&dbus_instances);
-    settings.gondor_bin = script_path;
-
-    let application =
-        helpers::spawn_supervisor_service(settings, supervisor_zenorb).await?;
-    let _application_handle = tokio::spawn(application.run());
-
-    tokio::time::sleep(Duration::from_millis(300)).await;
-
-    let cases = [
-        ("to-1.2.3", vec!["to-1.2.3"]),
-        (
-            r#"{"version":"to-4.5.6","no_restart":true}"#,
-            vec!["to-4.5.6", "--no-restart"],
-        ),
-        (r#"{"version":"to-7.8.9"}"#, vec!["to-7.8.9"]),
-        (
-            r#"{"version":"to-0.0.1","no_restart":false}"#,
-            vec!["to-0.0.1"],
-        ),
-    ];
-
-    for (payload, _) in &cases {
-        let reply = client_zenorb
-            .command_raw("supervisor/job/gondor", payload)
-            .await?;
-        if let Err(e) = reply {
-            let body = String::from_utf8_lossy(&e.payload().to_bytes()).into_owned();
-            panic!("payload {payload:?} produced error reply: {body}");
-        }
+    if let Err(e) = reply {
+        let body = String::from_utf8_lossy(&e.payload().to_bytes()).into_owned();
+        panic!("expected success reply, got error: {body}");
     }
 
-    let log = std::fs::read_to_string(&log_path)?;
-    let invocations: Vec<Vec<&str>> = log
-        .split("---\n")
-        .filter(|s| !s.is_empty())
-        .map(|chunk| chunk.lines().collect())
-        .collect();
-
-    let expected: Vec<Vec<&str>> = cases.iter().map(|(_, argv)| argv.clone()).collect();
+    let env = captured.set_environment.lock().unwrap();
     assert_eq!(
-        invocations, expected,
-        "gondor invocation argv sequence didn't match"
+        *env,
+        vec![vec![
+            "ORB_UPDATE_AGENT_VERSION_OVERWRITE=to-main-diamond-prod".to_string()
+        ]],
+        "expected exactly one SetEnvironment call with the derived version"
+    );
+
+    let restarts = captured.restart_unit.lock().unwrap();
+    assert_eq!(
+        *restarts,
+        vec!["worldcoin-update-agent.service".to_string()],
+        "expected exactly one RestartUnit call for the update-agent service"
     );
 
     Ok(())

--- a/telemetry/src/lib.rs
+++ b/telemetry/src/lib.rs
@@ -295,7 +295,7 @@ pub struct TraceCtx {
 /// use orb_telemetry::TraceCtx;
 ///
 /// fn remote_method(param: &str, trace_ctx: TraceCtx) {
-///     let span = tracing::span!(tracing::Level::INFO, "remote_method");       
+///     let span = tracing::span!(tracing::Level::INFO, "remote_method");
 ///     trace_ctx.apply(&span);
 ///     // ...
 /// }

--- a/update-agent/src/main.rs
+++ b/update-agent/src/main.rs
@@ -163,6 +163,17 @@ fn run(args: &Args) -> eyre::Result<()> {
     let settings = Settings::get(args, config_path, ENV_VAR_PREFIX, active_slot.into())
         .wrap_err("failed reading settings")?;
 
+    let platform_version =
+        if let Some(overwrite) = settings.version_overwrite.as_deref() {
+            warn!(
+            "ORB_UPDATE_AGENT_VERSION_OVERWRITE is set; overriding platform_version \
+             `{platform_version}` with `{overwrite}` for the claim request",
+        );
+            overwrite.to_string()
+        } else {
+            platform_version
+        };
+
     let settings_ser = match serde_json::to_string(&settings) {
         Ok(ser) => ser,
         Err(e) => {

--- a/update-agent/src/settings/mod.rs
+++ b/update-agent/src/settings/mod.rs
@@ -45,6 +45,7 @@ pub struct Settings {
     #[serde_as(as = "DurationMilliSeconds")]
     pub download_delay: Duration,
     pub token: Option<String>,
+    pub version_overwrite: Option<String>,
 }
 
 impl Settings {

--- a/update-agent/src/settings/tests.rs
+++ b/update-agent/src/settings/tests.rs
@@ -100,6 +100,7 @@ fn test_cli_args_override_config_file_and_env_vars() {
             recovery,
             download_delay,
             token,
+            version_overwrite: _,
         } = Settings::get(&args, "config.toml", "update_agent_", current_slot)?;
         assert_eq!(active_slot, current_slot);
         assert_eq!(workspace.as_os_str(), args.workspace.unwrap().as_str());
@@ -163,6 +164,7 @@ fn test_cli_args_override_config_file() {
             recovery,
             download_delay,
             token,
+            version_overwrite: _,
         } = Settings::get(&args, "config.toml", "update_agent_", current_slot)?;
         assert_eq!(active_slot, current_slot);
         assert_eq!(workspace.as_os_str(), args.workspace.unwrap().as_str());
@@ -209,6 +211,7 @@ fn test_only_setting_config_file_works() {
             recovery,
             download_delay,
             token,
+            version_overwrite: _,
         } = Settings::get(&args, "config.toml", "update_agent_", Slot::A)?;
         assert_eq!(active_slot, Slot::A);
         assert_eq!(workspace, Path::new("/config/workspace"));
@@ -251,6 +254,7 @@ fn test_env_override_config_file() {
             recovery,
             download_delay,
             token,
+            version_overwrite: _,
         } = Settings::get(&args, "config.toml", "update_agent_", current_slot)?;
         assert_eq!(active_slot, current_slot);
         assert_eq!(workspace, Path::new("/env/workspace"));
@@ -312,6 +316,7 @@ fn production_config() {
             recovery,
             download_delay,
             token,
+            version_overwrite: _,
         } = Settings::get(&args, "config.toml", "update_agent_", Slot::A)?;
         assert_eq!(active_slot, Slot::A);
         assert_eq!(workspace, Path::new("/config/workspace"));


### PR DESCRIPTION
* `supervisor`: instead of wrapping another python script, sanitizes the input, and exports it to systemd
* `orb-hil`: instead of calling gondor, use `zorb` from the runner to query supervisor's job
* `update-agent`: consume `version_overwrite`, if that is provided, overwrite `/etc/os-release` with that value.

The `gondor` binary will be removed from `development` builds, and be replaced by an alias to `zorb`querying 
`supervisor`.

This is a development feature to quickly allow developers to OTA to whatever they wish.
PR is spread upon commits touching the different crates separately 