### PR TITLE
feat(dogd): handle backpressure

### DIFF
--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -15,6 +15,7 @@ const QUEUE_SIZE: usize = 1024;
 const MAX_EMIT_PER_TICK: usize = 20;
 const TICK: Duration = Duration::from_millis(100);
 
+#[derive(Clone)]
 pub struct DogstatsdClient {
     tx: Sender<Metric>,
 }

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -11,9 +11,9 @@ use tracing::{error, info};
 
 const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
 const DOGSTATSD_BACKOFF: Duration = Duration::from_secs(3);
-const QUEUE_SIZE: usize = 1024;
-const MAX_EMIT_PER_TICK: usize = 20;
-const TICK: Duration = Duration::from_millis(100);
+const QUEUE_SIZE: usize = 2048;
+const MAX_EMIT_PER_TICK: usize = 25;
+const TICK: Duration = Duration::from_millis(50);
 
 #[derive(Clone)]
 pub struct DogstatsdClient {

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -1,19 +1,23 @@
+use super::{MetricEmitter, MetricError};
 use dogstatsd::Client;
+use flume::RecvError;
 use flume::Sender;
 use flume::TrySendError;
 use std::thread;
+use std::time::Instant;
 use std::{fs, path::Path, time::Duration};
 use tracing::warn;
 use tracing::{error, info};
 
-use super::{MetricEmitter, MetricError};
+const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
+const DOGSTATSD_BACKOFF: Duration = Duration::from_secs(3);
+const QUEUE_SIZE: usize = 2048;
+const MAX_EMIT_PER_TICK: usize = 3;
+const TICK: Duration = Duration::from_millis(100);
 
 pub struct DogstatsdClient {
     tx: Sender<Metric>,
 }
-
-const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
-const DOGSTATSD_BACKOFF: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Metric {
@@ -67,9 +71,9 @@ impl DogstatsdClient {
     ///
     /// Fails if the underlying socket cannot be bound.
     pub fn new() -> Self {
-        let (tx, rx) = flume::bounded(512);
+        let (tx, rx) = flume::bounded(QUEUE_SIZE);
 
-        thread::spawn(move || {
+        thread::spawn(move || loop {
             let client = loop {
                 let err_msg =
                     if fs::exists(Path::new(DOGSTATSD_SOCKET_PATH)).unwrap_or(false) {
@@ -95,36 +99,77 @@ impl DogstatsdClient {
                 thread::sleep(DOGSTATSD_BACKOFF);
             };
 
-            while let Ok(metric) = rx.recv() {
+            let mut tick = Instant::now();
+            let mut count = 0;
+
+            let mut send = |metric| {
+                use Metric::*;
+
                 match metric {
-                    Metric::Count { stat, val, tags } => {
+                    Count { stat, val, tags } => {
                         if let Err(e) = client.count(stat, val, tags) {
                             warn!("emitting metric failed with: {e}");
                         }
                     }
-                    Metric::Gauge { stat, val, tags } => {
+
+                    Gauge { stat, val, tags } => {
                         if let Err(e) = client.gauge(stat, val.to_string(), tags) {
                             warn!("emitting metric failed with: {e}");
                         }
                     }
-                    Metric::Histogram { stat, val, tags } => {
+
+                    Histogram { stat, val, tags } => {
                         if let Err(e) = client.histogram(stat, val.to_string(), tags) {
                             warn!("emitting metric failed with: {e}");
                         }
                     }
-                    Metric::Distribution { stat, val, tags } => {
+
+                    Distribution { stat, val, tags } => {
                         if let Err(e) = client.distribution(stat, val.to_string(), tags)
                         {
                             warn!("emitting metric failed with: {e}");
                         }
                     }
-                    Metric::Timing { stat, val, tags } => {
+
+                    Timing { stat, val, tags } => {
                         if let Err(e) = client.timing(stat, val, tags) {
                             warn!("emitting metric failed with: {e}");
                         }
                     }
                 }
+
+                count += 1;
+
+                if tick.elapsed() >= TICK || count >= MAX_EMIT_PER_TICK {
+                    let sleep = TICK.saturating_sub(tick.elapsed());
+                    if sleep > Duration::ZERO {
+                        thread::sleep(sleep);
+                    }
+
+                    count = 0;
+                    tick = Instant::now();
+                }
+            };
+
+            loop {
+                let msg = match rx.recv() {
+                    Err(RecvError::Disconnected) => {
+                        error!("main datadog channel disconnected!");
+                        break;
+                    }
+
+                    Ok(msg) => msg,
+                };
+
+                send(msg);
+
+                while let Ok(msg) = rx.try_recv() {
+                    send(msg);
+                }
             }
+
+            warn!("recreating dogstatsd::Client");
+            thread::sleep(DOGSTATSD_BACKOFF);
         });
 
         Self { tx }

--- a/orb-dogd/src/dd.rs
+++ b/orb-dogd/src/dd.rs
@@ -11,8 +11,8 @@ use tracing::{error, info};
 
 const DOGSTATSD_SOCKET_PATH: &str = "/run/datadog/dsd.socket";
 const DOGSTATSD_BACKOFF: Duration = Duration::from_secs(3);
-const QUEUE_SIZE: usize = 2048;
-const MAX_EMIT_PER_TICK: usize = 3;
+const QUEUE_SIZE: usize = 1024;
+const MAX_EMIT_PER_TICK: usize = 20;
 const TICK: Duration = Duration::from_millis(100);
 
 pub struct DogstatsdClient {
@@ -73,7 +73,7 @@ impl DogstatsdClient {
     pub fn new() -> Self {
         let (tx, rx) = flume::bounded(QUEUE_SIZE);
 
-        thread::spawn(move || loop {
+        thread::spawn(move || {
             let client = loop {
                 let err_msg =
                     if fs::exists(Path::new(DOGSTATSD_SOCKET_PATH)).unwrap_or(false) {
@@ -154,7 +154,7 @@ impl DogstatsdClient {
             loop {
                 let msg = match rx.recv() {
                     Err(RecvError::Disconnected) => {
-                        error!("main datadog channel disconnected!");
+                        warn!("main datadog channel disconnected, all clients were dropped, exiting thread!");
                         break;
                     }
 
@@ -167,9 +167,6 @@ impl DogstatsdClient {
                     send(msg);
                 }
             }
-
-            warn!("recreating dogstatsd::Client");
-            thread::sleep(DOGSTATSD_BACKOFF);
         });
 
         Self { tx }


### PR DESCRIPTION
## changes
introduces backpressure handling to avoid issue seen when burst emitting full queue of metrics
<img width="2910" height="1327" alt="image" src="https://github.com/user-attachments/assets/2615eeba-68ab-4f25-a56d-8eb471199ff4" />


limits metrics to 25/50ms (500/s). this should avoid the errno 11 seen in the image above, most likely caused by multiple clients overwhelming the socket/agent.

## drawbacks
if we add any metrics where the _emitting itself_ (not the value of the metric) is time sensitive, this could cause issues if we have a hot loop. worst case scenario we deviate a bit on distribution of some metric time buckets up to 5s. if this becomes an issue we might prefer to drop sending these metrics