### PR TITLE
fix: cargo deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,6 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 name = "artificer"
 version = "0.0.0"
 dependencies = [
- "cacache",
  "clap",
  "color-eyre",
  "derive_more 2.1.1",
@@ -334,6 +333,7 @@ dependencies = [
  "reqwest 0.12.24",
  "semver",
  "serde",
+ "ssri",
  "tokio",
  "tokio-util",
  "toml 0.8.23",
@@ -1949,32 +1949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cacache"
-version = "13.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5063741c7b2e260bbede781cf4679632dd90e2718e99f7715e46824b65670b"
-dependencies = [
- "async-std",
- "digest",
- "either",
- "futures",
- "hex 0.4.3",
- "libc",
- "memmap2",
- "miette 5.10.0",
- "reflink-copy",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "sha2",
- "ssri",
- "tempfile",
- "thiserror 1.0.69",
- "walkdir",
-]
-
-[[package]]
 name = "camino"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3181,7 +3155,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5257,7 +5231,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.59.0",
 ]
 
 [[package]]
@@ -5960,7 +5934,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6785,15 +6759,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7495,7 +7460,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10514,9 +10479,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -10845,7 +10810,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rustix 1.1.2",
- "windows 0.62.2",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -11257,7 +11222,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11370,7 +11335,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12560,9 +12525,9 @@ dependencies = [
 
 [[package]]
 name = "stabby"
-version = "72.1.1"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976399a0c48ea769ef7f5dc303bb88240ab8d84008647a6b2303eced3dab3945"
+checksum = "a7b834ec7ced12095fea1e4b07dcb7e8cf2b59b18afa3eac52494d835965a5ec"
 dependencies = [
  "rustversion",
  "stabby-abi",
@@ -12570,9 +12535,9 @@ dependencies = [
 
 [[package]]
 name = "stabby-abi"
-version = "72.1.1"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b54832a9a1f92a0e55e74a5c0332744426edc515bb3fbad82f10b874a87f0d"
+checksum = "ff1a4f477858a5bdf927c9fab7f579899de9b13e39f8b3b3b300c89fbab632f4"
 dependencies = [
  "rustc_version",
  "rustversion",
@@ -12582,15 +12547,14 @@ dependencies = [
 
 [[package]]
 name = "stabby-macros"
-version = "72.1.1"
+version = "72.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a768b1e51e4dbfa4fa52ae5c01241c0a41e2938fdffbb84add0c8238092f9091"
+checksum = "b31c4b2434980b67ad83f300a58088ba14d59454dcd79ba3d87419bbd924d31e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
- "syn 1.0.109",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/experiments/artificer/Cargo.toml
+++ b/experiments/artificer/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-ssri = "9"
 clap.workspace = true
 color-eyre.workspace = true
 derive_more.workspace = true
@@ -22,6 +21,7 @@ orb-build-info.workspace = true
 reqwest.workspace = true
 semver = { version = "1", features = ["serde"] }
 serde.workspace = true
+ssri = "9"
 tokio.workspace = true
 tokio-util = { version = "0.7", default-features = false, features = ["compat"] }
 toml = "0.8.8"

--- a/experiments/artificer/Cargo.toml
+++ b/experiments/artificer/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-cacache = "13"
+ssri = "9"
 clap.workspace = true
 color-eyre.workspace = true
 derive_more.workspace = true

--- a/experiments/artificer/src/config/lock.rs
+++ b/experiments/artificer/src/config/lock.rs
@@ -22,7 +22,7 @@ pub struct LockedSpec {
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LockedArtifact {
     pub source: Source,
-    pub hash: cacache::Integrity,
+    pub hash: ssri::Integrity,
 }
 
 #[cfg(test)]

--- a/experiments/artificer/src/config/spec.rs
+++ b/experiments/artificer/src/config/spec.rs
@@ -47,7 +47,7 @@ pub struct CustomExtractor {
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum Hash {
-    Hash(cacache::Integrity),
+    Hash(ssri::Integrity),
     /// Dummy hash value that will never correct. Specified by an empty string.
     Dummy,
     False,
@@ -106,7 +106,7 @@ impl<'de> Deserialize<'de> for Hash {
                     Ok(Hash::Dummy)
                 } else {
                     let integrity =
-                        cacache::Integrity::from_str(v).map_err(E::custom)?;
+                        ssri::Integrity::from_str(v).map_err(E::custom)?;
                     Ok(Hash::Hash(integrity))
                 }
             }

--- a/experiments/artificer/src/config/spec.rs
+++ b/experiments/artificer/src/config/spec.rs
@@ -105,8 +105,7 @@ impl<'de> Deserialize<'de> for Hash {
                 if v.is_empty() {
                     Ok(Hash::Dummy)
                 } else {
-                    let integrity =
-                        ssri::Integrity::from_str(v).map_err(E::custom)?;
+                    let integrity = ssri::Integrity::from_str(v).map_err(E::custom)?;
                     Ok(Hash::Hash(integrity))
                 }
             }


### PR DESCRIPTION
fixes cargo deny caused by outdated `memmap2` dependency.

replaces `cacache::Integrity` with the equivalent `ssri::Integrity` (`cacache` was using internally `ssri`)

Also does 
```
cargo update -p quinn-proto
cargo update -p stabby
```