### PR TITLE
feat: make orb-mini runners work with hil-agent

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,17 +176,17 @@
         "nixpkgs-cargo-deny": "nixpkgs-cargo-deny"
       },
       "locked": {
-        "lastModified": 1783010910,
-        "narHash": "sha256-pn3yJp7vsDsHL+fYHt90jywXt20M06jCy1AQtSfZ7iw=",
+        "lastModified": 1784133309,
+        "narHash": "sha256-MIh+9F1YbZisaMFtqySiGstBzjrmShkKbZ5zdIIj7Ps=",
         "owner": "worldcoin",
         "repo": "orb-internal",
-        "rev": "0ae426e15655a5dcd7ef5743a84291ba04a2a293",
+        "rev": "dc171236eb87414940f6004a2012f6cf2d86384a",
         "type": "github"
       },
       "original": {
         "owner": "worldcoin",
         "repo": "orb-internal",
-        "rev": "0ae426e15655a5dcd7ef5743a84291ba04a2a293",
+        "rev": "dc171236eb87414940f6004a2012f6cf2d86384a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
     # HTTPS (not git+ssh) so CI can authenticate via the github_access_token
     # passed to install-nix-action (the runners have no SSH key).
     orb-internal = {
-      url = "github:worldcoin/orb-internal?rev=0ae426e15655a5dcd7ef5743a84291ba04a2a293";
+      url = "github:worldcoin/orb-internal?rev=dc171236eb87414940f6004a2012f6cf2d86384a";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.fenix.follows = "fenix";
       inputs.flake-utils.follows = "flake-utils";

--- a/nix/machines/hil-common.nix
+++ b/nix/machines/hil-common.nix
@@ -104,6 +104,10 @@ in
   };
 
   config = {
+    nix.extraOptions = ''
+      netrc-file = /etc/worldcoin/secrets/nix-github-netrc
+    '';
+
     # Install test-related packages
     environment.systemPackages = with pkgs; [
       orb-hil

--- a/nix/machines/worldcoin-hil-munich-1/configuration.nix
+++ b/nix/machines/worldcoin-hil-munich-1/configuration.nix
@@ -16,7 +16,16 @@
     ../hil-common.nix
   ];
 
+  worldcoin.orbId = "muc1mini";
   worldcoin.orbPlatform = "mini";
+
+  environment.etc."worldcoin/orb.yaml" = {
+    text = ''
+      orb_id: ${config.worldcoin.orbId}
+      platform: ${config.worldcoin.orbPlatform}
+    '';
+    mode = "0644";
+  };
 
   services.udev.packages = [ pkgs.android-udev-rules ];
 

--- a/nix/machines/worldcoin-hil-sf-1/configuration.nix
+++ b/nix/machines/worldcoin-hil-sf-1/configuration.nix
@@ -16,7 +16,16 @@
     ../hil-common.nix
   ];
 
+  worldcoin.orbId = "sf1mini1";
   worldcoin.orbPlatform = "mini";
+
+  environment.etc."worldcoin/orb.yaml" = {
+    text = ''
+      orb_id: ${config.worldcoin.orbId}
+      platform: ${config.worldcoin.orbPlatform}
+    '';
+    mode = "0644";
+  };
 
   services.udev.packages = [ pkgs.android-udev-rules ];
 


### PR DESCRIPTION
netrc is required for the very first run. Otherwise we are not able to setup nixos in the first place, because it can't fetch orb-internal