### PR TITLE
fix(orb-registration): use camelCase field names in MongoDB register

### DIFF
--- a/scripts/orb-registration/orb-registration.py
+++ b/scripts/orb-registration/orb-registration.py
@@ -322,9 +322,9 @@ class OrbRegistration:
         self.logger.info(f"Creating Orb record in Management API for Orb ID: {orb_id}")
 
         data = {
-            "BuildVersion": self.args.hardware_version,
-            "ManufacturerName": self.args.manufacturer,
-            "Platform": platform,
+            "buildVersion": self.args.hardware_version,
+            "manufacturerName": self.args.manufacturer,
+            "platform": platform,
         }
 
         req = urllib.request.Request(


### PR DESCRIPTION
 ## Summary

  Fixes a registration failure where the Management API rejects the orb  registration request with `HTTP 422 Unprocessable Entity`. The API now deserializes the request body into a camelCase struct, but the script was still sending PascalCase field names (`BuildVersion`, `ManufacturerName`, `Platform`), so the server reported the expected field as missing.

  ## The error

  [11:47:08]INFO: Logging in to Cloudflare Access for domain:
  https://management.internal.stage.orb.worldcoin.dev
  [11:47:09]INFO: Fetching Cloudflare access token
  [11:47:09]INFO: Processing Diamond Orb ID: a214c186
  [11:47:09]INFO: Creating Orb record in Management API for Orb ID: a214c186
  [11:47:09]ERROR: Failed to register orb a214c186 in MongoDB: HTTP 422 Unprocessable Entity
  - Failed to deserialize the JSON body into the target type: missing field buildVersion at
  line 1 column 87
  Error: HTTP Error 422: Unprocessable Entity


    ## Testing

  Re-ran the registration command against the stage backend and confirmed the orb record is created successfully without the `422`.