### PR TITLE
fix(attest): recreate client on every flow 

### DIFF
--- a/attest/src/client.rs
+++ b/attest/src/client.rs
@@ -1,6 +1,7 @@
 use orb_const_concat::const_concat;
 use reqwest::Client;
 use secrecy::ExposeSecret;
+use std::time::Duration;
 use tracing::{error, info, warn};
 
 use crate::BUILD_INFO;
@@ -22,7 +23,7 @@ pub enum Error {
 /// Returns an instance of a http [`Client`] with pinned certificates.
 pub fn create() -> Client {
     let builder = orb_security_utils::reqwest::client_builder()
-        .timeout(std::time::Duration::from_secs(60))
+        .timeout(Duration::from_secs(30))
         .user_agent(USER_AGENT);
     #[cfg(test)]
     let builder = builder.https_only(false);

--- a/attest/src/client.rs
+++ b/attest/src/client.rs
@@ -1,5 +1,3 @@
-use std::sync::OnceLock;
-
 use orb_const_concat::const_concat;
 use reqwest::Client;
 use secrecy::ExposeSecret;
@@ -21,17 +19,14 @@ pub enum Error {
     ConnectionFailed(#[source] reqwest::Error),
 }
 
-/// Returns a shared instance of a http [`Client`] with pinned certificates.
-pub fn client() -> &'static Client {
-    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-    CLIENT.get_or_init(|| {
-        let builder = orb_security_utils::reqwest::client_builder()
-            .timeout(std::time::Duration::from_secs(60))
-            .user_agent(USER_AGENT);
-        #[cfg(test)]
-        let builder = builder.https_only(false);
-        builder.build().expect("Failed to build client")
-    })
+/// Returns an instance of a http [`Client`] with pinned certificates.
+pub fn create() -> Client {
+    let builder = orb_security_utils::reqwest::client_builder()
+        .timeout(std::time::Duration::from_secs(60))
+        .user_agent(USER_AGENT);
+    #[cfg(test)]
+    let builder = builder.https_only(false);
+    builder.build().expect("Failed to build client")
 }
 
 /// Contact the backend to verify that the token is valid.
@@ -43,11 +38,12 @@ pub fn client() -> &'static Client {
 ///
 /// If failed to connect to the backend.
 pub async fn validate_token(
+    client: &Client,
     orb_id: &str,
     token: &crate::remote_api::Token,
     ping_url: &url::Url,
 ) -> Result<bool, Error> {
-    let resp = client()
+    let resp = client
         .get(ping_url.clone())
         .basic_auth(orb_id, Some(token.token.expose_secret()))
         .send()

--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -174,8 +174,12 @@ async fn wait_for_backend_reachable(orb_id: &str, auth_url: &Url) {
     let tokenchallenge_url = auth_url
         .join("tokenchallenge")
         .expect("auth_url must have a path");
+
+    let client = client::create();
+
     loop {
-        match remote_api::Challenge::request(orb_id, &tokenchallenge_url).await {
+        match remote_api::Challenge::request(&client, orb_id, &tokenchallenge_url).await
+        {
             Ok(_) | Err(remote_api::ChallengeError::ServerReturnedError(..)) => {
                 info!("backend reachable");
                 return;
@@ -280,8 +284,10 @@ async fn get_working_static_token(
     // Loop until we get confirmation from the backend that the token is valid
     // or not. In case of network errors, keep trying.
     info!("got static token {token:#?}, validating it");
+    let client = client::create();
+
     loop {
-        match crate::client::validate_token(orb_id, &token, ping_url).await {
+        match client::validate_token(&client, orb_id, &token, ping_url).await {
             Ok(true) => {
                 info!("Static token is valid");
                 return Ok(token);

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -1,5 +1,6 @@
 use data_encoding::BASE64;
 use orb_dogd::MetricEmitter;
+use reqwest::Client;
 use ring::{digest, digest::digest};
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
@@ -19,7 +20,7 @@ use tokio::{
 use tracing::{error, event, info, warn, Level};
 use url::Url;
 
-use crate::ConnectivityTracker;
+use crate::{client, ConnectivityTracker};
 
 /// Path to persistent token, don't use it directly, use `Token::from_usr_persistent()` instead
 #[cfg(test)]
@@ -203,10 +204,12 @@ pub struct Challenge {
 }
 
 impl Challenge {
-    #[tracing::instrument]
-    pub async fn request(orb_id: &str, url: &url::Url) -> Result<Self, ChallengeError> {
-        let client = crate::client::client();
-
+    #[tracing::instrument(skip(client))]
+    pub async fn request(
+        client: &Client,
+        orb_id: &str,
+        url: &url::Url,
+    ) -> Result<Self, ChallengeError> {
         let req = serde_json::json!({
             "orbId": orb_id,
         });
@@ -396,15 +399,14 @@ pub struct Token {
 }
 
 impl Token {
-    #[tracing::instrument]
+    #[tracing::instrument(skip(client))]
     pub async fn request(
+        client: &Client,
         url: &url::Url,
         orb_id: &str,
         challenge: &Challenge,
         signature: &Signature,
     ) -> Result<Self, TokenError> {
-        let client = crate::client::client();
-
         info!("requesting token from {}", url);
 
         let req = TokenRequest {
@@ -508,12 +510,14 @@ async fn get_token_inner(
     token_challenge: &url::Url,
     token_fetch: &url::Url,
 ) -> Result<Token, RefreshTokenError> {
+    let client = client::create();
+
     let challenge = retry(
         NUMBER_OF_CHALLENGE_RETRIES,
         CHALLENGE_DELAY,
         "get challenge",
         || async {
-            Challenge::request(orb_id, token_challenge)
+            Challenge::request(&client, orb_id, token_challenge)
                 .await
                 .map_err(RefreshTokenError::ChallengeError)
         },
@@ -548,7 +552,7 @@ async fn get_token_inner(
             if challenge.expired() {
                 return Err(RefreshTokenError::ChallengeExpired);
             }
-            Token::request(token_fetch, orb_id, &challenge, &signature)
+            Token::request(&client, token_fetch, orb_id, &challenge, &signature)
                 .await
                 .map_err(RefreshTokenError::TokenError)
         },
@@ -726,7 +730,9 @@ pub async fn try_token_with_migrated_key(orb_id: &str, auth_url: &Url) -> bool {
         }
     };
 
-    let challenge = match Challenge::request(orb_id, &tokenchallenge_url).await {
+    let client = client::create();
+    let challenge = match Challenge::request(&client, orb_id, &tokenchallenge_url).await
+    {
         Ok(c) => c,
         Err(e) => {
             warn!("migrated key probe: challenge request failed: {e}");
@@ -751,7 +757,7 @@ pub async fn try_token_with_migrated_key(orb_id: &str, auth_url: &Url) -> bool {
         }
     };
 
-    match Token::request(&token_url, orb_id, &challenge, &sig).await {
+    match Token::request(&client, &token_url, orb_id, &challenge, &sig).await {
         Ok(_) => true,
         Err(e) => {
             warn!("migrated key probe: token request failed (backend not yet activated): {e}");
@@ -774,7 +780,7 @@ pub async fn submit_proof(
     keys_challenge_url: &Url,
     keys_proof_url: &Url,
 ) -> Result<(), ProofError> {
-    let client = crate::client::client();
+    let client = crate::client::create();
 
     // 1. Get challenge nonce
     let resp = client
@@ -907,6 +913,8 @@ mod test {
     use std::os::unix::fs::PermissionsExt;
     use std::time::Duration;
 
+    use crate::client;
+
     use super::{
         ChallengeError, RefreshTokenError, SignError, MAX_TOKEN_DELAY, MIN_TOKEN_DELAY,
     };
@@ -966,9 +974,11 @@ printf dmFsaWRzaWduYXR1cmU=
         let token_challenge = base_url.join("tokenchallenge").unwrap();
 
         // 1. get challenge
-        let challenge = crate::remote_api::Challenge::request(orb_id, &token_challenge)
-            .await
-            .unwrap();
+        let client = client::create();
+        let challenge =
+            crate::remote_api::Challenge::request(&client, orb_id, &token_challenge)
+                .await
+                .unwrap();
 
         let clone_of_challenge = challenge.clone();
 
@@ -1000,6 +1010,7 @@ printf dmFsaWRzaWduYXR1cmU=
 
         // 3. get token
         let token = crate::remote_api::Token::request(
+            &client,
             &base_url.join("token").unwrap(),
             orb_id,
             &challenge,


### PR DESCRIPTION
recreate client on every flow to avoid dns resolution issues when switching connections

still need testing on an orb