### PR TITLE
ci: fix Rust CI cache (share across jobs, restore-only on PRs)

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -65,7 +65,15 @@ jobs:
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # pin@v2.8.0
         with:
-          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          # Share one cache across all Rust jobs (clippy/doc/test/build) instead
+          # of a separate per-job cache. GitHub's 10GB/repo cache budget can't
+          # hold 5 multi-GB target caches, so per-job caches evict each other and
+          # every run misses. Swatinem still appends runner OS/arch, so the Test
+          # matrix stays isolated per platform.
+          shared-key: "rust-ci-${{ hashFiles('**/*.nix', 'flake.lock') }}"
+          # Only write the cache from main; PR runs restore-only. Prevents each PR
+          # run from saving (and evicting) caches, keeping main's cache warm.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Print environment
         run: |
           uname -a
@@ -96,7 +104,15 @@ jobs:
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # pin@v2.8.0
         with:
-          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          # Share one cache across all Rust jobs (clippy/doc/test/build) instead
+          # of a separate per-job cache. GitHub's 10GB/repo cache budget can't
+          # hold 5 multi-GB target caches, so per-job caches evict each other and
+          # every run misses. Swatinem still appends runner OS/arch, so the Test
+          # matrix stays isolated per platform.
+          shared-key: "rust-ci-${{ hashFiles('**/*.nix', 'flake.lock') }}"
+          # Only write the cache from main; PR runs restore-only. Prevents each PR
+          # run from saving (and evicting) caches, keeping main's cache warm.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Print environment
         run: |
           uname -a
@@ -132,7 +148,15 @@ jobs:
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # pin@v2.8.0
         with:
-          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          # Share one cache across all Rust jobs (clippy/doc/test/build) instead
+          # of a separate per-job cache. GitHub's 10GB/repo cache budget can't
+          # hold 5 multi-GB target caches, so per-job caches evict each other and
+          # every run misses. Swatinem still appends runner OS/arch, so the Test
+          # matrix stays isolated per platform.
+          shared-key: "rust-ci-${{ hashFiles('**/*.nix', 'flake.lock') }}"
+          # Only write the cache from main; PR runs restore-only. Prevents each PR
+          # run from saving (and evicting) caches, keeping main's cache warm.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Print environment
         run: |
           uname -a
@@ -173,7 +197,15 @@ jobs:
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0 # pin@v2.8.0
         with:
-          key: custom-${{ hashFiles('**/*.nix', 'flake.lock') }}
+          # Share one cache across all Rust jobs (clippy/doc/test/build) instead
+          # of a separate per-job cache. GitHub's 10GB/repo cache budget can't
+          # hold 5 multi-GB target caches, so per-job caches evict each other and
+          # every run misses. Swatinem still appends runner OS/arch, so the Test
+          # matrix stays isolated per platform.
+          shared-key: "rust-ci-${{ hashFiles('**/*.nix', 'flake.lock') }}"
+          # Only write the cache from main; PR runs restore-only. Prevents each PR
+          # run from saving (and evicting) caches, keeping main's cache warm.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Print environment
         run: |
           uname -a


### PR DESCRIPTION
## Summary
Rust CI jobs (Clippy, Doc, Test, Build) **miss the cache on every run** and recompile all dependencies from scratch. This draft fixes the cache configuration — no new cache is added, the existing `Swatinem/rust-cache` is made effective.

## Evidence
From a recent Clippy run:
```
##[warning]Cache not found for keys: v0-rust-custom-…-clippy-Linux-x64-…
No cache found.
```
→ followed by `Compiling proc-macro2 … serde … libc …` (full dependency rebuild, ~3 min of the ~7 min job).

## Root cause
`Swatinem/rust-cache` keys the cache **per job** (`…-clippy-…`, `…-build-…`, etc.), so the 4 Rust jobs each keep a separate multi-GB `target/`+`~/.cargo` cache. That exceeds GitHub's **10 GB per-repo cache budget**, the caches evict each other, and subsequent runs miss → full recompile. It's an eviction thrash loop.

## Changes
- **`shared-key: "rust-ci-<nix hash>"`** on all four cache steps → jobs share **one** cache instead of five, restoring from a common warm cache. Swatinem still appends runner OS/arch, so the Test matrix stays isolated per platform.
- **`save-if: github.ref == 'refs/heads/main'`** → PR runs are restore-only; they no longer write/evict caches, keeping main's cache warm for PRs.

Workflow-only, fully reversible.

## Follow-ups (out of scope here)
1. **`CACHIX_AUTH_TOKEN` looks unset for this repo** — `cachix-action` errors (`exit code 1`, swallowed by `continue-on-error`), so the Nix devshell is rebuilt each run (~3.5 min) instead of pulled from the `worldcoin` binary cache. Provisioning the secret would remove most of that.
2. **`sccache` backed by S3** — since Rust CI now runs on TFH self-hosted ARC runners, a shared sccache (S3 backend, via the repo's OIDC `AWS_ROLE`) would cache compiled artifacts across all jobs and runs, bypassing the 10 GB GitHub-cache limit entirely. Biggest durable win.

## Testing
Draft — leaving CI to run. First main run after merge populates the shared cache; subsequent PR runs should show `Cache restored from key: …` instead of `No cache found`, and Clippy compile time should drop. Ticket: INFRA-6936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)