### PR TITLE
feat(systemd): fix legacy orb-ids

### DIFF
--- a/orb-backend-status/debian/worldcoin-backend-status.service
+++ b/orb-backend-status/debian/worldcoin-backend-status.service
@@ -37,7 +37,9 @@ ProtectSystem=strict
 # If at some point this service will need write access make sure to change this
 ReadOnlyPaths=/
 PrivateTmp=no
-PrivateDevices=yes
+DevicePolicy=closed
+# Legacy Pearl orb-id reads the public UID partition through this by-partlabel symlink
+DeviceAllow=/dev/disk/by-partlabel/UID-PUB r
 PrivateNetwork=no
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 

--- a/orb-connd/debian/worldcoin-connd.service
+++ b/orb-connd/debian/worldcoin-connd.service
@@ -55,6 +55,8 @@ PrivateTmp=no
 # Pearl doesn't use the OP-TEE path but the setting must be the same service file.
 PrivateDevices=no
 DeviceAllow=/dev/tee0 rw
+# Legacy Pearl orb-id reads the public UID partition through this by-partlabel symlink
+DeviceAllow=/dev/disk/by-partlabel/UID-PUB r
 # Needs outbound TCP (zenoh :7447), UDP (StatsD/dogstatsd), HTTPS (connectivity checks),
 # AF_UNIX (D-Bus system/session buses, wpa_supplicant control socket), and AF_CAN
 # (modem power-cycle via orb-mcu-util which calls socket(AF_CAN, ...))


### PR DESCRIPTION
Fixed hardened services that were not able to read the legacy-orb id.

