### PR TITLE
ci: migrate GitHub-hosted runners → self-hosted ARC (INFRA-6936)

### DIFF
--- a/.github/workflows/codex-pr-review.yaml
+++ b/.github/workflows/codex-pr-review.yaml
@@ -18,7 +18,7 @@ jobs:
   authorize:
     name: Check PR author team
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     outputs:
       allowed: ${{ steps.team.outputs.allowed }}
     steps:
@@ -53,7 +53,7 @@ jobs:
   codex:
     name: Review with Codex
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     needs: authorize
     if: ${{ needs.authorize.outputs.allowed == 'true' && !github.event.pull_request.draft }}
     permissions:
@@ -109,7 +109,7 @@ jobs:
   post_feedback:
     name: Post Codex feedback
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     needs:
       - authorize
       - codex

--- a/.github/workflows/codex-pr-review.yaml
+++ b/.github/workflows/codex-pr-review.yaml
@@ -17,7 +17,8 @@ concurrency:
 jobs:
   authorize:
     name: Check PR author team
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     outputs:
       allowed: ${{ steps.team.outputs.allowed }}
     steps:
@@ -51,7 +52,8 @@ jobs:
 
   codex:
     name: Review with Codex
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     needs: authorize
     if: ${{ needs.authorize.outputs.allowed == 'true' && !github.event.pull_request.draft }}
     permissions:
@@ -106,7 +108,8 @@ jobs:
 
   post_feedback:
     name: Post Codex feedback
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     needs:
       - authorize
       - codex

--- a/.github/workflows/delete-tmp-release.yaml
+++ b/.github/workflows/delete-tmp-release.yaml
@@ -9,7 +9,8 @@ on:
 jobs:
   clean_tmp:
     name: Delete Expired Releases
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - name: Delete old releases on `tmp` channel
         uses: dev-drprasad/delete-older-releases@0bf4e6748f08135170c2294f877ba7d9b633b028 # pin@v0.3.3

--- a/.github/workflows/delete-tmp-release.yaml
+++ b/.github/workflows/delete-tmp-release.yaml
@@ -10,7 +10,7 @@ jobs:
   clean_tmp:
     name: Delete Expired Releases
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - name: Delete old releases on `tmp` channel
         uses: dev-drprasad/delete-older-releases@0bf4e6748f08135170c2294f877ba7d9b633b028 # pin@v0.3.3

--- a/.github/workflows/deploy-hil.yaml
+++ b/.github/workflows/deploy-hil.yaml
@@ -18,7 +18,7 @@ jobs:
   prepare:
     name: Prepare deployment matrix
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     outputs:
       targets: ${{ steps.targets.outputs.targets }}
     steps:

--- a/.github/workflows/deploy-hil.yaml
+++ b/.github/workflows/deploy-hil.yaml
@@ -17,7 +17,8 @@ env:
 jobs:
   prepare:
     name: Prepare deployment matrix
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     outputs:
       targets: ${{ steps.targets.outputs.targets }}
     steps:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,8 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/misc-ci.yaml
+++ b/.github/workflows/misc-ci.yaml
@@ -22,7 +22,7 @@ jobs:
   fmt_toml:
     name: TOML Format (Taplo)
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/misc-ci.yaml
+++ b/.github/workflows/misc-ci.yaml
@@ -21,7 +21,8 @@ permissions:
 jobs:
   fmt_toml:
     name: TOML Format (Taplo)
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -22,7 +22,7 @@ jobs:
   fmt:
     name: Format
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -48,7 +48,7 @@ jobs:
   shells:
     name: Check that devshells work
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -78,7 +78,7 @@ jobs:
   nixos:
     name: Build NixOS Machines
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -21,7 +21,8 @@ env:
 jobs:
   fmt:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -46,7 +47,8 @@ jobs:
 
   shells:
     name: Check that devshells work
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -75,7 +77,8 @@ jobs:
 
   nixos:
     name: Build NixOS Machines
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -101,7 +104,8 @@ jobs:
 
   liveusb:
     name: Build NixOS Installer
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/pr-compliance.yaml
+++ b/.github/workflows/pr-compliance.yaml
@@ -15,7 +15,7 @@ jobs:
   check-pr-title:
     name: Check PR title
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # pin@v5.5.3
         env:
@@ -24,7 +24,7 @@ jobs:
   require-pr-description:
     name: Require PR Description
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - name: Fail if description is empty
         if: ${{ github.event.pull_request.body == '' }}

--- a/.github/workflows/pr-compliance.yaml
+++ b/.github/workflows/pr-compliance.yaml
@@ -14,7 +14,8 @@ permissions:
 jobs:
   check-pr-title:
     name: Check PR title
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # pin@v5.5.3
         env:
@@ -22,7 +23,8 @@ jobs:
 
   require-pr-description:
     name: Require PR Description
-    runs-on: ubuntu-latest
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - name: Fail if description is empty
         if: ${{ github.event.pull_request.body == '' }}

--- a/.github/workflows/proto-ci.yaml
+++ b/.github/workflows/proto-ci.yaml
@@ -25,7 +25,8 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -49,7 +50,8 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/proto-ci.yaml
+++ b/.github/workflows/proto-ci.yaml
@@ -26,7 +26,7 @@ jobs:
   lint:
     name: Lint
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -51,7 +51,7 @@ jobs:
   format:
     name: Format
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -18,7 +18,8 @@ on:
 jobs:
   format:
     name: Black Format for Python
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -19,7 +19,7 @@ jobs:
   format:
     name: Black Format for Python
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,8 @@ env:
 jobs:
   release-name:
     name: Creates the Release Name
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     outputs:
       release-name: ${{ steps.release-name.outputs.CI_RELEASE_NAME }}
     steps:
@@ -47,7 +48,8 @@ jobs:
 
   test:
     name: Test
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -100,7 +102,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -206,7 +209,8 @@ jobs:
 
   release:
     name: Release
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     needs:
       - release-name
       - test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
   release-name:
     name: Creates the Release Name
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     outputs:
       release-name: ${{ steps.release-name.outputs.CI_RELEASE_NAME }}
     steps:
@@ -210,7 +210,7 @@ jobs:
   release:
     name: Release
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     needs:
       - release-name
       - test

--- a/.github/workflows/relyance-sci.yml
+++ b/.github/workflows/relyance-sci.yml
@@ -12,7 +12,7 @@ jobs:
   execute-relyance-sci:
     name: Relyance SCI Job
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     permissions:
       contents: read
 

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -24,7 +24,8 @@ on:
 jobs:
   fmt:
     name: Format
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -47,7 +48,8 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -78,7 +80,8 @@ jobs:
 
   doc:
     name: Doc
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -154,7 +157,8 @@ jobs:
 
   build:
     name: Build
-    runs-on: public-ubuntu-24.04-32core
+    runs-on:
+      group: arc-public-8xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -222,7 +226,8 @@ jobs:
 
   cargo-deny:
     name: Cargo Deny
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     if: ${{ !inputs.skip_cargo_deny }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -25,7 +25,7 @@ jobs:
   fmt:
     name: Format
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -81,7 +81,7 @@ jobs:
   doc:
     name: Doc
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -227,7 +227,7 @@ jobs:
   cargo-deny:
     name: Cargo Deny
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     if: ${{ !inputs.skip_cargo_deny }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3

--- a/.github/workflows/update-agent.yml
+++ b/.github/workflows/update-agent.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   test:
     runs-on:
-      group: arc-public-large-amd64-runner
+      group: arc-public-xlarge-amd64-runner
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/.github/workflows/update-agent.yml
+++ b/.github/workflows/update-agent.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-24.04
+    runs-on:
+      group: arc-public-large-amd64-runner
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies


### PR DESCRIPTION
## Summary
Migrates orb-software CI from GitHub-hosted runners to TFH self-hosted **ARC public** runners (INFRA-6936), to cut GitHub Actions per-minute billing. macOS jobs are left on GitHub-hosted (no self-hosted mac).

## Runner mapping (public repo → arc-public-*)
| Original (GitHub-hosted) | vCPU/RAM | ARC target | vCPU/RAM |
|---|---|---|---|
| `public-ubuntu-24.04-32core` | 32 / 128 | `arc-public-8xlarge-amd64` | 30 / 122 |
| `ubuntu-24.04` / `ubuntu-latest` (standard) | 4 / 16 | `arc-public-xlarge-amd64` | 4 / 16 |

Heavy Nix/Rust jobs (rust-ci, nix-ci, release) → `8xlarge`; all light jobs → `xlarge` (4c/16GB parity with the GitHub-hosted standard public-repo runner — **not** `large`, which would halve cores).

## Skipped (intentionally)
- `cargo-vuln-scan.yaml` — `runs-on` comes from a reusable-workflow input, not a static label.
- macOS matrix legs.

## Notes
Supersedes the fork-based PR #1323, which couldn't run CI because orb-software workflows check out with `secrets.ORB_GIT_HUB_TOKEN` and GitHub withholds secrets from fork PRs. This branch is in-repo (infra team push access granted via infrastructure#45964), so CI runs with secrets and genuinely exercises the ARC runners.