### PR TITLE
ci: migrate GitHub-hosted runners → self-hosted ARC (INFRA-6936)

### DIFF
--- a/.github/workflows/codex-pr-review.yaml
+++ b/.github/workflows/codex-pr-review.yaml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   authorize:
     name: Check PR author team
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     outputs:
       allowed: ${{ steps.team.outputs.allowed }}
     steps:
@@ -51,7 +52,8 @@ jobs:
 
   codex:
     name: Review with Codex
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     needs: authorize
     if: ${{ needs.authorize.outputs.allowed == 'true' && !github.event.pull_request.draft }}
     permissions:
@@ -106,7 +108,8 @@ jobs:
 
   post_feedback:
     name: Post Codex feedback
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     needs:
       - authorize
       - codex

--- a/.github/workflows/delete-tmp-release.yaml
+++ b/.github/workflows/delete-tmp-release.yaml
@@ -9,7 +9,8 @@ on:
 jobs:
   clean_tmp:
     name: Delete Expired Releases
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - name: Delete old releases on `tmp` channel
         uses: dev-drprasad/delete-older-releases@0bf4e6748f08135170c2294f877ba7d9b633b028 # pin@v0.3.3

--- a/.github/workflows/deploy-hil.yaml
+++ b/.github/workflows/deploy-hil.yaml
@@ -17,7 +17,8 @@ env:
 jobs:
   prepare:
     name: Prepare deployment matrix
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     outputs:
       targets: ${{ steps.targets.outputs.targets }}
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/misc-ci.yaml
+++ b/.github/workflows/misc-ci.yaml
@@ -21,7 +21,8 @@ permissions:
 jobs:
   fmt_toml:
     name: TOML Format (Taplo)
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -21,7 +21,8 @@ env:
 jobs:
   fmt:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -46,7 +47,8 @@ jobs:
 
   shells:
     name: Check that devshells work
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -75,7 +77,8 @@ jobs:
 
   nixos:
     name: Build NixOS Machines
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -101,7 +104,8 @@ jobs:
 
   liveusb:
     name: Build NixOS Installer
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/pr-compliance.yaml
+++ b/.github/workflows/pr-compliance.yaml
@@ -14,7 +14,8 @@ permissions:
 jobs:
   check-pr-title:
     name: Check PR title
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # pin@v5.5.3
         env:
@@ -22,7 +23,8 @@ jobs:
 
   require-pr-description:
     name: Require PR Description
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - name: Fail if description is empty
         if: ${{ github.event.pull_request.body == '' }}

--- a/.github/workflows/proto-ci.yaml
+++ b/.github/workflows/proto-ci.yaml
@@ -25,7 +25,8 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -49,7 +50,8 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -18,7 +18,8 @@ on:
 jobs:
   format:
     name: Black Format for Python
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,8 @@ env:
 jobs:
   release-name:
     name: Creates the Release Name
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     outputs:
       release-name: ${{ steps.release-name.outputs.CI_RELEASE_NAME }}
     steps:
@@ -47,7 +48,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -100,7 +102,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -206,7 +209,8 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     needs:
       - release-name
       - test

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -24,7 +24,8 @@ on:
 jobs:
   fmt:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -47,7 +48,8 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -78,7 +80,8 @@ jobs:
 
   doc:
     name: Doc
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -154,7 +157,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -222,7 +226,8 @@ jobs:
 
   cargo-deny:
     name: Cargo Deny
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     if: ${{ !inputs.skip_cargo_deny }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3

--- a/.github/workflows/update-agent.yml
+++ b/.github/workflows/update-agent.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
Part of [INFRA-6936](https://linear.app/worldcoin/issue/INFRA-6936) — org GitHub Actions billing is maxed (50k min / 50 GB); **orb-software is a top-cost repo (~\$233/mo)**. Self-hosted ARC runners aren't billed per-minute. (Opened from a fork — I don't have push access to orb-software.)

## Change
GitHub-hosted Linux jobs → **public** self-hosted ARC (`arc-public-*`, required for public repos per the [runner docs](https://app.notion.com/p/a36d84956fbe4bed8f5664ca7add982a)).
- **Arch preserved** (x86 → amd64). **Size map:** `ubuntu-24.04`/`ubuntu-latest` → `large` (2/8); `public-ubuntu-24.04-32core` → `8xlarge` (30/122).
- **26 `runs-on` migrated.**

## Review / follow-up
- Matrix/input-driven runners **not** auto-changed — map by hand: `rust-ci.yaml` (`matrix.platform`), `cargo-vuln-scan.yaml` (`inputs.runs-on`).
- ⚠️ Confirm `public-ubuntu-24.04-32core` was a GitHub-hosted (billable) label.
- ⚠️ **HW/nix** jobs (`nix-ci`, `deploy-hil`): if any need dedicated hardware runners, use `arc-hw-arm64-runner` instead of the generic pool.
- `python-ci` kept on amd64 (setup-python unsupported on arm64 self-hosted).

Draft — review with Orb owners before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)