### PR TITLE
feat(worldcoin-attest): Add ExecStartPre for permissions on /usr/persistent/se

### DIFF
--- a/attest/debian/orb-attest.worldcoin-attest.service
+++ b/attest/debian/orb-attest.worldcoin-attest.service
@@ -21,6 +21,9 @@ Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
 Environment=RUST_BACKTRACE=1
 SyslogIdentifier=worldcoin-attest
 Restart=on-failure
+# In case /usr/persistent/se was manually re-proved under root
+ExecStartPre=+/bin/chmod -R +X /usr/persistent/se
+ExecStartPre=+/bin/chown -R worldcoin:worldcoin /usr/persistent/se
 # TODO: use the orb-info crate
 ExecStart=/bin/bash -c 'export ORB_ID="$("/usr/local/bin/orb-id")"; exec /usr/local/bin/orb-attest'
 IPAccounting=yes


### PR DESCRIPTION
Added ExecStartPre commands to set permissions and ownership for /usr/persistent/se.