### PR TITLE
refactor(connd): use crabwire::inject for DI on modem_supervisor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2475,6 +2475,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crabwire"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436cde1b854d98a37baace56bf17cd64a4b48821851ccdfe648908c3e1c48666"
+dependencies = [
+ "crabwire_macros",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "crabwire_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81c452987f1725b201224dcd5ae680e94c47aa907cf219fbe865a2e3627cd60f"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "crc"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7468,6 +7490,7 @@ dependencies = [
  "ciborium",
  "clap",
  "color-eyre",
+ "crabwire",
  "dashmap",
  "derive_more 2.1.1",
  "escargot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "crabwire"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436cde1b854d98a37baace56bf17cd64a4b48821851ccdfe648908c3e1c48666"
+checksum = "d1ccfeb0ef1e063ace4e5a93b51c003d4589906f6fa70a82014c96b2ac6e290b"
 dependencies = [
  "crabwire_macros",
  "foldhash 0.2.0",
@@ -2486,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "crabwire_macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c452987f1725b201224dcd5ae680e94c47aa907cf219fbe865a2e3627cd60f"
+checksum = "0d0e325d3562fcd522c37ead25a5912c793cc93dcb345b09b54aca6575575ae7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ clap-stdin = { version = "0.6.0", default-features = false }
 cmd_lib = "1.9.3"
 color-eyre = "0.6.5"
 console-subscriber = "0.4"
+crabwire = "0.1"
 dashmap = "5.5.3"
 data-encoding = "2.3"
 dbus-launch = "0.2.0"

--- a/orb-connd/Cargo.toml
+++ b/orb-connd/Cargo.toml
@@ -20,6 +20,7 @@ chrono.workspace = true
 ciborium.workspace = true
 clap = { workspace = true, features = ["derive"] }
 color-eyre.workspace = true
+crabwire.workspace = true
 dashmap.workspace = true
 derive_more = { workspace = true, default-features = false, features = ["display"] }
 flume.workspace = true

--- a/orb-connd/src/connectivity_daemon.rs
+++ b/orb-connd/src/connectivity_daemon.rs
@@ -1,9 +1,7 @@
-use crate::mcu_util::McuUtil;
 use crate::modem_manager::ModemManager;
 use crate::network_manager::NetworkManager;
 use crate::resolved::Resolved;
 use crate::service::{self, ConndService, ProfileStorage};
-use crate::systemd::Systemd;
 use crate::{modem, reporters, OrbCapabilities};
 use color_eyre::eyre::{Context, Result};
 use orb_dogd::MetricEmitter;
@@ -22,13 +20,11 @@ pub async fn program(
     procfs: impl AsRef<Path>,
     usr_persistent: impl AsRef<Path>,
     network_manager: NetworkManager,
-    systemd: Systemd,
     resolved: Resolved,
     session_bus: zbus::Connection,
     os_release: OrbOsRelease,
     statsd_client: impl MetricEmitter,
     modem_manager: impl ModemManager,
-    mcu_util: impl McuUtil,
     connect_timeout: Duration,
     profile_storage: ProfileStorage,
     zenoh: &Zenorb,
@@ -36,7 +32,6 @@ pub async fn program(
     let sysfs = sysfs.as_ref().to_path_buf();
     let procfs = procfs.as_ref().to_path_buf();
     let modem_manager: Arc<dyn ModemManager> = Arc::new(modem_manager);
-    let mcu_util: Arc<dyn McuUtil> = Arc::new(mcu_util);
     let statsd_client = Arc::new(statsd_client);
 
     let cap = OrbCapabilities::from_sysfs(&sysfs).await;
@@ -91,7 +86,6 @@ pub async fn program(
         resolved,
         session_bus,
         statsd_client.clone(),
-        systemd.clone(),
         zsender,
         sysfs,
         procfs,
@@ -104,8 +98,6 @@ pub async fn program(
             .args(modem::Args {
                 poll_interval: Duration::from_secs(30),
                 modem_manager,
-                mcu_util,
-                systemd,
                 metrics: statsd_client,
             })
             .on_err(OnErr::Restart {

--- a/orb-connd/src/connectivity_daemon.rs
+++ b/orb-connd/src/connectivity_daemon.rs
@@ -1,4 +1,3 @@
-use crate::modem_manager::ModemManager;
 use crate::network_manager::NetworkManager;
 use crate::resolved::Resolved;
 use crate::service::{self, ConndService, ProfileStorage};
@@ -24,14 +23,12 @@ pub async fn program(
     session_bus: zbus::Connection,
     os_release: OrbOsRelease,
     statsd_client: impl MetricEmitter,
-    modem_manager: impl ModemManager,
     connect_timeout: Duration,
     profile_storage: ProfileStorage,
     zenoh: &Zenorb,
 ) -> Result<mini::Ctx<()>> {
     let sysfs = sysfs.as_ref().to_path_buf();
     let procfs = procfs.as_ref().to_path_buf();
-    let modem_manager: Arc<dyn ModemManager> = Arc::new(modem_manager);
     let statsd_client = Arc::new(statsd_client);
 
     let cap = OrbCapabilities::from_sysfs(&sysfs).await;
@@ -97,7 +94,6 @@ pub async fn program(
             .task_with()
             .args(modem::Args {
                 poll_interval: Duration::from_secs(30),
-                modem_manager,
                 metrics: statsd_client,
             })
             .on_err(OnErr::Restart {

--- a/orb-connd/src/connectivity_daemon.rs
+++ b/orb-connd/src/connectivity_daemon.rs
@@ -3,12 +3,11 @@ use crate::resolved::Resolved;
 use crate::service::{self, ConndService, ProfileStorage};
 use crate::{modem, reporters, OrbCapabilities};
 use color_eyre::eyre::{Context, Result};
-use orb_dogd::MetricEmitter;
 use orb_info::orb_os_release::OrbOsRelease;
 use speare::mini::{self, OnErr};
 use speare::Backoff;
+use std::path::Path;
 use std::time::Duration;
-use std::{path::Path, sync::Arc};
 use tracing::{error, info};
 use zenorb::zenoh::bytes::Encoding;
 use zenorb::Zenorb;
@@ -22,14 +21,12 @@ pub async fn program(
     resolved: Resolved,
     session_bus: zbus::Connection,
     os_release: OrbOsRelease,
-    statsd_client: impl MetricEmitter,
     connect_timeout: Duration,
     profile_storage: ProfileStorage,
     zenoh: &Zenorb,
 ) -> Result<mini::Ctx<()>> {
     let sysfs = sysfs.as_ref().to_path_buf();
     let procfs = procfs.as_ref().to_path_buf();
-    let statsd_client = Arc::new(statsd_client);
 
     let cap = OrbCapabilities::from_sysfs(&sysfs).await;
 
@@ -60,7 +57,6 @@ pub async fn program(
         connect_timeout,
         &usr_persistent,
         profile_storage,
-        statsd_client.clone(),
     )
     .await?;
 
@@ -82,7 +78,6 @@ pub async fn program(
         network_manager,
         resolved,
         session_bus,
-        statsd_client.clone(),
         zsender,
         sysfs,
         procfs,
@@ -94,7 +89,6 @@ pub async fn program(
             .task_with()
             .args(modem::Args {
                 poll_interval: Duration::from_secs(30),
-                metrics: statsd_client,
             })
             .on_err(OnErr::Restart {
                 max: 10.into(),

--- a/orb-connd/src/main.rs
+++ b/orb-connd/src/main.rs
@@ -4,7 +4,7 @@ use orb_build_info::{make_build_info, BuildInfo};
 use orb_connd::{
     connectivity_daemon,
     mcu_util::{cli::McuUtilCli, McuUtil},
-    modem_manager::cli::ModemManagerCli,
+    modem_manager::{cli::ModemManagerCli, ModemManager},
     network_manager::NetworkManager,
     resolved::Resolved,
     secure_storage::{self, ConndStorageScopes, SecureStorage},
@@ -108,7 +108,8 @@ fn connectivity_daemon() -> Result<()> {
 
         let registry = crabwire::Registry::new()
             .insert(systemd)
-            .insert(Box::new(McuUtilCli) as Box<dyn McuUtil>);
+            .insert(Box::new(McuUtilCli) as Box<dyn McuUtil>)
+            .insert(Box::new(ModemManagerCli) as Box<dyn ModemManager>);
 
         crabwire::register!(registry);
 
@@ -121,7 +122,6 @@ fn connectivity_daemon() -> Result<()> {
             .session_bus(zbus::Connection::session().await?)
             .os_release(os_release)
             .statsd_client(DogstatsdClient::default())
-            .modem_manager(ModemManagerCli)
             .connect_timeout(Duration::from_secs(15))
             .profile_storage(profile_storage)
             .zenoh(&zenoh)

--- a/orb-connd/src/main.rs
+++ b/orb-connd/src/main.rs
@@ -3,7 +3,7 @@ use color_eyre::eyre::{Context, Result};
 use orb_build_info::{make_build_info, BuildInfo};
 use orb_connd::{
     connectivity_daemon,
-    mcu_util::cli::McuUtilCli,
+    mcu_util::{cli::McuUtilCli, McuUtil},
     modem_manager::cli::ModemManagerCli,
     network_manager::NetworkManager,
     resolved::Resolved,
@@ -106,7 +106,10 @@ fn connectivity_daemon() -> Result<()> {
             .with_name("connd")
             .await?;
 
-        let registry = crabwire::Registry::new();
+        let registry = crabwire::Registry::new()
+            .insert(systemd)
+            .insert(Box::new(McuUtilCli) as Box<dyn McuUtil>);
+
         crabwire::register!(registry);
 
         let speare = connectivity_daemon::program()
@@ -122,8 +125,6 @@ fn connectivity_daemon() -> Result<()> {
             .connect_timeout(Duration::from_secs(15))
             .profile_storage(profile_storage)
             .zenoh(&zenoh)
-            .mcu_util(McuUtilCli)
-            .systemd(systemd)
             .run()
             .await?;
 

--- a/orb-connd/src/main.rs
+++ b/orb-connd/src/main.rs
@@ -106,6 +106,9 @@ fn connectivity_daemon() -> Result<()> {
             .with_name("connd")
             .await?;
 
+        let registry = crabwire::Registry::new();
+        crabwire::register!(registry);
+
         let speare = connectivity_daemon::program()
             .sysfs("/sys")
             .procfs("/proc")

--- a/orb-connd/src/main.rs
+++ b/orb-connd/src/main.rs
@@ -109,7 +109,8 @@ fn connectivity_daemon() -> Result<()> {
         let registry = crabwire::Registry::new()
             .insert(systemd)
             .insert(Box::new(McuUtilCli) as Box<dyn McuUtil>)
-            .insert(Box::new(ModemManagerCli) as Box<dyn ModemManager>);
+            .insert(Box::new(ModemManagerCli) as Box<dyn ModemManager>)
+            .insert(DogstatsdClient::default());
 
         crabwire::register!(registry);
 
@@ -121,7 +122,6 @@ fn connectivity_daemon() -> Result<()> {
             .resolved(resolved)
             .session_bus(zbus::Connection::session().await?)
             .os_release(os_release)
-            .statsd_client(DogstatsdClient::default())
             .connect_timeout(Duration::from_secs(15))
             .profile_storage(profile_storage)
             .zenoh(&zenoh)

--- a/orb-connd/src/modem/mod.rs
+++ b/orb-connd/src/modem/mod.rs
@@ -34,11 +34,10 @@ pub struct Snapshot {
 
 pub struct Args<M: MetricEmitter> {
     pub poll_interval: Duration,
-    pub modem_manager: Arc<dyn ModemManager>,
     pub metrics: Arc<M>,
 }
 
-#[inject(systemd: &Systemd, mcu_util: &Box<dyn McuUtil>)]
+#[inject(systemd: &Systemd, mcu_util: &Box<dyn McuUtil>, modem_manager: &Box<dyn ModemManager>)]
 pub async fn supervisor<M>(ctx: mini::Ctx<Args<M>>) -> Result<()>
 where
     M: MetricEmitter,
@@ -47,7 +46,7 @@ where
 
     let mut snapshot: Option<Snapshot> = None;
     let mut refresh_snapshot = async || -> Result<()> {
-        let new_snapshot = take_snapshot(ctx.modem_manager.as_ref()).await?;
+        let new_snapshot = take_snapshot(modem_manager.as_ref()).await?;
 
         let modem_id_changed_msg = match &snapshot {
             None => Some(format!(
@@ -68,7 +67,7 @@ where
             warn!(msg);
 
             let _ =
-                setup_signal_and_bands(ctx.modem_manager.as_ref(), &new_snapshot.id)
+                setup_signal_and_bands(modem_manager.as_ref(), &new_snapshot.id)
                     .await
                     .inspect_err(|e| warn!("failed to setup signal and bands: {e:?}"));
         }
@@ -91,9 +90,11 @@ where
                 ctx.metrics
                     .count("orb.platform.connd.modem_powercycle", 1, NO_TAGS);
 
-            let _ = powercycle_modem(mcu_util.as_ref(), systemd).await.inspect_err(|e| {
-                error!("failed to to powercycle modem with err: {e:?}");
-            });
+            let _ = powercycle_modem(mcu_util.as_ref(), systemd)
+                .await
+                .inspect_err(|e| {
+                    error!("failed to to powercycle modem with err: {e:?}");
+                });
 
             return Err(e);
         }

--- a/orb-connd/src/modem/mod.rs
+++ b/orb-connd/src/modem/mod.rs
@@ -9,6 +9,7 @@ use color_eyre::{
     eyre::{eyre, Context, ContextCompat},
     Result,
 };
+use crabwire::inject;
 use orb_dogd::{MetricEmitter, NO_TAGS};
 use speare::mini;
 use std::{sync::Arc, time::Duration};
@@ -34,11 +35,10 @@ pub struct Snapshot {
 pub struct Args<M: MetricEmitter> {
     pub poll_interval: Duration,
     pub modem_manager: Arc<dyn ModemManager>,
-    pub mcu_util: Arc<dyn McuUtil>,
-    pub systemd: Systemd,
     pub metrics: Arc<M>,
 }
 
+#[inject(systemd: &Systemd, mcu_util: &Box<dyn McuUtil>)]
 pub async fn supervisor<M>(ctx: mini::Ctx<Args<M>>) -> Result<()>
 where
     M: MetricEmitter,
@@ -91,11 +91,9 @@ where
                 ctx.metrics
                     .count("orb.platform.connd.modem_powercycle", 1, NO_TAGS);
 
-            let _ = powercycle_modem(ctx.mcu_util.as_ref(), &ctx.systemd)
-                .await
-                .inspect_err(|e| {
-                    error!("failed to to powercycle modem with err: {e:?}");
-                });
+            let _ = powercycle_modem(mcu_util.as_ref(), systemd).await.inspect_err(|e| {
+                error!("failed to to powercycle modem with err: {e:?}");
+            });
 
             return Err(e);
         }

--- a/orb-connd/src/modem/mod.rs
+++ b/orb-connd/src/modem/mod.rs
@@ -10,9 +10,9 @@ use color_eyre::{
     Result,
 };
 use crabwire::inject;
-use orb_dogd::{MetricEmitter, NO_TAGS};
+use orb_dogd::{DogstatsdClient, MetricEmitter, NO_TAGS};
 use speare::mini;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tokio::{
     fs,
     time::{self, timeout},
@@ -32,16 +32,12 @@ pub struct Snapshot {
     pub location: Location,
 }
 
-pub struct Args<M: MetricEmitter> {
+pub struct Args {
     pub poll_interval: Duration,
-    pub metrics: Arc<M>,
 }
 
-#[inject(systemd: &Systemd, mcu_util: &Box<dyn McuUtil>, modem_manager: &Box<dyn ModemManager>)]
-pub async fn supervisor<M>(ctx: mini::Ctx<Args<M>>) -> Result<()>
-where
-    M: MetricEmitter,
-{
+#[inject(systemd: &Systemd, mcu_util: &Box<dyn McuUtil>, modem_manager: &Box<dyn ModemManager>, metrics: &DogstatsdClient)]
+pub async fn supervisor(ctx: mini::Ctx<Args>) -> Result<()> {
     info!("starting modem supervisor");
 
     let mut snapshot: Option<Snapshot> = None;
@@ -66,10 +62,9 @@ where
         if let Some(msg) = modem_id_changed_msg {
             warn!(msg);
 
-            let _ =
-                setup_signal_and_bands(modem_manager.as_ref(), &new_snapshot.id)
-                    .await
-                    .inspect_err(|e| warn!("failed to setup signal and bands: {e:?}"));
+            let _ = setup_signal_and_bands(modem_manager.as_ref(), &new_snapshot.id)
+                .await
+                .inspect_err(|e| warn!("failed to setup signal and bands: {e:?}"));
         }
 
         let _ = ctx.publish("modem-snapshot", new_snapshot.clone());
@@ -86,9 +81,7 @@ where
             error!("failed to refresh modem snapshot with err: {e}");
             error!("powercycling modem");
 
-            let _ =
-                ctx.metrics
-                    .count("orb.platform.connd.modem_powercycle", 1, NO_TAGS);
+            let _ = metrics.count("orb.platform.connd.modem_powercycle", 1, NO_TAGS);
 
             let _ = powercycle_modem(mcu_util.as_ref(), systemd)
                 .await

--- a/orb-connd/src/reporters/connd_report.rs
+++ b/orb-connd/src/reporters/connd_report.rs
@@ -1,26 +1,27 @@
 use crate::network_manager::{Connection, NetworkManager};
 use color_eyre::{eyre::Context, Result};
+use crabwire::inject;
 use flume::Receiver;
 use orb_backend_status_dbus::{
     types::{ConndReport, WifiNetwork, WifiProfile},
     BackendStatusProxy,
 };
-use orb_dogd::MetricEmitter;
+use orb_dogd::{DogstatsdClient, MetricEmitter};
 use speare::mini;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tokio::time;
 use tracing::{info, warn};
 
-pub struct Args<M: MetricEmitter> {
+pub struct Args {
     pub nm: NetworkManager,
     pub session_bus: zbus::Connection,
     pub report_interval: Duration,
-    pub metrics: Arc<M>,
 }
 
 const IFACES: &[&str] = &["eth0", "wwan0", "wlan0"];
 
-pub async fn report<M: MetricEmitter>(ctx: mini::Ctx<Args<M>>) -> Result<()> {
+#[inject(metrics: &DogstatsdClient)]
+pub async fn report(ctx: mini::Ctx<Args>) -> Result<()> {
     info!("starting connd report reporter");
 
     async {
@@ -60,7 +61,7 @@ pub async fn report<M: MetricEmitter>(ctx: mini::Ctx<Args<M>>) -> Result<()> {
                     _ => 0.0,
                 };
 
-                let _ = ctx.metrics.gauge(
+                let _ = metrics.gauge(
                     "orb.platform.connd.primary_connection",
                     value,
                     [format!("iface:{conn}")],

--- a/orb-connd/src/reporters/data_usage.rs
+++ b/orb-connd/src/reporters/data_usage.rs
@@ -1,18 +1,14 @@
 use crate::systemd::{IpAccounting, ServiceProxyExt, Systemd};
 use color_eyre::Result;
 use crabwire::inject;
-use orb_dogd::MetricEmitter;
+use orb_dogd::{DogstatsdClient, MetricEmitter};
 use speare::mini;
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, time::Duration};
 use tokio::time;
 use tracing::{info, warn};
 
-pub struct Args<M: MetricEmitter> {
-    pub statsd: Arc<M>,
-}
-
-#[inject(systemd: &Systemd)]
-pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
+#[inject(systemd: &Systemd, statsd: &DogstatsdClient)]
+pub async fn report(_: mini::Ctx<()>) -> Result<()> {
     info!("starting data usage reporter");
 
     let mut data_usage_map: HashMap<String, IpAccounting> = HashMap::new();
@@ -45,7 +41,7 @@ pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
             let tags = vec![format!("service:{unit}")];
 
             if ingress_diff > 0 {
-                let _ = ctx.statsd.count(
+                let _ = statsd.count(
                     "orb.platform.connd.service_ingress_bytes",
                     ingress_diff as i64,
                     tags.clone(),
@@ -53,7 +49,7 @@ pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
             }
 
             if egress_diff > 0 {
-                let _ = ctx.statsd.count(
+                let _ = statsd.count(
                     "orb.platform.connd.service_egress_bytes",
                     egress_diff as i64,
                     tags,

--- a/orb-connd/src/reporters/data_usage.rs
+++ b/orb-connd/src/reporters/data_usage.rs
@@ -1,5 +1,6 @@
 use crate::systemd::{IpAccounting, ServiceProxyExt, Systemd};
 use color_eyre::Result;
+use crabwire::inject;
 use orb_dogd::MetricEmitter;
 use speare::mini;
 use std::{collections::HashMap, sync::Arc, time::Duration};
@@ -8,16 +9,16 @@ use tracing::{info, warn};
 
 pub struct Args<M: MetricEmitter> {
     pub statsd: Arc<M>,
-    pub systemd: Systemd,
 }
 
+#[inject(systemd: &Systemd)]
 pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
     info!("starting data usage reporter");
 
     let mut data_usage_map: HashMap<String, IpAccounting> = HashMap::new();
 
     loop {
-        let new_data_usage_map = get_data_usage_map(&ctx.systemd).await?;
+        let new_data_usage_map = get_data_usage_map(systemd).await?;
 
         for (unit, usage) in new_data_usage_map.iter() {
             let Some(old_usage) = data_usage_map.get(unit) else {

--- a/orb-connd/src/reporters/datadog.rs
+++ b/orb-connd/src/reporters/datadog.rs
@@ -1,16 +1,14 @@
 use crate::modem;
 use color_eyre::Result;
+use crabwire::inject;
 use flume::Receiver;
-use orb_dogd::{MetricEmitter, NO_TAGS};
+use orb_dogd::{DogstatsdClient, MetricEmitter, NO_TAGS};
 use speare::mini;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 use tracing::{info, warn};
 
-pub struct Args<M: MetricEmitter> {
-    pub statsd: Arc<M>,
-}
-
-pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
+#[inject(statsd: &DogstatsdClient)]
+pub async fn report(ctx: mini::Ctx<()>) -> Result<()> {
     info!("starting datadog reporter");
 
     async {
@@ -23,7 +21,7 @@ pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
         loop {
             tokio::select! {
                 Ok(snapshot) = modem_snapshot_rx.recv_async() => {
-                    report_modem(ctx.statsd.as_ref(), snapshot).await?;
+                    report_modem(statsd, snapshot).await?;
                 }
 
                 Ok(all_netstats) = netstats_rx.recv_async() => {
@@ -31,7 +29,7 @@ pub async fn report(ctx: mini::Ctx<Args<impl MetricEmitter>>) -> Result<()> {
                         let old_netstats = netstats_map.remove(&new_netstats.iface)
                             .unwrap_or_else(|| new_netstats.clone());
 
-                        report_netstats(ctx.statsd.as_ref(), &old_netstats, &new_netstats).await?;
+                        report_netstats(statsd, &old_netstats, &new_netstats).await?;
 
                         netstats_map.insert(new_netstats.iface.clone(), new_netstats);
                     }

--- a/orb-connd/src/reporters/mod.rs
+++ b/orb-connd/src/reporters/mod.rs
@@ -1,4 +1,4 @@
-use crate::{network_manager::NetworkManager, resolved::Resolved, systemd::Systemd};
+use crate::{network_manager::NetworkManager, resolved::Resolved};
 use color_eyre::Result;
 use orb_dogd::MetricEmitter;
 use speare::{mini::OnErr, Backoff, Limit};
@@ -19,7 +19,6 @@ pub async fn spawn(
     resolved: Resolved,
     session_bus: zbus::Connection,
     statsd: Arc<impl MetricEmitter>,
-    systemd: Systemd,
     zsender: zenorb::Sender,
     sysfs: PathBuf,
     procfs: PathBuf,
@@ -78,7 +77,7 @@ pub async fn spawn(
 
     speare
         .task_with()
-        .args(data_usage::Args { statsd, systemd })
+        .args(data_usage::Args { statsd })
         .on_err(static_backoff(15))
         .spawn(data_usage::report)?;
 

--- a/orb-connd/src/reporters/mod.rs
+++ b/orb-connd/src/reporters/mod.rs
@@ -1,8 +1,7 @@
 use crate::{network_manager::NetworkManager, resolved::Resolved};
 use color_eyre::Result;
-use orb_dogd::MetricEmitter;
 use speare::{mini::OnErr, Backoff, Limit};
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{path::PathBuf, time::Duration};
 use tracing::info;
 
 pub mod active_connections;
@@ -18,7 +17,6 @@ pub async fn spawn(
     nm: NetworkManager,
     resolved: Resolved,
     session_bus: zbus::Connection,
-    statsd: Arc<impl MetricEmitter>,
     zsender: zenorb::Sender,
     sysfs: PathBuf,
     procfs: PathBuf,
@@ -46,9 +44,6 @@ pub async fn spawn(
 
     speare
         .task_with()
-        .args(datadog::Args {
-            statsd: statsd.clone(),
-        })
         .on_err(static_backoff(15))
         .spawn(datadog::report)?;
 
@@ -58,7 +53,6 @@ pub async fn spawn(
             nm: nm.clone(),
             session_bus,
             report_interval: Duration::from_secs(30),
-            metrics: statsd.clone(),
         })
         .on_err(static_backoff(15))
         .spawn(connd_report::report)?;
@@ -77,7 +71,6 @@ pub async fn spawn(
 
     speare
         .task_with()
-        .args(data_usage::Args { statsd })
         .on_err(static_backoff(15))
         .spawn(data_usage::report)?;
 

--- a/orb-connd/src/service/dbus.rs
+++ b/orb-connd/src/service/dbus.rs
@@ -10,18 +10,16 @@ use crate::{
 use async_trait::async_trait;
 use chrono::Utc;
 use color_eyre::eyre::eyre;
+use crabwire::inject;
 use orb_connd_dbus::{ConndT, ConnectionState};
-use orb_dogd::MetricEmitter;
+use orb_dogd::{DogstatsdClient, MetricEmitter};
 use orb_info::orb_os_release::OrbRelease;
 use rusty_network_manager::dbus_interface_types::NMConnectivityState;
 use tracing::{error, info, warn};
 use zbus::fdo::{Error as ZErr, Result as ZResult};
 
 #[async_trait]
-impl<M> ConndT for ConndService<M>
-where
-    M: MetricEmitter,
-{
+impl ConndT for ConndService {
     /// d-bus impl
     async fn netconfig_set(
         &self,
@@ -98,6 +96,7 @@ where
     }
 
     /// d-bus impl
+    #[inject(metrics: &DogstatsdClient)]
     async fn apply_wifi_qr(&self, contents: String) -> ZResult<()> {
         let started = Instant::now();
 
@@ -158,18 +157,19 @@ where
             ["success:false"]
         };
 
-        let _ = self.metrics.dist(
+        let _ = metrics.dist(
             "orb.platform.connd.wifi_qr_duration",
             started.elapsed().as_millis() as f64,
             tags,
         );
 
-        let _ = self.metrics.count("orb.platform.connd.wifi_qr", 1, tags);
+        let _ = metrics.count("orb.platform.connd.wifi_qr", 1, tags);
 
         result
     }
 
     /// d-bus impl
+    #[inject(metrics: &DogstatsdClient)]
     async fn apply_netconfig_qr(
         &self,
         contents: String,
@@ -252,15 +252,13 @@ where
             ["success:false"]
         };
 
-        let _ = self.metrics.dist(
+        let _ = metrics.dist(
             "orb.platform.connd.netconfig_qr_duration",
             started.elapsed().as_millis() as f64,
             tags,
         );
 
-        let _ = self
-            .metrics
-            .count("orb.platform.connd.netconfig_qr", 1, tags);
+        let _ = metrics.count("orb.platform.connd.netconfig_qr", 1, tags);
 
         result
     }

--- a/orb-connd/src/service/mod.rs
+++ b/orb-connd/src/service/mod.rs
@@ -11,13 +11,11 @@ use color_eyre::{
     Result,
 };
 use orb_connd_dbus::{Connd, OBJ_PATH, SERVICE};
-use orb_dogd::MetricEmitter;
 use orb_info::orb_os_release::OrbRelease;
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::collections::HashSet;
 use std::path::Path;
-use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::fs::{self, File};
 use tokio::io::{self};
@@ -33,7 +31,7 @@ mod wifi;
 mod wpa_conf;
 pub mod zoci;
 
-pub struct ConndService<M: MetricEmitter> {
+pub struct ConndService {
     session_dbus: zbus::Connection,
     nm: NetworkManager,
     release: OrbRelease,
@@ -41,7 +39,6 @@ pub struct ConndService<M: MetricEmitter> {
     magic_qr_applied_at: State<DateTime<Utc>>,
     connect_timeout: Duration,
     profile_storage: ProfileStorage,
-    metrics: Arc<M>,
 }
 
 #[derive(Debug, Clone)]
@@ -56,10 +53,7 @@ impl ProfileStorage {
     }
 }
 
-impl<M> Clone for ConndService<M>
-where
-    M: MetricEmitter,
-{
+impl Clone for ConndService {
     fn clone(&self) -> Self {
         Self {
             session_dbus: self.session_dbus.clone(),
@@ -69,15 +63,11 @@ where
             magic_qr_applied_at: self.magic_qr_applied_at.clone(),
             connect_timeout: self.connect_timeout,
             profile_storage: self.profile_storage.clone(),
-            metrics: self.metrics.clone(),
         }
     }
 }
 
-impl<M> ConndService<M>
-where
-    M: MetricEmitter,
-{
+impl ConndService {
     const NM_FOLDER: &str = "network-manager";
     const DEFAULT_CELLULAR_PROFILE: &str = "cellular";
     const DEFAULT_CELLULAR_APN: &str = "em";
@@ -98,7 +88,6 @@ where
         connect_timeout: Duration,
         usr_persistent: impl AsRef<Path>,
         profile_storage: ProfileStorage,
-        metrics: Arc<M>,
     ) -> Result<Self> {
         let usr_persistent = usr_persistent.as_ref();
 
@@ -110,7 +99,6 @@ where
             magic_qr_applied_at: State::new(DateTime::default()),
             connect_timeout,
             profile_storage,
-            metrics,
         };
 
         // we start after NM, but NM slow (c++ haha), we also slow, but they slower

--- a/orb-connd/src/service/zoci.rs
+++ b/orb-connd/src/service/zoci.rs
@@ -3,7 +3,6 @@ use crate::{
     service::ConndService,
 };
 use color_eyre::{eyre::eyre, Result};
-use orb_dogd::MetricEmitter;
 use rusty_network_manager::dbus_interface_types::NM80211Mode;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -21,10 +20,7 @@ struct WifiAdd {
     join_now: bool,
 }
 
-pub async fn wifi_add(
-    connd: ConndService<impl MetricEmitter>,
-    query: Query,
-) -> Result<()> {
+pub async fn wifi_add(connd: ConndService, query: Query) -> Result<()> {
     let response = async {
         let WifiAdd {
             ssid,
@@ -92,10 +88,7 @@ pub async fn wifi_add(
     Ok(())
 }
 
-pub async fn wifi_connect(
-    connd: ConndService<impl MetricEmitter>,
-    query: Query,
-) -> Result<()> {
+pub async fn wifi_connect(connd: ConndService, query: Query) -> Result<()> {
     let response = async {
         let ssid = query.payload_str()?;
         connd
@@ -111,10 +104,7 @@ pub async fn wifi_connect(
     Ok(())
 }
 
-pub async fn wifi_list(
-    connd: ConndService<impl MetricEmitter>,
-    query: Query,
-) -> Result<()> {
+pub async fn wifi_list(connd: ConndService, query: Query) -> Result<()> {
     info!("listing wifi profiles");
 
     let active_conns = connd
@@ -146,10 +136,7 @@ pub async fn wifi_list(
     Ok(())
 }
 
-pub async fn wifi_scan(
-    connd: ConndService<impl MetricEmitter>,
-    query: Query,
-) -> Result<()> {
+pub async fn wifi_scan(connd: ConndService, query: Query) -> Result<()> {
     info!("scanning for wifi access points");
     let response = connd
         .wifi_scan()
@@ -168,10 +155,7 @@ pub async fn wifi_scan(
     Ok(())
 }
 
-pub async fn wifi_remove(
-    connd: ConndService<impl MetricEmitter>,
-    query: Query,
-) -> Result<()> {
+pub async fn wifi_remove(connd: ConndService, query: Query) -> Result<()> {
     let response = async {
         let ssid = query.payload_str()?;
         connd.remove_wifi_profile(&ssid).await?;

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -210,7 +210,9 @@ impl Fixture {
         let registry = crabwire::Registry::new()
             .insert(Systemd::new(conn.clone()))
             .insert(Box::new(mcu_util.unwrap_or_else(default_mock_mcu_util_cli))
-                as Box<dyn McuUtil>);
+                as Box<dyn McuUtil>)
+            .insert(Box::new(modem_manager.unwrap_or_else(default_mockmmcli))
+                as Box<dyn ModemManager>);
 
         let _ = crabwire::try_register!(registry);
 
@@ -222,7 +224,6 @@ impl Fixture {
                 expected_main_mcu_version: String::new(),
                 expected_sec_mcu_version: String::new(),
             })
-            .modem_manager(modem_manager.unwrap_or_else(default_mockmmcli))
             .network_manager(nm.clone())
             .resolved(Resolved::new(conn.clone()))
             .statsd_client(statsd.unwrap_or(MockStatsd))
@@ -329,7 +330,6 @@ impl Fixture {
                 expected_main_mcu_version: String::new(),
                 expected_sec_mcu_version: String::new(),
             })
-            .modem_manager(default_mockmmcli())
             .network_manager(nm.clone())
             .resolved(Resolved::new(self.conn.clone()))
             .statsd_client(MockStatsd)

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -207,6 +207,9 @@ impl Fixture {
             .await
             .unwrap();
 
+        let registry = crabwire::Registry::new();
+        let _ = crabwire::try_register!(registry);
+
         let speare = program()
             .os_release(OrbOsRelease {
                 release_type: release,
@@ -266,6 +269,7 @@ impl Fixture {
         &self.zsession
     }
 
+    // TODO: refactor this shit to repeat less code
     pub async fn restart(&mut self) {
         self.speare.abort_children().unwrap();
         self.container.rm().await;

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -207,7 +207,11 @@ impl Fixture {
             .await
             .unwrap();
 
-        let registry = crabwire::Registry::new();
+        let registry = crabwire::Registry::new()
+            .insert(Systemd::new(conn.clone()))
+            .insert(Box::new(mcu_util.unwrap_or_else(default_mock_mcu_util_cli))
+                as Box<dyn McuUtil>);
+
         let _ = crabwire::try_register!(registry);
 
         let speare = program()
@@ -221,7 +225,6 @@ impl Fixture {
             .modem_manager(modem_manager.unwrap_or_else(default_mockmmcli))
             .network_manager(nm.clone())
             .resolved(Resolved::new(conn.clone()))
-            .systemd(Systemd::new(conn.clone()))
             .statsd_client(statsd.unwrap_or(MockStatsd))
             .sysfs(sysfs.clone())
             .procfs(procfs.clone())
@@ -230,7 +233,6 @@ impl Fixture {
             .connect_timeout(Duration::from_secs(1))
             .profile_storage(profile_storage)
             .zenoh(&zsession)
-            .mcu_util(mcu_util.unwrap_or_else(default_mock_mcu_util_cli))
             .run()
             .await
             .unwrap();
@@ -330,7 +332,6 @@ impl Fixture {
             .modem_manager(default_mockmmcli())
             .network_manager(nm.clone())
             .resolved(Resolved::new(self.conn.clone()))
-            .systemd(Systemd::new(self.conn.clone()))
             .statsd_client(MockStatsd)
             .sysfs(self.sysfs.clone())
             .procfs(self.procfs.clone())
@@ -339,7 +340,6 @@ impl Fixture {
             .connect_timeout(Duration::from_secs(1))
             .profile_storage(profile_storage)
             .zenoh(&zsession)
-            .mcu_util(default_mock_mcu_util_cli())
             .run()
             .await
             .unwrap();

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -22,7 +22,7 @@ use orb_connd::{
     OrbCapabilities,
 };
 use orb_connd_dbus::ConndProxy;
-use orb_dogd::MetricEmitter;
+use orb_dogd::DogstatsdClient;
 use orb_info::{
     orb_os_release::{OrbOsPlatform, OrbOsRelease, OrbRelease},
     OrbId,
@@ -83,7 +83,6 @@ impl Fixture {
         release: OrbRelease,
         #[builder(default = OrbCapabilities::WifiOnly)] cap: OrbCapabilities,
         modem_manager: Option<MockMMCli>,
-        statsd: Option<MockStatsd>,
         wpa_ctrl: Option<MockWpaCli>,
         arrange: Option<Callback<Ctx>>,
         mcu_util: Option<MockMcuUtilCli>,
@@ -207,12 +206,17 @@ impl Fixture {
             .await
             .unwrap();
 
+        let mcu_util: Box<dyn McuUtil> =
+            Box::new(mcu_util.unwrap_or_else(default_mock_mcu_util_cli));
+
+        let modem_manager: Box<dyn ModemManager> =
+            Box::new(modem_manager.unwrap_or_else(default_mockmmcli));
+
         let registry = crabwire::Registry::new()
             .insert(Systemd::new(conn.clone()))
-            .insert(Box::new(mcu_util.unwrap_or_else(default_mock_mcu_util_cli))
-                as Box<dyn McuUtil>)
-            .insert(Box::new(modem_manager.unwrap_or_else(default_mockmmcli))
-                as Box<dyn ModemManager>);
+            .insert(mcu_util)
+            .insert(modem_manager)
+            .insert(DogstatsdClient::default());
 
         let _ = crabwire::try_register!(registry);
 
@@ -226,7 +230,6 @@ impl Fixture {
             })
             .network_manager(nm.clone())
             .resolved(Resolved::new(conn.clone()))
-            .statsd_client(statsd.unwrap_or(MockStatsd))
             .sysfs(sysfs.clone())
             .procfs(procfs.clone())
             .usr_persistent(usr_persistent.clone())
@@ -332,7 +335,6 @@ impl Fixture {
             })
             .network_manager(nm.clone())
             .resolved(Resolved::new(self.conn.clone()))
-            .statsd_client(MockStatsd)
             .sysfs(self.sysfs.clone())
             .procfs(self.procfs.clone())
             .usr_persistent(self.usr_persistent.clone())
@@ -508,83 +510,6 @@ mock! {
             allowed: &[&'a str],
             preferred: &'a str,
         ) -> Result<()>;
-    }
-}
-
-pub struct MockStatsd;
-
-impl MetricEmitter for MockStatsd {
-    fn count<S, I>(
-        &self,
-        _stat: S,
-        _val: i64,
-        _tags: I,
-    ) -> Result<(), orb_dogd::MetricError>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item: Into<String>>,
-    {
-        Ok(())
-    }
-
-    fn incr<S, I>(&self, _stat: S, _tags: I) -> Result<(), orb_dogd::MetricError>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item: Into<String>>,
-    {
-        Ok(())
-    }
-
-    fn gauge<S, I>(
-        &self,
-        _stat: S,
-        _val: f64,
-        _tags: I,
-    ) -> Result<(), orb_dogd::MetricError>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item: Into<String>>,
-    {
-        Ok(())
-    }
-
-    fn hist<S, I>(
-        &self,
-        _stat: S,
-        _val: f64,
-        _tags: I,
-    ) -> Result<(), orb_dogd::MetricError>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item: Into<String>>,
-    {
-        Ok(())
-    }
-
-    fn dist<S, I>(
-        &self,
-        _stat: S,
-        _val: f64,
-        _tags: I,
-    ) -> Result<(), orb_dogd::MetricError>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item: Into<String>>,
-    {
-        Ok(())
-    }
-
-    fn timing<S, I>(
-        &self,
-        _stat: S,
-        _val: i64,
-        _tags: I,
-    ) -> Result<(), orb_dogd::MetricError>
-    where
-        S: Into<String>,
-        I: IntoIterator<Item: Into<String>>,
-    {
-        Ok(())
     }
 }
 


### PR DESCRIPTION
## changes
- refactors modem supervisor and other functions that share the same dependencies to use `crabwire::inejct` to inject depndencies to avoid having to drill them down every single function