### PR TITLE
fix(attest): keep zenoh alive; use prelude ConnectivityTracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,6 +7274,7 @@ dependencies = [
  "orb-info",
  "orb-security-utils",
  "orb-telemetry",
+ "prelude",
  "reqwest 0.12.24",
  "ring",
  "secrecy 0.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ orb-update-agent.path = "update-agent"
 orb-update-agent-core.path = "update-agent/core"
 orb-update-agent-dbus.path = "update-agent/dbus"
 orb-zbus-proxies.path = "zbus-proxies"
-prelude.path = "prelude"
+prelude = { path = "prelude", default-features = false }
 seek-camera.path = "seek-camera/wrapper"
 test-utils.path = "test-utils"
 zenorb.path = "zenorb"

--- a/attest/Cargo.toml
+++ b/attest/Cargo.toml
@@ -25,6 +25,7 @@ orb-endpoints.workspace = true
 orb-info = { workspace = true, features = ["async", "orb-id"] }
 orb-security-utils = { workspace = true, features = ["reqwest"] }
 orb-telemetry.workspace = true
+prelude = { workspace = true, features = ["connectivity"] }
 reqwest = { workspace = true, features = ["json", "multipart"] }
 ring.workspace = true
 secrecy = { workspace = true, features = ["serde"] }

--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -10,21 +10,11 @@ use futures::{FutureExt, StreamExt};
 use orb_build_info::{make_build_info, BuildInfo};
 use orb_dogd::{DogstatsdClient, MetricEmitter};
 use orb_info::OrbId;
+use prelude::connectivity::tracker::ConnectivityTracker;
 use secrecy::ExposeSecret;
 use std::default::Default;
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
-use tokio::{
-    select,
-    sync::{watch, Notify},
-    task::{self, JoinHandle},
-    time::sleep,
-};
+use std::{sync::Arc, time::Duration};
+use tokio::{select, sync::Notify, time::sleep};
 use tracing::{info, warn};
 use url::Url;
 use zenorb::{zenoh::sample::Sample, Zenorb};
@@ -91,28 +81,32 @@ pub async fn main() -> eyre::Result<()> {
 
     let conn = iface_ref.signal_context().connection().clone();
 
-    let (is_online_tx, is_online_rx) = watch::channel(false);
+    let connectivity_tracker = ConnectivityTracker::default();
 
-    match Zenorb::from_cfg(zenorb::default_cfg())
+    let _zenorb = match Zenorb::from_cfg(zenorb::default_cfg())
         .orb_id(orb_id.clone())
         .with_name("attest")
         .await
     {
         Ok(zenorb) => {
             let _ = zenorb
-                .receiver(is_online_tx)
+                .receiver(connectivity_tracker.clone())
                 .querying_subscriber(
                     "connd/oes/active_connections",
                     Duration::from_secs(1),
-                    update_is_online,
+                    update_connectivity_tracker,
                 )
                 .run()
                 .await?;
+
+            Some(zenorb)
         }
+
         Err(e) => {
             warn!("zenoh not available, connectivity tracking disabled: {e}");
+            None
         }
-    }
+    };
 
     let run_fut = run(
         orb_id.as_str(),
@@ -120,7 +114,7 @@ pub async fn main() -> eyre::Result<()> {
         force_refresh_token.clone(),
         config.auth_url,
         config.ping_url,
-        is_online_rx,
+        connectivity_tracker,
         DogstatsdClient::default(),
     );
 
@@ -329,13 +323,13 @@ async fn run(
     force_refresh_token: Arc<Notify>,
     auth_url: Url,
     ping_url: Url,
-    is_online_rx: watch::Receiver<bool>,
+    conn_tracker: ConnectivityTracker,
     metrics: impl MetricEmitter,
 ) -> eyre::Result<()> {
     loop {
         let token = select! {
             Ok(token) = get_working_static_token(orb_id, &ping_url) => token,
-            token = remote_api::get_token(orb_id, &auth_url, &metrics, &is_online_rx) => token,
+            token = remote_api::get_token(orb_id, &auth_url, &metrics, &conn_tracker) => token,
         };
 
         let token_refresh_delay = token.get_best_refresh_time();
@@ -367,8 +361,8 @@ async fn run(
     }
 }
 
-async fn update_is_online(
-    is_online: watch::Sender<bool>,
+async fn update_connectivity_tracker(
+    conn_tracker: ConnectivityTracker,
     sample: Sample,
 ) -> color_eyre::Result<()> {
     let active_conns: oes::ActiveConnections =
@@ -376,46 +370,7 @@ async fn update_is_online(
             .context("failed to parse ActiveConnections json")?;
 
     let has_internet = active_conns.connections.iter().any(|c| c.has_internet);
-    is_online
-        .send(has_internet)
-        .context("failed to send is_online watch value")?;
+    conn_tracker.update(has_internet);
 
     Ok(())
-}
-
-pub struct ConnectivityTracker {
-    stable_connection: Arc<AtomicBool>,
-    handle: JoinHandle<()>,
-}
-
-impl Drop for ConnectivityTracker {
-    fn drop(&mut self) {
-        self.handle.abort();
-    }
-}
-
-impl ConnectivityTracker {
-    pub fn start(mut is_online_rx: watch::Receiver<bool>) -> Self {
-        let stable_connection = Arc::new(AtomicBool::new(*is_online_rx.borrow()));
-        let sc = stable_connection.clone();
-
-        let handle = task::spawn(async move {
-            while let Ok(()) = is_online_rx.changed().await {
-                if !*is_online_rx.borrow() {
-                    sc.store(false, Ordering::Release);
-                }
-            }
-        });
-
-        Self {
-            stable_connection,
-            handle,
-        }
-    }
-
-    /// Returns true if internet connection was stable (did not lose connection) for the lifetime of
-    /// this ConnectivityTracker
-    pub fn stable_connection(&self) -> bool {
-        self.stable_connection.load(Ordering::Acquire)
-    }
 }

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -12,7 +12,6 @@ use std::{
     io::Write,
     process::{Command, Stdio},
 };
-use tokio::sync::watch;
 use tokio::{
     fs::read_to_string,
     time::{self, sleep},
@@ -570,12 +569,12 @@ async fn get_token_inner(
 /// Panics
 ///
 /// if fails to construct API URL
-#[tracing::instrument(skip(metrics))]
+#[tracing::instrument(skip(metrics, conn_tracker))]
 pub async fn get_token(
     orb_id: &str,
     base_url: &Url,
     metrics: &impl MetricEmitter,
-    is_online_rx: &watch::Receiver<bool>,
+    conn_tracker: &ConnectivityTracker,
 ) -> Token {
     let tokenchallenge_url = base_url.join("tokenchallenge").unwrap();
     let token_url = base_url.join("token").unwrap();
@@ -584,12 +583,12 @@ pub async fn get_token(
     loop {
         // We do not count metrics for when we lose connectivity in between requests as it introduces
         // only noise in determining success and speed of challenge flow.
-        let conn_tracker = ConnectivityTracker::start(is_online_rx.clone());
+        let conn_stability = conn_tracker.track_stability();
         let start = Instant::now();
 
         match get_token_inner(orb_id, &tokenchallenge_url, &token_url).await {
             Ok(token) => {
-                if conn_tracker.stable_connection() {
+                if conn_stability.is_stable() {
                     let _ = metrics.dist(
                         "orb.platform.attest.token_refresh_duration",
                         start.elapsed().as_millis() as f64,
@@ -610,7 +609,7 @@ pub async fn get_token(
                 let retry_delay = e.retry_delay(delay);
                 error!("failed to get token: {e}, retrying in {retry_delay:?}");
 
-                if conn_tracker.stable_connection() {
+                if conn_stability.is_stable() {
                     let _ = metrics.count(
                         "orb.platform.attest.token_refresh",
                         1,

--- a/prelude/src/connectivity/tracker.rs
+++ b/prelude/src/connectivity/tracker.rs
@@ -20,7 +20,7 @@ pub struct ConnectivityTracker {
 
 impl Default for ConnectivityTracker {
     fn default() -> Self {
-        let (tx, rx) = watch::channel(false);
+        let (tx, rx) = watch::channel(true);
 
         Self { tx, rx }
     }
@@ -103,7 +103,7 @@ mod tests {
     }
 
     #[test]
-    fn default_tracker_starts_offline() {
+    fn default_tracker_starts_online() {
         // Arrange
         let tracker = ConnectivityTracker::default();
 
@@ -111,7 +111,7 @@ mod tests {
         let is_online = tracker.is_online();
 
         // Assert
-        assert!(!is_online);
+        assert!(is_online);
     }
 
     #[test]
@@ -149,6 +149,7 @@ mod tests {
     async fn stability_starts_unstable_when_created_while_offline() {
         // Arrange
         let tracker = ConnectivityTracker::default();
+        tracker.update(false);
 
         // Act
         let stability = tracker.track_stability();


### PR DESCRIPTION
## fixes
- attest not keeping zenoh alive, causing subscriptions to fail

## changes
- attest to use prelude's ConnectivityTracker
- default ConnectivityTracker state is now true