### PR TITLE
feat(backend-status): add orb stand QR type to CoreStats

### DIFF
--- a/orb-backend-status/dbus/src/types.rs
+++ b/orb-backend-status/dbus/src/types.rs
@@ -124,6 +124,9 @@ pub struct CoreStats {
     pub version: OrbVersion,
     pub mac_address: String,
     pub orb_stand_qr_id: Option<String>,
+    /// "tablet" or "static": whether the stand QR came from a tablet screen (its
+    /// /orbVerification URL carried a tablet utm_source) or a static printed sign.
+    pub orb_stand_qr_type: Option<String>,
 }
 
 #[allow(missing_docs)]

--- a/orb-backend-status/src/backend/status_req_builder.rs
+++ b/orb-backend-status/src/backend/status_req_builder.rs
@@ -182,6 +182,10 @@ impl CurrentStatus {
                 .core_stats
                 .as_ref()
                 .and_then(|core_stats| core_stats.orb_stand_qr_id.clone()),
+            orb_stand_qr_type: self
+                .core_stats
+                .as_ref()
+                .and_then(|core_stats| core_stats.orb_stand_qr_type.clone()),
             timestamp: Utc::now(),
         }
     }

--- a/orb-backend-status/src/backend/types.rs
+++ b/orb-backend-status/src/backend/types.rs
@@ -37,6 +37,7 @@ pub struct OrbStatusApiV2 {
     pub oes: Option<Vec<Event>>,
     pub oes_cached: bool,
     pub orb_stand_qr_id: Option<String>,
+    pub orb_stand_qr_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Motivation
The FM backend already receives the orb stand QR id, but can't tell whether a scan came from a tablet screen or a static printed sign.

Adds `orb_stand_qr_type` ("tablet"/"static") and `orb_stand_qr_utm_source` to `CoreStats` and threads both through to the `OrbStatusApiV2` payload sent to the backend. orb-core will populate them in a follow-up.