### PR TITLE
ci: right-size runners + PR concurrency to cut Actions cost (INFRA-6936)

### DIFF
--- a/.github/workflows/misc-ci.yaml
+++ b/.github/workflows/misc-ci.yaml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel superseded PR runs; never cancel main/prod/tag/release builds.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fmt_toml:
     name: TOML Format (Taplo)

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -18,6 +18,11 @@ on:
 env: 
   CI_NIXOS_HOSTNAMES: ryan-worldcoin-hil worldcoin-hil-munich-0 worldcoin-hil-munich-1 worldcoin-hil-munich-2 worldcoin-hil-jabil-0
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel superseded PR runs; never cancel main/prod/tag/release builds.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fmt:
     name: Format
@@ -101,7 +106,7 @@ jobs:
 
   liveusb:
     name: Build NixOS Installer
-    runs-on: public-ubuntu-24.04-32core
+    runs-on: public-ubuntu-24.04-16core
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:

--- a/.github/workflows/proto-ci.yaml
+++ b/.github/workflows/proto-ci.yaml
@@ -22,6 +22,11 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel superseded PR runs; never cancel main/prod/tag/release builds.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -15,6 +15,11 @@ on:
     tags:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel superseded PR runs; never cancel main/prod/tag/release builds.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   format:
     name: Black Format for Python

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -21,6 +21,11 @@ on:
     tags:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only cancel superseded PR runs; never cancel main/prod/tag/release builds.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fmt:
     name: Format
@@ -47,7 +52,7 @@ jobs:
 
   clippy:
     name: Clippy
-    runs-on: public-ubuntu-24.04-32core
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
@@ -112,7 +117,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ public-ubuntu-24.04-32core ]
+        platform: [ public-ubuntu-24.04-16core ]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
@@ -154,7 +159,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: public-ubuntu-24.04-32core
+    runs-on: public-ubuntu-24.04-16core
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:


### PR DESCRIPTION
## Summary
orb-device team stays on **GitHub-hosted** runners; this PR lowers Actions cost by right-sizing rather than migrating. On a public repo, standard `ubuntu-24.04`/`ubuntu-latest` runners are **free** — only `public-ubuntu-24.04-*core` larger runners are billed. Most light jobs were already on free runners; the billed footprint is ~6 build/test jobs.

## Changes
**1. Concurrency (cancel superseded PR runs)** on `rust-ci`, `nix-ci`, `misc-ci`, `python-ci`, `proto-ci`:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```
`cancel-in-progress` is gated to `pull_request` so **main/prod/tag/release builds are never cancelled** — only stacked PR runs on the same ref.

**2. Clippy -> free `ubuntu-24.04`** (was `public-ubuntu-24.04-32core`). It's a lint/check, not build/test, and is well-cached (~2 min) — slower on a free runner but $0.

**3. Build/Test -> 16-core (trial, to measure):**
- `rust-ci` **Build** and **Test**: `32core -> public-ubuntu-24.04-16core`
- `nix-ci` **Build NixOS Installer**: `32core -> public-ubuntu-24.04-16core`

Large-runner billing is ~linear in vCPU, so 16-core is cheaper *if* wall-clock grows less than 2x. This PR is **draft** so we can compare times against the 32-core baseline (Build ~10m, Test ~5m, Installer ~5m on 32-core) before deciding.

## Before this can produce data
- [ ] Confirm the **`public-ubuntu-24.04-16core`** runner label is provisioned for the org/repo. If it doesn't exist, those jobs will queue indefinitely — create it (or tell me the correct 16-core label) and I'll adjust.

## Not changed
- `release.yaml` Test/Build (32-core) — release-only; left as baseline until the 16-core trial data looks good.
- Everything already on free runners (fmt, doc, cargo-deny, taplo, black, PR checks, codex, vuln-scan, gh-pages).
- `deploy-hil` (self-hosted HIL hardware), `relyance-sci` (self-hosted ARC).

## How to read the results
Compare this PR's **Build / Test / Build NixOS Installer** durations vs. `main`. If 16-core wall-clock is <2x the 32-core time, it's a net saving; if it balloons, we revert those three to 32-core (or try 24-core) and keep #1 + #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)