### PR TITLE
fix(update-agent): report resumed download progress correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2547,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -7337,7 +7337,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "serial_test 3.2.0",
+ "serial_test 3.5.0",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -7624,7 +7624,7 @@ dependencies = [
  "orb-attest-dbus",
  "serde",
  "serde_json",
- "serial_test 3.2.0",
+ "serial_test 3.5.0",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
@@ -7677,7 +7677,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_with",
- "serial_test 3.2.0",
+ "serial_test 3.5.0",
  "tap",
  "test-utils",
  "test-with",
@@ -10507,15 +10507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10589,12 +10580,6 @@ dependencies = [
  "ring",
  "untrusted",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -10965,16 +10950,16 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot 0.12.5",
- "scc",
- "serial_test_derive 3.2.0",
+ "serial_test_derive 3.5.0",
 ]
 
 [[package]]
@@ -10990,9 +10975,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -624,38 +624,15 @@ pub fn download<P: AsRef<Path>>(
     let mut current_delay = download_delay;
     let mut allowed_before = true;
 
-    let remaining_chunks =
-        ((component_remote_len - start_bytes) / CHUNK_SIZE as u64) as usize;
-
-    let mut progress_percent = 0;
-    for (i, range) in
+    let mut downloaded_bytes = start_bytes;
+    report_download_progress(
+        name,
+        download_progress_percent(downloaded_bytes, component_remote_len),
+        update_iface,
+    );
+    for range in
         util::HttpRangeIter::try_new(start_bytes, component_remote_len - 1, CHUNK_SIZE)?
-            .enumerate()
     {
-        if let Some(current_progress_percent) = (i * 100).checked_div(remaining_chunks)
-        {
-            if progress_percent != current_progress_percent {
-                progress_percent = current_progress_percent;
-            }
-        } else {
-            progress_percent = 100;
-        }
-
-        info!("downloading component `{name}`: {progress_percent}%");
-        if let Some(iface) = update_iface
-            && let Err(e) = interfaces::update_dbus_progress(
-                Some(ComponentStatus {
-                    name: name.to_string(),
-                    state: ComponentState::Downloading,
-                    progress: progress_percent as u8,
-                }),
-                Some(UpdateAgentState::Downloading),
-                iface,
-            )
-        {
-            warn!("{e:?}");
-        }
-
         // We are using `downloads_allowed` as a proxy to set/unset the sleep duration for now.
         // Downloads are no longer blocked entirely. Dbus error when communicating are reported
         // but leave the currently set duration unchanged.
@@ -699,9 +676,15 @@ pub fn download<P: AsRef<Path>>(
         let response = response
             .bytes()
             .map_err(|e| Error::GetBytes(range, url.clone(), e))?;
+        let bytes_read = response.len() as u64;
         io::copy(&mut response.as_ref(), &mut &dst).map_err(|e| {
             Error::MergeChunk(range, component_path.clone(), url.clone(), e)
         })?;
+
+        downloaded_bytes = downloaded_bytes.saturating_add(bytes_read);
+        let progress_percent =
+            download_progress_percent(downloaded_bytes, component_remote_len);
+        report_download_progress(name, progress_percent, update_iface);
 
         std::thread::sleep(current_delay);
     }
@@ -715,6 +698,35 @@ pub fn download<P: AsRef<Path>>(
         .map_err(|e| Error::DiskSync(component_path.clone(), e))?;
 
     Ok(component_path)
+}
+
+fn report_download_progress(
+    name: &str,
+    progress_percent: u8,
+    update_iface: Option<&InterfaceRef<UpdateAgentManager<UpdateProgress>>>,
+) {
+    info!("downloading component `{name}`: {progress_percent}%");
+    if let Some(iface) = update_iface
+        && let Err(e) = interfaces::update_dbus_progress(
+            Some(ComponentStatus {
+                name: name.to_string(),
+                state: ComponentState::Downloading,
+                progress: progress_percent,
+            }),
+            Some(UpdateAgentState::Downloading),
+            iface,
+        )
+    {
+        warn!("{e:?}");
+    }
+}
+
+fn download_progress_percent(downloaded_bytes: u64, total_bytes: u64) -> u8 {
+    if total_bytes == 0 {
+        return 100;
+    }
+    let progress = downloaded_bytes.saturating_mul(100) / total_bytes;
+    progress.min(100) as u8
 }
 
 // Fetches a component by finding it on disk or downloading it from remote.
@@ -775,4 +787,24 @@ pub fn fetch<P: AsRef<Path>>(
         source: source.clone(),
         on_disk: path,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::download_progress_percent;
+
+    #[test]
+    fn download_progress_uses_total_bytes_after_resume() {
+        assert_eq!(download_progress_percent(4_800, 5_600), 85);
+    }
+
+    #[test]
+    fn download_progress_clamps_to_complete() {
+        assert_eq!(download_progress_percent(120, 100), 100);
+    }
+
+    #[test]
+    fn download_progress_treats_empty_component_as_complete() {
+        assert_eq!(download_progress_percent(0, 0), 100);
+    }
 }

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -631,9 +631,7 @@ pub fn download<P: AsRef<Path>>(
     {
         let current_progress_percent =
             (start_bytes + (i as u64 * CHUNK_SIZE as u64)) * 100 / component_remote_len;
-        if progress_percent != current_progress_percent {
-            progress_percent = current_progress_percent;
-        }
+        progress_percent = current_progress_percent;
 
         info!("downloading component `{name}`: {progress_percent}%");
         if let Some(iface) = update_iface

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -624,15 +624,32 @@ pub fn download<P: AsRef<Path>>(
     let mut current_delay = download_delay;
     let mut allowed_before = true;
 
-    let mut downloaded_bytes = start_bytes;
-    report_download_progress(
-        name,
-        download_progress_percent(downloaded_bytes, component_remote_len),
-        update_iface,
-    );
-    for range in
+    let mut progress_percent = 0;
+    for (i, range) in
         util::HttpRangeIter::try_new(start_bytes, component_remote_len - 1, CHUNK_SIZE)?
+            .enumerate()
     {
+        let current_progress_percent =
+            (start_bytes + (i as u64 * CHUNK_SIZE as u64)) * 100 / component_remote_len;
+        if progress_percent != current_progress_percent {
+            progress_percent = current_progress_percent;
+        }
+
+        info!("downloading component `{name}`: {progress_percent}%");
+        if let Some(iface) = update_iface
+            && let Err(e) = interfaces::update_dbus_progress(
+                Some(ComponentStatus {
+                    name: name.to_string(),
+                    state: ComponentState::Downloading,
+                    progress: progress_percent as u8,
+                }),
+                Some(UpdateAgentState::Downloading),
+                iface,
+            )
+        {
+            warn!("{e:?}");
+        }
+
         // We are using `downloads_allowed` as a proxy to set/unset the sleep duration for now.
         // Downloads are no longer blocked entirely. Dbus error when communicating are reported
         // but leave the currently set duration unchanged.
@@ -676,15 +693,9 @@ pub fn download<P: AsRef<Path>>(
         let response = response
             .bytes()
             .map_err(|e| Error::GetBytes(range, url.clone(), e))?;
-        let bytes_read = response.len() as u64;
         io::copy(&mut response.as_ref(), &mut &dst).map_err(|e| {
             Error::MergeChunk(range, component_path.clone(), url.clone(), e)
         })?;
-
-        downloaded_bytes = downloaded_bytes.saturating_add(bytes_read);
-        let progress_percent =
-            download_progress_percent(downloaded_bytes, component_remote_len);
-        report_download_progress(name, progress_percent, update_iface);
 
         std::thread::sleep(current_delay);
     }
@@ -698,35 +709,6 @@ pub fn download<P: AsRef<Path>>(
         .map_err(|e| Error::DiskSync(component_path.clone(), e))?;
 
     Ok(component_path)
-}
-
-fn report_download_progress(
-    name: &str,
-    progress_percent: u8,
-    update_iface: Option<&InterfaceRef<UpdateAgentManager<UpdateProgress>>>,
-) {
-    info!("downloading component `{name}`: {progress_percent}%");
-    if let Some(iface) = update_iface
-        && let Err(e) = interfaces::update_dbus_progress(
-            Some(ComponentStatus {
-                name: name.to_string(),
-                state: ComponentState::Downloading,
-                progress: progress_percent,
-            }),
-            Some(UpdateAgentState::Downloading),
-            iface,
-        )
-    {
-        warn!("{e:?}");
-    }
-}
-
-fn download_progress_percent(downloaded_bytes: u64, total_bytes: u64) -> u8 {
-    if total_bytes == 0 {
-        return 100;
-    }
-    let progress = downloaded_bytes.saturating_mul(100) / total_bytes;
-    progress.min(100) as u8
 }
 
 // Fetches a component by finding it on disk or downloading it from remote.
@@ -787,24 +769,4 @@ pub fn fetch<P: AsRef<Path>>(
         source: source.clone(),
         on_disk: path,
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::download_progress_percent;
-
-    #[test]
-    fn download_progress_uses_total_bytes_after_resume() {
-        assert_eq!(download_progress_percent(4_800, 5_600), 85);
-    }
-
-    #[test]
-    fn download_progress_clamps_to_complete() {
-        assert_eq!(download_progress_percent(120, 100), 100);
-    }
-
-    #[test]
-    fn download_progress_treats_empty_component_as_complete() {
-        assert_eq!(download_progress_percent(0, 0), 100);
-    }
 }

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -624,12 +624,11 @@ pub fn download<P: AsRef<Path>>(
     let mut current_delay = download_delay;
     let mut allowed_before = true;
 
-    let mut progress_percent = 0;
     for (i, range) in
         util::HttpRangeIter::try_new(start_bytes, component_remote_len - 1, CHUNK_SIZE)?
             .enumerate()
     {
-        progress_percent =
+        let progress_percent =
             (start_bytes + (i as u64 * CHUNK_SIZE as u64)) * 100 / component_remote_len;
 
         info!("downloading component `{name}`: {progress_percent}%");

--- a/update-agent/src/component.rs
+++ b/update-agent/src/component.rs
@@ -629,9 +629,8 @@ pub fn download<P: AsRef<Path>>(
         util::HttpRangeIter::try_new(start_bytes, component_remote_len - 1, CHUNK_SIZE)?
             .enumerate()
     {
-        let current_progress_percent =
+        progress_percent =
             (start_bytes + (i as u64 * CHUNK_SIZE as u64)) * 100 / component_remote_len;
-        progress_percent = current_progress_percent;
 
         info!("downloading component `{name}`: {progress_percent}%");
         if let Some(iface) = update_iface

--- a/update-agent/t/qemu-runner.js
+++ b/update-agent/t/qemu-runner.js
@@ -17,7 +17,7 @@ import { promises as fs, constants } from 'fs';
 import { join, resolve } from 'path';
 import { createHash } from 'crypto';
 
-const FEDORA_CLOUD_QCOW2_URL = 'https://mirror.us.mirhosting.net/fedora/linux/releases/42/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-42-1.1.x86_64.qcow2';
+const FEDORA_CLOUD_QCOW2_URL = 'https://download.fedoraproject.org/pub/fedora/linux/releases/44/Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2';
 const QEMU_MEMORY = '2G';
 const QEMU_DISK_SIZE = '64G';
 


### PR DESCRIPTION
## Summary
- Base update-agent download progress on the absolute downloaded offset instead of the resumed loop index.
- Keeps the existing logging and DBus reporting flow, while making resumed downloads show their real total progress.

CI failures fixed:
- Refresh Cargo.lock for current Cargo Deny RustSec advisories (`crossbeam-epoch`, `serial_test`/`scc`).
- Refresh the update-agent QEMU test Fedora Cloud image URL after the pinned mirror URL started returning 404.
