### PR TITLE
feat(orb-attest): fix legacy orb-id path

### DIFF
--- a/attest/debian/orb-attest.worldcoin-attest.service
+++ b/attest/debian/orb-attest.worldcoin-attest.service
@@ -38,6 +38,8 @@ DevicePolicy=closed
 # orb-sign-attestation accesses SE050 via /dev/i2c-* and OP-TEE via /dev/tee0
 DeviceAllow=/dev/i2c-* rw
 DeviceAllow=/dev/tee0 rw
+# Legacy Pearl orb-id reads the public UID partition through this by-partlabel symlink
+DeviceAllow=/dev/disk/by-partlabel/UID-PUB r
 PrivateNetwork=no
 # AF_CAN is required: orb-mcu-util opens a raw CAN-FD socket to reboot the security MCU
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX AF_CAN


### PR DESCRIPTION
Fixes [ORBS-1692](https://linear.app/worldcoin/issue/ORBS-1692/bug-orb-reports-incorrect-orb-id-hostname-causing-authentication)

Long story short: legacy orb-ids on Pearl depend on reading `/dev/disk/by-partlabel/UID-PUB` and the hardened` orb-attest `service had no rights to read from there, resulting in a hash of an empty orb id.

# Testing

- Tested on a stage Pearl orb, that had an old `/dev/disk/by-partlabel/UID-PUB` orb-id. Attest was able to read the id, but no t authenticate, for obvious reasons. 
- Added a test to our HIL testing framework that looks roughly like this:
1. Run on Pearl Stage only
2. Checks if `dev/disk/by-partlabel/UID-PUB` exists on this orb
3. If it exists, continue with the test
4. Bind-mount a fake read-fuse binary  so `odm-lock` returns 0 (marker for legacy orb-id)
5. Verify that calling orb-id now returns a legacy orb-id, comparing the value from `dev/disk/by-partlabel/UID-PUB`
6. Restart `worldcoin-attest.service`
7. read `/proc/$PID/environ`  (wher PID is the PID of attest.service) and assert ORB_ID equals the legacy ID.
8. Cleanup, restart attest, confirm it get's the token with a normal orb-id