### PR TITLE
docs(zorb): document developer only

### DIFF
--- a/zorb/README.md
+++ b/zorb/README.md
@@ -2,6 +2,8 @@
 
 CLI tool for Zenoh introspection and conditional command execution.
 
+`zorb` is a developer tool and is not included on production Orb devices.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
`zorb` is a developer tool only included on development devices. It should be made clear in the readme.