### PR TITLE
refactor(connd): make fixture startable / stoppable, remove duplicated code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14633,6 +14633,7 @@ dependencies = [
 name = "zenorb"
 version = "0.1.0"
 dependencies = [
+ "async-tempfile",
  "bon",
  "color-eyre",
  "orb-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2476,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "crabwire"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ccfeb0ef1e063ace4e5a93b51c003d4589906f6fa70a82014c96b2ac6e290b"
+checksum = "e3169ef8d67c50d5dff4b93c43493533a5550aee64a5386893e45ddca7602bad"
 dependencies = [
  "crabwire_macros",
  "foldhash 0.2.0",

--- a/orb-connd/Cargo.toml
+++ b/orb-connd/Cargo.toml
@@ -67,6 +67,7 @@ zenorb.workspace = true
 
 [dev-dependencies]
 async-tempfile.workspace = true
+crabwire = { workspace = true, features = ["testing"] }
 escargot.workspace = true
 test-utils.workspace = true
 nix = { workspace = true, features = ["socket"] }

--- a/orb-connd/tests/connd_service.rs
+++ b/orb-connd/tests/connd_service.rs
@@ -10,13 +10,14 @@ mod fixture;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_does_not_change_netconfig_if_no_cellular() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .cap(OrbCapabilities::WifiOnly)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // Act
     let actual = connd
@@ -35,13 +36,14 @@ async fn it_does_not_change_netconfig_if_no_cellular() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_sets_and_gets_netconfig() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .cap(OrbCapabilities::CellularAndWifi)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // Act
     let res = connd.netconfig_set(false, false, false).await.unwrap();
@@ -67,13 +69,14 @@ async fn it_sets_and_gets_netconfig() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_returns_connected_connection_state() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .cap(OrbCapabilities::CellularAndWifi)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // Act
     let state = connd.connection_state().await.unwrap();
@@ -85,14 +88,16 @@ async fn it_returns_connected_connection_state() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_returns_partial_connection_state() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .cap(OrbCapabilities::CellularAndWifi)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // change connectivity check uri
-    let out = fx.container
+    let out = handle.container
         .exec(&[
             "sed",
             "-i",
@@ -107,7 +112,7 @@ async fn it_returns_partial_connection_state() {
     assert!(out.status.success(), "stdout: {stdout}\nstderr: {stderr}");
 
     // reload network manager to apply new connectivity check uri
-    let out = fx.container.exec(&["nmcli", "general", "reload"]).await;
+    let out = handle.container.exec(&["nmcli", "general", "reload"]).await;
 
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
@@ -116,7 +121,7 @@ async fn it_returns_partial_connection_state() {
     // wait enough time for nmcli to reload
     time::sleep(Duration::from_secs(1)).await;
 
-    let connd = fx.connd().await;
+    let connd = handle.connd().await;
 
     // Act
     let state = connd.connection_state().await.unwrap();

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -212,7 +212,7 @@ impl Fixture {
             .insert(modem_manager)
             .insert(DogstatsdClient::default());
 
-        let _ = crabwire::reregister!(registry);
+        crabwire::reregister!(registry);
 
         let speare = program()
             .os_release(OrbOsRelease {

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -78,7 +78,7 @@ impl Fixture {
     pub async fn new(
         #[builder(start_fn)] platform: OrbOsPlatform,
         release: OrbRelease,
-        #[builder(default = OrbCapabilities::CellularAndWifi)] cap: OrbCapabilities,
+        #[builder(default = OrbCapabilities::WifiOnly)] cap: OrbCapabilities,
         modem_manager: Option<MockMMCli>,
         wpa_ctrl: Option<MockWpaCli>,
         mcu_util: Option<MockMcuUtilCli>,

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -27,8 +27,6 @@ use orb_info::{
     orb_os_release::{OrbOsPlatform, OrbOsRelease, OrbRelease},
     OrbId,
 };
-use prelude::future::Callback;
-use speare::mini;
 use std::{
     env,
     os::unix::fs::FileTypeExt,
@@ -37,279 +35,154 @@ use std::{
     time::Duration,
 };
 use test_utils::docker::{self, Container};
-use tokio::{fs, time};
+use tokio::{fs, task, time};
 use tokio_util::sync::CancellationToken;
 use zbus::Address;
 use zenorb::{zenoh, Zenorb};
 
-#[allow(dead_code)]
 pub struct Fixture {
-    pub nm: NetworkManager,
+    orb_id: OrbId,
+    platform: OrbOsPlatform,
+    release: OrbRelease,
+    cap: OrbCapabilities,
+
+    modem_manager: Option<MockMMCli>,
+    wpa_ctrl: Option<MockWpaCli>,
+    mcu_util: Option<MockMcuUtilCli>,
+
+    container_tempdir: TempDir,
+    sysfs: PathBuf,
+    procfs: PathBuf,
+    pub usr_persistent: PathBuf,
+    connd_bin_path: PathBuf,
+}
+
+pub struct FxHandle {
     pub container: Container,
-    conn: zbus::Connection,
-    speare: mini::Ctx<()>,
-    pub sysfs: PathBuf,
-    pub procfs: PathBuf,
-    pub usr_persistent: PathBuf,
-    pub secure_storage: SecureStorage,
-    pub secure_storage_cancel_token: CancellationToken,
-    pub platform: OrbOsPlatform,
-    zsession: Zenorb,
-    router_socket: PathBuf,
-    pub orb_id: String,
-    pub connd_path: PathBuf,
-}
 
-impl Drop for Fixture {
-    fn drop(&mut self) {
-        self.secure_storage_cancel_token.cancel();
+    zenorb: Zenorb,
+    zenoh_router_socket: PathBuf,
 
-        self.speare.abort_children().unwrap();
-    }
-}
-
-#[allow(dead_code)]
-pub struct Ctx {
-    pub usr_persistent: PathBuf,
+    dbus: zbus::Connection,
     pub nm: NetworkManager,
+
     pub secure_storage: SecureStorage,
+    secure_storage_cancel_token: CancellationToken,
+
+    speare: speare::mini::Ctx,
 }
 
 #[bon]
 impl Fixture {
-    #[builder(start_fn = platform, finish_fn = run)]
+    #[builder(start_fn = platform, finish_fn = build)]
     pub async fn new(
         #[builder(start_fn)] platform: OrbOsPlatform,
         release: OrbRelease,
-        #[builder(default = OrbCapabilities::WifiOnly)] cap: OrbCapabilities,
+        #[builder(default = OrbCapabilities::CellularAndWifi)] cap: OrbCapabilities,
         modem_manager: Option<MockMMCli>,
         wpa_ctrl: Option<MockWpaCli>,
-        arrange: Option<Callback<Ctx>>,
         mcu_util: Option<MockMcuUtilCli>,
-        #[builder(default = false)] log: bool,
     ) -> Self {
+        let connd_build = task::spawn_blocking(|| {
+            CargoBuild::new()
+                .bin("orb-connd")
+                .current_target()
+                .current_release()
+                .manifest_path(env!("CARGO_MANIFEST_PATH"))
+                .run()
+                .unwrap()
+        });
+
+        let container_tempdir = TempDir::new().await.unwrap();
+        let usr_persistent = setup_usr_persistent(&container_tempdir).await;
+        let sysfs = setup_sysfs(&container_tempdir, cap).await;
+        let procfs = setup_procfs(&container_tempdir).await;
+
+        let connd_bin_path = connd_build.await.unwrap().path().to_path_buf();
+
+        Self {
+            orb_id: OrbId::from_str("ea2ea744").unwrap(),
+            platform,
+            release,
+            cap,
+            modem_manager,
+            wpa_ctrl,
+            mcu_util,
+            container_tempdir,
+            usr_persistent,
+            sysfs,
+            procfs,
+            connd_bin_path,
+        }
+    }
+
+    pub async fn run_secure_storage(&mut self) -> (SecureStorage, CancellationToken) {
+        let secure_storage_cancel_token = CancellationToken::new();
+        let secure_storage = SecureStorage::new(
+            self.connd_bin_path.clone(),
+            true,
+            secure_storage_cancel_token.clone(),
+            ConndStorageScopes::NmProfiles,
+        );
+
+        (secure_storage, secure_storage_cancel_token)
+    }
+
+    pub async fn run(&mut self) -> FxHandle {
+        self.run_with().log(false).call().await
+    }
+
+    #[builder]
+    pub async fn run_with(
+        &mut self,
+        #[builder(default = false)] log: bool,
+        secure_storage: Option<SecureStorage>,
+        secure_storage_cancel_token: Option<CancellationToken>,
+    ) -> FxHandle {
         let _ = color_eyre::install();
 
         if log {
             let _ = orb_telemetry::TelemetryConfig::new().init();
         }
 
-        let (container, router_socket) =
-            setup_container(TempDir::new().await.unwrap()).await;
-
-        let sysfs = container.tempdir.dir_path().join("sysfs");
-        let procfs = container.tempdir.dir_path().join("procfs");
-        let usr_persistent = container.tempdir.dir_path().join("usr_persistent");
-
-        let network_manager_folder = usr_persistent.join("network-manager");
-        fs::create_dir_all(&sysfs).await.unwrap();
-        fs::create_dir_all(&procfs).await.unwrap();
-        fs::create_dir_all(&usr_persistent).await.unwrap();
-        fs::create_dir_all(&network_manager_folder).await.unwrap();
-
-        let net_dir = sysfs.join("class").join("net");
-        fs::create_dir_all(net_dir.join("eth0")).await.unwrap();
-        fs::create_dir_all(net_dir.join("wlan0")).await.unwrap();
-
-        fs::write(net_dir.join("eth0").join("operstate"), "down\n")
-            .await
-            .unwrap();
-        fs::write(net_dir.join("wlan0").join("operstate"), "up\n")
-            .await
-            .unwrap();
-
-        if cap == OrbCapabilities::CellularAndWifi {
-            let stats = net_dir.join("wwan0").join("statistics");
-            let tx = stats.join("tx_bytes");
-            let rx = stats.join("rx_bytes");
-
-            fs::create_dir_all(stats).await.unwrap();
-            fs::write(tx, "0").await.unwrap();
-            fs::write(rx, "0").await.unwrap();
-
-            fs::write(net_dir.join("wwan0").join("operstate"), "unknown\n")
-                .await
-                .unwrap();
-        }
-
-        let procnet = procfs.join("net");
-        let route_path = procnet.join("route");
-
-        fs::create_dir_all(&procnet).await.unwrap();
-        fs::write(
-            &route_path,
-            concat!(
-                "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n",
-                "eth0\t0010A8C0\t00000000\t0001\t0\t0\t100\t00FFFFFF\t0\t0\t0\n",
-                "wlan0\t00000000\t01006C0A\t0003\t0\t0\t400\t00000000\t0\t0\t0\n",
-                "wwan0\t00000000\t39A54664\t0003\t0\t0\t500\t00000000\t0\t0\t0\n",
-                "wlan0\t00006C0A\t00000000\t0001\t0\t0\t400\t0000FFFF\t0\t0\t0\n",
-                "wwan0\t30A54664\t00000000\t0001\t0\t0\t500\tF0FFFFFF\t0\t0\t0\n",
-            ),
-        )
-        .await
-        .unwrap();
+        let (container, zenoh_router_socket) =
+            setup_container(&self.container_tempdir).await;
 
         time::sleep(Duration::from_secs(1)).await;
 
-        let dbus_socket = container.tempdir.dir_path().join("socket");
+        let dbus_socket = container.tempdir.join("socket");
         let dbus_socket = format!("unix:path={}", dbus_socket.display());
         let addr: Address = dbus_socket.parse().unwrap();
 
-        let conn = zbus::ConnectionBuilder::address(addr)
+        let dbus = zbus::ConnectionBuilder::address(addr)
             .unwrap()
             .build()
             .await
             .unwrap();
 
         let nm = NetworkManager::new(
-            conn.clone(),
-            wpa_ctrl.unwrap_or_else(default_mock_wpa_cli),
+            dbus.clone(),
+            self.wpa_ctrl.take().unwrap_or_else(default_mock_wpa_cli),
         );
 
-        let built_connd = CargoBuild::new()
-            .bin("orb-connd")
-            .current_target()
-            .current_release()
-            .manifest_path(env!("CARGO_MANIFEST_PATH"))
-            .run()
-            .unwrap();
+        let (secure_storage, secure_storage_cancel_token) =
+            match (secure_storage, secure_storage_cancel_token) {
+                (Some(ss), Some(ssct)) => (ss, ssct),
 
-        let cancel_token = CancellationToken::new();
-        let secure_storage = SecureStorage::new(
-            built_connd.path().into(),
-            true,
-            cancel_token.clone(),
-            ConndStorageScopes::NmProfiles,
-        );
+                (None, None) => {
+                    let ssct = CancellationToken::new();
+                    let ss = SecureStorage::new(
+                        self.connd_bin_path.clone(),
+                        true,
+                        ssct.clone(),
+                        ConndStorageScopes::NmProfiles,
+                    );
 
-        let profile_storage = match platform {
-            OrbOsPlatform::Pearl => ProfileStorage::NetworkManager,
-            OrbOsPlatform::Diamond => {
-                ProfileStorage::SecureStorage(secure_storage.clone())
-            }
-        };
+                    (ss, ssct)
+                }
 
-        if let Some(arrange_cb) = arrange {
-            let ctx = Ctx {
-                usr_persistent: usr_persistent.clone(),
-                nm: nm.clone(),
-                secure_storage: secure_storage.clone(),
+                _ => panic!("secure_storage and secure_storage_cancel_token must be both Some or both None"),
             };
-
-            arrange_cb.call(ctx).await;
-        }
-        let orb_id = OrbId::from_str("ea2ea744").unwrap();
-        let zsession = Zenorb::from_cfg(zenoh_socket_cfg(&router_socket))
-            .orb_id(orb_id.clone())
-            .with_name("connd")
-            .await
-            .unwrap();
-
-        let mcu_util: Box<dyn McuUtil> =
-            Box::new(mcu_util.unwrap_or_else(default_mock_mcu_util_cli));
-
-        let modem_manager: Box<dyn ModemManager> =
-            Box::new(modem_manager.unwrap_or_else(default_mockmmcli));
-
-        let registry = crabwire::Registry::new()
-            .insert(Systemd::new(conn.clone()))
-            .insert(mcu_util)
-            .insert(modem_manager)
-            .insert(DogstatsdClient::default());
-
-        let _ = crabwire::try_register!(registry);
-
-        let speare = program()
-            .os_release(OrbOsRelease {
-                release_type: release,
-                orb_os_platform_type: platform,
-                orb_os_version: String::new(),
-                expected_main_mcu_version: String::new(),
-                expected_sec_mcu_version: String::new(),
-            })
-            .network_manager(nm.clone())
-            .resolved(Resolved::new(conn.clone()))
-            .sysfs(sysfs.clone())
-            .procfs(procfs.clone())
-            .usr_persistent(usr_persistent.clone())
-            .session_bus(conn.clone())
-            .connect_timeout(Duration::from_secs(1))
-            .profile_storage(profile_storage)
-            .zenoh(&zsession)
-            .run()
-            .await
-            .unwrap();
-
-        let millisecs = if env::var("GITHUB_ACTIONS").is_ok() {
-            4_000
-        } else {
-            500
-        };
-
-        time::sleep(Duration::from_millis(millisecs)).await;
-
-        Self {
-            nm,
-            conn,
-            speare,
-            container,
-            sysfs,
-            procfs,
-            usr_persistent,
-            secure_storage,
-            secure_storage_cancel_token: cancel_token,
-            router_socket,
-            zsession,
-            orb_id: orb_id.to_string(),
-            platform,
-            connd_path: built_connd.path().into(),
-        }
-    }
-
-    pub async fn connd(&self) -> ConndProxy<'_> {
-        ConndProxy::new(&self.conn).await.unwrap()
-    }
-
-    pub fn zenoh(&self) -> &Zenorb {
-        &self.zsession
-    }
-
-    // TODO: refactor this shit to repeat less code
-    pub async fn restart(&mut self) {
-        self.speare.abort_children().unwrap();
-        self.container.rm().await;
-
-        time::sleep(Duration::from_secs(1)).await;
-
-        let (container, router_socket) =
-            setup_container(self.container.tempdir.try_clone().await.unwrap()).await;
-
-        time::sleep(Duration::from_secs(1)).await;
-
-        self.router_socket = router_socket;
-        self.container = container;
-
-        let dbus_socket = self.container.tempdir.dir_path().join("socket");
-        let dbus_socket = format!("unix:path={}", dbus_socket.display());
-        let addr: Address = dbus_socket.parse().unwrap();
-
-        self.conn = zbus::ConnectionBuilder::address(addr)
-            .unwrap()
-            .build()
-            .await
-            .unwrap();
-
-        let nm = NetworkManager::new(self.conn.clone(), default_mock_wpa_cli());
-        nm.wait_for_nm_ready().await.unwrap();
-
-        let cancel_token = CancellationToken::new();
-        let secure_storage = SecureStorage::new(
-            self.connd_path.clone(),
-            true,
-            cancel_token.clone(),
-            ConndStorageScopes::NmProfiles,
-        );
 
         let profile_storage = match self.platform {
             OrbOsPlatform::Pearl => ProfileStorage::NetworkManager,
@@ -318,38 +191,49 @@ impl Fixture {
             }
         };
 
-        let orb_id = OrbId::from_str(&self.orb_id).unwrap();
-        let zsession = Zenorb::from_cfg(zenoh_socket_cfg(&self.router_socket))
-            .orb_id(orb_id)
+        let zenorb = Zenorb::from_cfg(zenoh_socket_cfg(&zenoh_router_socket))
+            .orb_id(self.orb_id.clone())
             .with_name("connd")
             .await
             .unwrap();
 
+        let mcu_util: Box<dyn McuUtil> = Box::new(
+            self.mcu_util
+                .take()
+                .unwrap_or_else(default_mock_mcu_util_cli),
+        );
+
+        let modem_manager: Box<dyn ModemManager> =
+            Box::new(self.modem_manager.take().unwrap_or_else(default_mockmmcli));
+
+        let registry = crabwire::Registry::new()
+            .insert(Systemd::new(dbus.clone()))
+            .insert(mcu_util)
+            .insert(modem_manager)
+            .insert(DogstatsdClient::default());
+
+        let _ = crabwire::reregister!(registry);
+
         let speare = program()
             .os_release(OrbOsRelease {
-                release_type: OrbRelease::Dev,
+                release_type: self.release,
                 orb_os_platform_type: self.platform,
                 orb_os_version: String::new(),
                 expected_main_mcu_version: String::new(),
                 expected_sec_mcu_version: String::new(),
             })
             .network_manager(nm.clone())
-            .resolved(Resolved::new(self.conn.clone()))
+            .resolved(Resolved::new(dbus.clone()))
             .sysfs(self.sysfs.clone())
             .procfs(self.procfs.clone())
             .usr_persistent(self.usr_persistent.clone())
-            .session_bus(self.conn.clone())
+            .session_bus(dbus.clone())
             .connect_timeout(Duration::from_secs(1))
             .profile_storage(profile_storage)
-            .zenoh(&zsession)
+            .zenoh(&zenorb)
             .run()
             .await
             .unwrap();
-
-        self.zsession = zsession;
-        self.nm = nm;
-        self.speare = speare;
-        self.secure_storage_cancel_token = cancel_token;
 
         let millisecs = if env::var("GITHUB_ACTIONS").is_ok() {
             4_000
@@ -358,10 +242,109 @@ impl Fixture {
         };
 
         time::sleep(Duration::from_millis(millisecs)).await;
+
+        FxHandle {
+            container,
+            zenorb,
+            zenoh_router_socket,
+            dbus,
+            nm,
+            secure_storage,
+            secure_storage_cancel_token,
+            speare,
+        }
     }
 }
 
-async fn setup_container(tempdir: TempDir) -> (Container, PathBuf) {
+impl Drop for FxHandle {
+    fn drop(&mut self) {
+        self.secure_storage_cancel_token.cancel();
+        self.speare.abort_children().unwrap();
+    }
+}
+
+impl FxHandle {
+    pub async fn stop(self) {
+        self.secure_storage_cancel_token.cancel();
+        self.speare.abort_children().unwrap();
+        self.container.rm().await;
+    }
+
+    pub async fn connd(&self) -> ConndProxy<'_> {
+        ConndProxy::new(&self.dbus).await.unwrap()
+    }
+
+    pub fn zenoh(&self) -> &Zenorb {
+        &self.zenorb
+    }
+}
+
+async fn setup_sysfs(container_path: &Path, cap: OrbCapabilities) -> PathBuf {
+    let sysfs = container_path.join("sysfs");
+    fs::create_dir_all(&sysfs).await.unwrap();
+
+    let net_dir = sysfs.join("class").join("net");
+    fs::create_dir_all(net_dir.join("eth0")).await.unwrap();
+    fs::create_dir_all(net_dir.join("wlan0")).await.unwrap();
+
+    fs::write(net_dir.join("eth0").join("operstate"), "down\n")
+        .await
+        .unwrap();
+    fs::write(net_dir.join("wlan0").join("operstate"), "up\n")
+        .await
+        .unwrap();
+
+    if cap == OrbCapabilities::CellularAndWifi {
+        let stats = net_dir.join("wwan0").join("statistics");
+        let tx = stats.join("tx_bytes");
+        let rx = stats.join("rx_bytes");
+
+        fs::create_dir_all(stats).await.unwrap();
+        fs::write(tx, "0").await.unwrap();
+        fs::write(rx, "0").await.unwrap();
+
+        fs::write(net_dir.join("wwan0").join("operstate"), "unknown\n")
+            .await
+            .unwrap();
+    }
+
+    sysfs
+}
+
+async fn setup_procfs(container_path: &Path) -> PathBuf {
+    let procfs = container_path.join("procfs");
+    fs::create_dir_all(&procfs).await.unwrap();
+    let procnet = procfs.join("net");
+    let route_path = procnet.join("route");
+
+    fs::create_dir_all(&procnet).await.unwrap();
+    fs::write(
+        &route_path,
+        concat!(
+            "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n",
+            "eth0\t0010A8C0\t00000000\t0001\t0\t0\t100\t00FFFFFF\t0\t0\t0\n",
+            "wlan0\t00000000\t01006C0A\t0003\t0\t0\t400\t00000000\t0\t0\t0\n",
+            "wwan0\t00000000\t39A54664\t0003\t0\t0\t500\t00000000\t0\t0\t0\n",
+            "wlan0\t00006C0A\t00000000\t0001\t0\t0\t400\t0000FFFF\t0\t0\t0\n",
+            "wwan0\t30A54664\t00000000\t0001\t0\t0\t500\tF0FFFFFF\t0\t0\t0\n",
+        ),
+    )
+    .await
+    .unwrap();
+
+    procfs
+}
+
+async fn setup_usr_persistent(container_path: &Path) -> PathBuf {
+    let usr_persistent = container_path.join("usr_persistent");
+    let network_manager_folder = usr_persistent.join("network-manager");
+    fs::create_dir_all(&usr_persistent).await.unwrap();
+    fs::create_dir_all(&network_manager_folder).await.unwrap();
+
+    usr_persistent
+}
+
+async fn setup_container(tempdir: &Path) -> (Container, PathBuf) {
     let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let docker_ctx = crate_dir.join("tests").join("docker");
     let dockerfile = crate_dir.join("tests").join("docker").join("Dockerfile");
@@ -371,8 +354,8 @@ async fn setup_container(tempdir: TempDir) -> (Container, PathBuf) {
     let uid = unsafe { libc::geteuid() };
     let gid = unsafe { libc::getegid() };
 
-    let nm_profiles_dir = tempdir.dir_path().join("system-connections");
-    let zenoh_dir = tempdir.dir_path().join("zenohd");
+    let nm_profiles_dir = tempdir.join("system-connections");
+    let zenoh_dir = tempdir.join("zenohd");
     fs::create_dir_all(&nm_profiles_dir).await.unwrap();
     fs::create_dir_all(&zenoh_dir).await.unwrap();
 

--- a/orb-connd/tests/legacy_wpa_import.rs
+++ b/orb-connd/tests/legacy_wpa_import.rs
@@ -1,7 +1,6 @@
 use fixture::Fixture;
 use orb_connd::network_manager::WifiSec;
 use orb_info::orb_os_release::{OrbOsPlatform, OrbRelease};
-use prelude::future::Callback;
 use tokio::fs;
 
 mod fixture;
@@ -9,12 +8,14 @@ mod fixture;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_imports_wpa_conf_with_hex_encoded_ssid() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Dev)
-        .arrange(Callback::new(async |ctx: fixture::Ctx| {
-            // Create wpa_supplicant config with hex-encoded SSID
-            // SSID "546573744e6574776f726b" is hex for "TestNetwork"
-            let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+        .build()
+        .await;
+
+    // Create wpa_supplicant config with hex-encoded SSID
+    // SSID "546573744e6574776f726b" is hex for "TestNetwork"
+    let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 
 network={
     key_mgmt=WPA-PSK
@@ -22,18 +23,17 @@ network={
     psk=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 }
 "#;
-            fs::write(
-                ctx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
-                wpa_conf_content,
-            )
-            .await
-            .unwrap();
-        }))
-        .run()
-        .await;
+    fs::write(
+        fx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
+        wpa_conf_content,
+    )
+    .await
+    .unwrap();
+
+    let handle = fx.run().await;
 
     // Assert - the hex-encoded SSID should be decoded to "TestNetwork"
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     let test_profile = profiles
         .iter()
         .find(|p| p.ssid == "TestNetwork")
@@ -54,11 +54,13 @@ network={
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_imports_wpa_conf_with_quoted_ssid() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Dev)
-        .arrange(Callback::new(async |ctx: fixture::Ctx| {
-            // Create wpa_supplicant config with quoted SSID
-            let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+        .build()
+        .await;
+
+    // Create wpa_supplicant config with quoted SSID
+    let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 
 network={
     key_mgmt=WPA-PSK
@@ -66,18 +68,17 @@ network={
     psk=fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
 }
 "#;
-            fs::write(
-                ctx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
-                wpa_conf_content,
-            )
-            .await
-            .unwrap();
-        }))
-        .run()
-        .await;
+    fs::write(
+        fx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
+        wpa_conf_content,
+    )
+    .await
+    .unwrap();
+
+    let handle = fx.run().await;
 
     // Assert - the quoted SSID should be parsed correctly
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     let network_profile = profiles
         .iter()
         .find(|p| p.ssid == "MyNetwork")
@@ -99,28 +100,30 @@ network={
 async fn it_handles_invalid_wpa_conf_gracefully() {
     // Test empty SSID (quoted)
     {
-        let fx = Fixture::platform(OrbOsPlatform::Pearl)
+        let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
             .release(OrbRelease::Dev)
-            .arrange(Callback::new(async |ctx: fixture::Ctx| {
-                let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+            .build()
+            .await;
+
+        let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 network={
     key_mgmt=WPA-PSK
     ssid=""
     psk=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 }
 "#;
-                fs::write(
-                    ctx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
-                    wpa_conf_content,
-                )
-                .await
-                .unwrap();
-            }))
-            .run()
-            .await;
+        fs::write(
+            fx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
+            wpa_conf_content,
+        )
+        .await
+        .unwrap();
+
+        let handle = fx.run().await;
 
         // Should fail gracefully - no crash, just empty result
-        let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+        let profiles = handle.nm.list_wifi_profiles().await.unwrap();
+
         // Only default profile should exist (import should have failed gracefully)
         assert_eq!(profiles.len(), 1);
         assert_eq!(profiles[0].ssid, "hotspot");
@@ -128,57 +131,59 @@ network={
 
     // Test empty PSK
     {
-        let fx = Fixture::platform(OrbOsPlatform::Pearl)
+        let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
             .release(OrbRelease::Dev)
-            .arrange(Callback::new(async |ctx: fixture::Ctx| {
-                let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+            .build()
+            .await;
+
+        let wpa_conf_content = r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 network={
     key_mgmt=WPA-PSK
     ssid="ValidSSID"
     psk=
 }
 "#;
-                fs::write(
-                    ctx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
-                    wpa_conf_content,
-                )
-                .await
-                .unwrap();
-            }))
-            .run()
-            .await;
+        fs::write(
+            fx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
+            wpa_conf_content,
+        )
+        .await
+        .unwrap();
 
-        let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+        let handle = fx.run().await;
+
+        let profiles = handle.nm.list_wifi_profiles().await.unwrap();
         assert_eq!(profiles.len(), 1);
         assert_eq!(profiles[0].ssid, "hotspot");
     }
 
     // Test SSID too long (>32 bytes)
     {
-        let fx = Fixture::platform(OrbOsPlatform::Pearl)
+        let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
             .release(OrbRelease::Dev)
-            .arrange(Callback::new(async |ctx: fixture::Ctx| {
-                let long_ssid = "a".repeat(33);
-                let wpa_conf_content = format!(
-                    r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
+            .build()
+            .await;
+
+        let long_ssid = "a".repeat(33);
+        let wpa_conf_content = format!(
+            r#"ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 network={{
     key_mgmt=WPA-PSK
     ssid="{long_ssid}"
     psk=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
 }}
 "#
-                );
-                fs::write(
-                    ctx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
-                    wpa_conf_content,
-                )
-                .await
-                .unwrap();
-            }))
-            .run()
-            .await;
+        );
+        fs::write(
+            fx.usr_persistent.join("wpa_supplicant-wlan0.conf"),
+            wpa_conf_content,
+        )
+        .await
+        .unwrap();
 
-        let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+        let handle = fx.run().await;
+
+        let profiles = handle.nm.list_wifi_profiles().await.unwrap();
         assert_eq!(profiles.len(), 1);
         assert_eq!(profiles[0].ssid, "hotspot");
     }

--- a/orb-connd/tests/profile_management.rs
+++ b/orb-connd/tests/profile_management.rs
@@ -485,7 +485,7 @@ async fn profile_is_persisted_after_bumping_priority() {
 
     // Act: restart connd and environment -- profile should be reloaded
     drop(connd);
-    drop(handle);
+    handle.stop().await;
     let handle = fx.run().await;
 
     // Assert: both profiles are still persisted

--- a/orb-connd/tests/profile_management.rs
+++ b/orb-connd/tests/profile_management.rs
@@ -485,6 +485,7 @@ async fn profile_is_persisted_after_bumping_priority() {
 
     // Act: restart connd and environment -- profile should be reloaded
     drop(connd);
+    drop(handle);
     let handle = fx.run().await;
 
     // Assert: both profiles are still persisted

--- a/orb-connd/tests/profile_management.rs
+++ b/orb-connd/tests/profile_management.rs
@@ -4,7 +4,6 @@ use orb_connd::{
     network_manager::WifiSec, service::zoci::WifiProfileDto, OrbCapabilities,
 };
 use orb_info::orb_os_release::{OrbOsPlatform, OrbRelease};
-use prelude::future::Callback;
 use serde_json::json;
 use tokio::fs;
 use tokio_stream::wrappers::ReadDirStream;
@@ -15,13 +14,15 @@ mod fixture;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_increments_priority_when_adding_multiple_networks() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Diamond)
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Act
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -34,7 +35,7 @@ async fn it_increments_priority_when_adding_multiple_networks() {
         .await
         .unwrap();
 
-    let res = fx
+    let res = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -53,7 +54,7 @@ async fn it_increments_priority_when_adding_multiple_networks() {
     println!("e {e:?}");
 
     // Assert
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     println!("{profiles:?}");
 
     // profile 0 is default profile
@@ -80,13 +81,15 @@ async fn it_increments_priority_when_adding_multiple_networks() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_fails_adding_wifi_if_sec_isnt_wpa2psk_or_wpa3sae() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Diamond)
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Act
-    let actual1 = fx
+    let actual1 = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -100,7 +103,7 @@ async fn it_fails_adding_wifi_if_sec_isnt_wpa2psk_or_wpa3sae() {
         .unwrap()
         .unwrap_err();
 
-    let actual2 = fx
+    let actual2 = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -126,13 +129,15 @@ async fn it_fails_adding_wifi_if_sec_isnt_wpa2psk_or_wpa3sae() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_removes_a_wifi_profile() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Diamond)
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Act
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -145,14 +150,14 @@ async fn it_removes_a_wifi_profile() {
         .await
         .unwrap();
 
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command_raw("connd/job/wifi_remove", "one")
         .await
         .unwrap();
 
     // Assert
-    let profiles = fx
+    let profiles = handle
         .zenoh()
         .command_raw("connd/job/wifi_list", "")
         .await
@@ -167,20 +172,22 @@ async fn it_removes_a_wifi_profile() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_creates_default_profiles() {
     // Arrange & Act
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Prod)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Assert
-    let cellular_profiles = fx.nm.list_cellular_profiles().await.unwrap();
+    let cellular_profiles = handle.nm.list_cellular_profiles().await.unwrap();
     assert_eq!(cellular_profiles.len(), 1);
 
     let default_cel_profile = cellular_profiles.into_iter().next().unwrap();
     assert_eq!(default_cel_profile.id, "cellular");
     assert_eq!(default_cel_profile.apn, "em");
 
-    let wifi_profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let wifi_profiles = handle.nm.list_wifi_profiles().await.unwrap();
     assert_eq!(wifi_profiles.len(), 1);
 
     let default_wifi_profile = wifi_profiles.into_iter().next().unwrap();
@@ -194,34 +201,35 @@ async fn it_wipes_dhcp_leases_and_seen_bssids_if_too_big() {
     // - /usr/persistent/network-manager/connections
     // - /usr/persistent/network-manager/varlib
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Prod)
-        .arrange(Callback::new(async |ctx: fixture::Ctx| {
-            let varlib = ctx.usr_persistent.join("network-manager").join("varlib");
-            fs::create_dir_all(&varlib).await.unwrap();
-
-            // we create a file thats 2mb in size, which puts us
-            // above the 1mb limit for network-manager folder in /usr/persistent
-            let contents = vec![0u8; 2 * 1024 * 1024];
-            fs::write(varlib.join("seen-bssids"), &contents)
-                .await
-                .unwrap();
-
-            for n in 0..30 {
-                fs::write(varlib.join(format!("{n}.lease")), [])
-                    .await
-                    .unwrap();
-            }
-
-            let dir: Vec<_> = ReadDirStream::new(fs::read_dir(varlib).await.unwrap())
-                .try_collect()
-                .await
-                .unwrap();
-
-            assert_eq!(31, dir.len());
-        }))
-        .run()
+        .build()
         .await;
+
+    let varlib = fx.usr_persistent.join("network-manager").join("varlib");
+    fs::create_dir_all(&varlib).await.unwrap();
+
+    // we create a file thats 2mb in size, which puts us
+    // above the 1mb limit for network-manager folder in /usr/persistent
+    let contents = vec![0u8; 2 * 1024 * 1024];
+    fs::write(varlib.join("seen-bssids"), &contents)
+        .await
+        .unwrap();
+
+    for n in 0..30 {
+        fs::write(varlib.join(format!("{n}.lease")), [])
+            .await
+            .unwrap();
+    }
+
+    let dir: Vec<_> = ReadDirStream::new(fs::read_dir(varlib).await.unwrap())
+        .try_collect()
+        .await
+        .unwrap();
+
+    assert_eq!(31, dir.len());
+
+    let _handle = fx.run().await;
 
     // Assert
     // after connd starts, it should check if nm folder in persistent is over limit,
@@ -242,13 +250,15 @@ async fn it_wipes_dhcp_leases_and_seen_bssids_if_too_big() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_protects_default_wifi_and_cellular_profiles() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Act
-    let cellular_actual = fx
+    let cellular_actual = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -262,7 +272,7 @@ async fn it_protects_default_wifi_and_cellular_profiles() {
         .unwrap()
         .unwrap_err();
 
-    let wifi_actual = fx
+    let wifi_actual = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -290,13 +300,15 @@ async fn it_protects_default_wifi_and_cellular_profiles() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_returns_saved_wifi_profiles() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Act
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -309,7 +321,7 @@ async fn it_returns_saved_wifi_profiles() {
         .await
         .unwrap();
 
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -322,7 +334,7 @@ async fn it_returns_saved_wifi_profiles() {
         .await
         .unwrap();
 
-    let actual = fx
+    let actual = handle
         .zenoh()
         .command_raw("connd/job/wifi_list", "")
         .await
@@ -356,14 +368,16 @@ async fn it_returns_saved_wifi_profiles() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_bumps_priority_of_wifi_profile_on_manual_connection_attempt() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .cap(OrbCapabilities::CellularAndWifi)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
+    let handle = fx.run().await;
+
     // Act: create profiles
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -376,7 +390,7 @@ async fn it_bumps_priority_of_wifi_profile_on_manual_connection_attempt() {
         .await
         .unwrap();
 
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -390,33 +404,33 @@ async fn it_bumps_priority_of_wifi_profile_on_manual_connection_attempt() {
         .unwrap();
 
     // Assert: newest added profile has higher priority
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     let bla = profiles.iter().find(|p| p.ssid == "bla").unwrap();
     let bla2 = profiles.iter().find(|p| p.ssid == "bla2").unwrap();
     assert!(bla.priority < bla2.priority);
 
     // Act: attempt to connect to bla
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command_raw("connd/job/wifi_connect", "bla")
         .await
         .unwrap();
 
     // Assert: last attempted connection profile has higher priority
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     let bla = profiles.iter().find(|p| p.ssid == "bla").unwrap();
     let bla2 = profiles.iter().find(|p| p.ssid == "bla2").unwrap();
     assert!(bla.priority > bla2.priority);
 
     // Act: attempt to connect again to bla
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command_raw("connd/job/wifi_connect", "bla")
         .await
         .unwrap();
 
     // Assert: priority hasn't changed as highest bla was already highest prio
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     let new_bla = profiles.iter().find(|p| p.ssid == "bla").unwrap();
     assert!(bla.priority == new_bla.priority);
 }
@@ -427,13 +441,14 @@ async fn profile_is_persisted_after_bumping_priority() {
     let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .cap(OrbCapabilities::CellularAndWifi)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // Act: create profile
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -447,7 +462,7 @@ async fn profile_is_persisted_after_bumping_priority() {
         .unwrap();
 
     // Act: create second profile with higher priority
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -462,7 +477,7 @@ async fn profile_is_persisted_after_bumping_priority() {
 
     // Act: force connect, should rewrite profile to raise priority
     // will fail due to ssid "bla" not existing
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command_raw("connd/job/wifi_connect", "bla")
         .await
@@ -470,10 +485,10 @@ async fn profile_is_persisted_after_bumping_priority() {
 
     // Act: restart connd and environment -- profile should be reloaded
     drop(connd);
-    fx.restart().await;
+    let handle = fx.run().await;
 
     // Assert: both profiles are still persisted
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     assert!(profiles.iter().any(|p| p.ssid == "bla2"));
     assert!(profiles.iter().any(|p| p.ssid == "bla"));
 }

--- a/orb-connd/tests/profile_store.rs
+++ b/orb-connd/tests/profile_store.rs
@@ -5,7 +5,6 @@ use orb_connd::{
     OrbCapabilities,
 };
 use orb_info::orb_os_release::{OrbOsPlatform, OrbRelease};
-use prelude::future::Callback;
 use serde_json::json;
 use uuid::Uuid;
 use zenorb::zoci::ReplyExt;
@@ -16,36 +15,44 @@ mod fixture;
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_adds_removes_and_imports_encrypted_profiles() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Diamond)
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
         .cap(OrbCapabilities::WifiOnly)
         .release(OrbRelease::Prod)
-        .arrange(Callback::new(async |ctx: fixture::Ctx| {
-            // prepopulate with encrypted profiles
-            let profiles = vec![WifiProfile {
-                id: "imported".into(),
-                uuid: Uuid::new_v4().to_string(),
-                ssid: "imported".into(),
-                sec: WifiSec::Wpa2Psk,
-                psk: "1234567890".into(),
-                autoconnect: false,
-                priority: 0,
-                hidden: false,
-                path: String::new(),
-            }];
+        .build()
+        .await;
 
-            let mut bytes = Vec::new();
-            ciborium::ser::into_writer(&profiles, &mut bytes).unwrap();
+    // prepopulate with encrypted profiles
+    let profiles = vec![WifiProfile {
+        id: "imported".into(),
+        uuid: Uuid::new_v4().to_string(),
+        ssid: "imported".into(),
+        sec: WifiSec::Wpa2Psk,
+        psk: "1234567890".into(),
+        autoconnect: false,
+        priority: 0,
+        hidden: false,
+        path: String::new(),
+    }];
 
-            ctx.secure_storage
-                .put("nmprofiles".into(), bytes)
-                .await
-                .unwrap();
-        }))
-        .run()
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&profiles, &mut bytes).unwrap();
+
+    let (secure_storage, secure_storage_cancel_token) = fx.run_secure_storage().await;
+
+    secure_storage
+        .put("nmprofiles".into(), bytes)
+        .await
+        .unwrap();
+
+    let handle = fx
+        .run_with()
+        .secure_storage(secure_storage)
+        .secure_storage_cancel_token(secure_storage_cancel_token)
+        .call()
         .await;
 
     // Assert profile was imported
-    let imported_profile = fx
+    let imported_profile = handle
         .zenoh()
         .command_raw("connd/job/wifi_list", "")
         .await
@@ -59,13 +66,13 @@ async fn it_adds_removes_and_imports_encrypted_profiles() {
     assert!(imported_profile.is_some());
 
     // Act: remove imported, add new profile
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command_raw("connd/job/wifi_remove", "imported")
         .await
         .unwrap();
 
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -79,7 +86,7 @@ async fn it_adds_removes_and_imports_encrypted_profiles() {
         .unwrap();
 
     // Assert: store reflects changes
-    let profiles = fx
+    let profiles = handle
         .secure_storage
         .get("nmprofiles".into())
         .await

--- a/orb-connd/tests/qr_codes.rs
+++ b/orb-connd/tests/qr_codes.rs
@@ -24,13 +24,14 @@ async fn it_applies_netconfig_qr_code() {
         (OrbRelease::Prod, STAGE, false),
         (OrbRelease::Prod, PROD, true),
     ] {
-        let fx = Fixture::platform(OrbOsPlatform::Diamond)
+        let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
             .cap(OrbCapabilities::CellularAndWifi)
             .release(release)
-            .run()
+            .build()
             .await;
 
-        let connd = fx.connd().await;
+        let handle = fx.run().await;
+        let connd = handle.connd().await;
 
         // Act
         // we unwrap the error here because attempting to connect will NOT work
@@ -53,7 +54,7 @@ async fn it_applies_netconfig_qr_code() {
             "org.freedesktop.DBus.Error.Failed: could not find ssid network"
         );
 
-        let profile = fx
+        let profile = handle
             .nm
             .list_wifi_profiles()
             .await
@@ -65,20 +66,21 @@ async fn it_applies_netconfig_qr_code() {
         assert_eq!(profile.ssid, "network");
         assert_eq!(profile.psk, "password");
         assert!(!profile.hidden);
-        assert!(!fx.nm.smart_switching_enabled().await.unwrap());
-        assert!(fx.nm.wifi_enabled().await.unwrap());
+        assert!(!handle.nm.smart_switching_enabled().await.unwrap());
+        assert!(handle.nm.wifi_enabled().await.unwrap());
     }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn it_applies_wifi_qr_code() {
     // Arrange (dev orbs)
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Dev)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // Act
     // we unwrap the error here because attempting to connect will NOT work
@@ -96,7 +98,7 @@ async fn it_applies_wifi_qr_code() {
         "org.freedesktop.DBus.Error.Failed: could not find ssid example"
     );
 
-    let profile = fx
+    let profile = handle
         .nm
         .list_wifi_profiles()
         .await
@@ -112,12 +114,13 @@ async fn it_applies_wifi_qr_code() {
     assert!(profile.hidden);
 
     // Arrange (prod orbs, fails if there is connectivity, which we do bc this is in a container and host has connectivity)
-    let fx = Fixture::platform(OrbOsPlatform::Pearl)
+    let mut fx = Fixture::platform(OrbOsPlatform::Pearl)
         .release(OrbRelease::Prod)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // Act
     let result = connd
@@ -131,15 +134,16 @@ async fn it_applies_wifi_qr_code() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn it_applies_magic_reset_qr() {
     // Arrange
-    let fx = Fixture::platform(OrbOsPlatform::Diamond)
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
         .release(OrbRelease::Prod)
-        .run()
+        .build()
         .await;
 
-    let connd = fx.connd().await;
+    let handle = fx.run().await;
+    let connd = handle.connd().await;
 
     // profile added, should be erased once magic qr is applied
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -152,7 +156,7 @@ async fn it_applies_magic_reset_qr() {
         .await
         .unwrap();
 
-    let _ = fx
+    let _ = handle
         .zenoh()
         .command(
             "connd/job/wifi_add",
@@ -181,10 +185,10 @@ async fn it_applies_magic_reset_qr() {
     connd.apply_magic_reset_qr().await.unwrap();
 
     // Assert: all wifi profiles except default deleted
-    let profiles = fx.nm.list_wifi_profiles().await.unwrap();
+    let profiles = handle.nm.list_wifi_profiles().await.unwrap();
     assert_eq!(profiles.len(), 1); // len is 1 bc default wifi profile was created
 
-    let ss_profiles = fx
+    let ss_profiles = handle
         .secure_storage
         .get("nmprofiles".into())
         .await

--- a/test-utils/src/docker.rs
+++ b/test-utils/src/docker.rs
@@ -1,6 +1,5 @@
-use async_tempfile::TempDir;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Output;
 use tokio::process::Command;
 use tokio::task;
@@ -33,33 +32,22 @@ pub async fn build(
 }
 
 /// Starts a container with a temporary directory mounted to /run/integration-tests
-pub async fn run<I, S>(img: impl AsRef<OsStr>, args: I) -> Container
-where
-    I: IntoIterator<Item = S>,
-    S: AsRef<OsStr>,
-{
-    let tempdir = TempDir::new().await.unwrap();
-
-    run_with(img, args, tempdir).await
-}
-
-/// Starts a container with a temporary directory mounted to /run/integration-tests
 pub async fn run_with<I, S>(
     img: impl AsRef<OsStr>,
     args: I,
-    tempdir: TempDir,
+    tempdir: &Path,
 ) -> Container
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let tempdir_path = tempdir.dir_path().canonicalize().unwrap();
+    let tempdir = tempdir.canonicalize().unwrap();
 
     let out = Command::new("docker")
         .args(["run", "-d", "--rm"])
         .args([
             "-v",
-            &format!("{}:/run/integration-tests", tempdir_path.display()),
+            &format!("{}:/run/integration-tests", tempdir.display()),
         ])
         .args(args)
         .arg(img)
@@ -79,7 +67,7 @@ where
 
 pub struct Container {
     pub id: String,
-    pub tempdir: TempDir,
+    pub tempdir: PathBuf,
 }
 
 impl Drop for Container {

--- a/zenorb/Cargo.toml
+++ b/zenorb/Cargo.toml
@@ -22,6 +22,7 @@ zenoh = { workspace = true, default-features = false, features = [
 ] }
 
 [dev-dependencies]
+async-tempfile.workspace = true
 portpicker = "0.1.1"
 test-utils.workspace = true
 tracing-subscriber.workspace = true

--- a/zenorb/tests/routerfx.rs
+++ b/zenorb/tests/routerfx.rs
@@ -17,7 +17,7 @@ pub async fn run() -> (Container, Port) {
     let container = docker::run_with(
         tag,
         [&format!("-p={port}:7447")],
-        &TempDir::new().await.unwrap().to_path_buf(),
+        &TempDir::new().await.unwrap(),
     )
     .await;
 

--- a/zenorb/tests/routerfx.rs
+++ b/zenorb/tests/routerfx.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use async_tempfile::TempDir;
 use std::path::PathBuf;
 use test_utils::docker::{self, Container};
 
@@ -13,7 +14,12 @@ pub async fn run() -> (Container, Port) {
     docker::build(tag, dockerfile, docker_ctx).await;
 
     let port = portpicker::pick_unused_port().expect("No ports free");
-    let container = docker::run(tag, [&format!("-p={port}:7447")]).await;
+    let container = docker::run_with(
+        tag,
+        [&format!("-p={port}:7447")],
+        &TempDir::new().await.unwrap().to_path_buf(),
+    )
+    .await;
 
     (container, port)
 }


### PR DESCRIPTION
## changes
- refactors connd fixtures to be startable / stoppable
- removes duplicated restart code
- removes need for arrange `Callback`
- should make tests easier to maintain, dependencies easier to manage