### PR TITLE
fix(bidiff-util): leave manifest data untouched

### DIFF
--- a/update-agent/core/src/claim.rs
+++ b/update-agent/core/src/claim.rs
@@ -407,7 +407,11 @@ mod serde_imp {
         where
             S: serde::Serializer,
         {
-            self.manifest.serialize(serializer)
+            // Need to serialize raw bytes verbatim to preserve the exact manifest
+            // content that was signed.
+            let raw: &serde_json::value::RawValue =
+                serde_json::from_str(&self.raw).map_err(serde::ser::Error::custom)?;
+            raw.serialize(serializer)
         }
     }
 


### PR DESCRIPTION
https://docs.rs/serde_json/latest/serde_json/value/struct.RawValue.html
The de-serialization & re-serialization should not be touching the manifest data