### PR TITLE
fix(attest): also recreate client on get_working_static_token

### DIFF
--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -284,9 +284,9 @@ async fn get_working_static_token(
     // Loop until we get confirmation from the backend that the token is valid
     // or not. In case of network errors, keep trying.
     info!("got static token {token:#?}, validating it");
-    let client = client::create();
 
     loop {
+        let client = client::create();
         match client::validate_token(&client, orb_id, &token, ping_url).await {
             Ok(true) => {
                 info!("Static token is valid");


### PR DESCRIPTION
```rust
        let token = select! {
            Ok(token) = get_working_static_token(orb_id, &ping_url) => token,
            token = remote_api::get_token(orb_id, &auth_url, &metrics, &conn_tracker) => token,
        };
```

in this loop if we don't recreate the http client in `get_working_static_token`, then `remote_api::get_token` gets an unfair bias due to the other function getting stuck with a bad http client for all retries as opposed to `remote_api::get_token` which recreates on every challenge flow attempt