### PR TITLE
feat(orb-connd): fix modem powercycle logic

### DIFF
--- a/orb-connd/Cargo.toml
+++ b/orb-connd/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 authors = [
-	"Philipp Poppov <pophilpo@users.noreply.github.com>",
+	"Philipp Popov <pophilpo@users.noreply.github.com>",
 	"Victor Ferreira Menge <vmenge@users.noreply.github.com>",
 ]
 

--- a/orb-connd/src/modem/mod.rs
+++ b/orb-connd/src/modem/mod.rs
@@ -219,6 +219,11 @@ async fn powercycle_modem(mcu_util: &dyn McuUtil, systemd: &Systemd) -> Result<(
         .await
         .wrap_err("restart ModemManager systemd service")?;
 
+    systemd
+        .wait_for_active("ModemManager.service", Duration::from_secs(30))
+        .await
+        .wrap_err("ModemManager did not become active after powercycle")?;
+
     info!("ModemManager restarted!");
 
     Ok(())

--- a/orb-connd/src/modem/mod.rs
+++ b/orb-connd/src/modem/mod.rs
@@ -214,11 +214,13 @@ async fn powercycle_modem(mcu_util: &dyn McuUtil, systemd: &Systemd) -> Result<(
 
     info!("modem detected at /dev/cdc-wdm0");
 
+    info!("Restarting ModemManager");
     systemd
         .restart_service("ModemManager.service")
         .await
         .wrap_err("restart ModemManager systemd service")?;
 
+    info!("Waiting for ModemManager to become active");
     systemd
         .wait_for_active("ModemManager.service", Duration::from_secs(30))
         .await

--- a/orb-connd/src/systemd.rs
+++ b/orb-connd/src/systemd.rs
@@ -1,5 +1,7 @@
-use color_eyre::Result;
-use zbus_systemd::systemd1::{ManagerProxy, ServiceProxy};
+use std::time::Duration;
+
+use color_eyre::{eyre::Context, Result};
+use zbus_systemd::systemd1::{ManagerProxy, ServiceProxy, UnitProxy};
 
 #[derive(Clone)]
 pub struct Systemd {
@@ -52,6 +54,34 @@ impl Systemd {
         }
 
         Ok(services)
+    }
+
+    pub async fn wait_for_active(&self, unit: &str, timeout: Duration) -> Result<()> {
+        let is_active = async {
+            loop {
+                if self.is_service_active(unit).await.unwrap_or(false) {
+                    return;
+                }
+
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        };
+
+        tokio::time::timeout(timeout, is_active)
+            .await
+            .with_context(|| format!("timed out waiting for {unit} to become active"))
+    }
+
+    async fn is_service_active(&self, unit: &str) -> Result<bool> {
+        let manager = ManagerProxy::new(&self.system_bus).await?;
+        let path = manager.get_unit(unit.to_string()).await?;
+
+        let unit_proxy = UnitProxy::builder(&self.system_bus)
+            .destination("org.freedesktop.systemd1")?
+            .path(path)?
+            .build()
+            .await?;
+        Ok(unit_proxy.active_state().await? == "active")
     }
 }
 


### PR DESCRIPTION
# Problem
 When ModemManager goes down, the modem supervisor detects the failure, powercycles the modem, and calls `restart_unit("ModemManager.service")`. This call only enqueues the systemd job — it returns immediately without waiting for MM to actually be up.

The supervisor then returns `Err`, and restarts after the minimum 10s backoff. On restart, the supervisor immediately calls `refresh_snapshot()` → `mmcli -L`. But `ModemManager` takes ~12s (or maybe longer) to fully initialize after being started. At the 10s mark MM is still starting, `mmcli -L` fails, and the supervisor concludes the modem is broken again — triggering a second unnecessary hardware powercycle that interrupts MM mid-startup.

This repeats with growing backoffs (10s, 20s, 30s…), causing repeated unnecessary powercycles and making ModemManager recovery slow.


# Fix
`powercycle_modem` now polls the` ActiveState` of `ModemManager.service` after calling `restart_unit`, blocking for up to 30s until the unit is fully active before returning.