### PR TITLE
ci(deny): patch advisories + bump event-listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -526,7 +526,7 @@ version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -553,7 +553,7 @@ dependencies = [
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-lite",
  "rustix 1.1.2",
 ]
@@ -3656,11 +3656,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3671,7 +3670,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -7322,7 +7321,7 @@ version = "0.2.10"
 dependencies = [
  "color-eyre",
  "data-encoding",
- "event-listener 5.4.1",
+ "event-listener 2.5.3",
  "eyre",
  "futures",
  "oes",
@@ -11383,7 +11382,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -14269,7 +14268,7 @@ dependencies = [
  "async-trait",
  "blocking",
  "enumflags2",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-core",
  "futures-sink",
  "futures-util",
@@ -14626,7 +14625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f132137bb003f10b7fff086cb18addf8e8273b9c0d2722a53b5074c8a79965"
 dependencies = [
  "arc-swap",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures",
  "tokio",
  "zenoh-buffers",

--- a/deny.toml
+++ b/deny.toml
@@ -5,13 +5,10 @@ all-features = true
 [advisories]
 ignore = [
 	# List of advisories we have ignored
-	{ id = "RUSTSEC-2023-0071", reason = "we dont use rsa keys" },
 	{ id = "RUSTSEC-2026-0002", reason = "todo" },
 	# rustls-webpki 0.101.7 and 0.102.8 are pulled in by older aws-sdk/reqwest 0.11
 	# crates; upgrade blocked until those dependents update their rustls stack
 	{ id = "RUSTSEC-2026-0049", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
-	# rand 0.8.5 is a transitive dep; unsound only under rare conditions (custom logger + thread_rng + trace logging)
-	{ id = "RUSTSEC-2026-0097", reason = "transitive dep, unsound only under rare conditions with custom logger accessing rand::rng(), upgrade blocked by upstream" },
 	{ id = "RUSTSEC-2026-0098", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
 	{ id = "RUSTSEC-2026-0099", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
 	{ id = "RUSTSEC-2026-0104", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },


### PR DESCRIPTION

-- Deleted advisories were not encountered anymore in the codebase are were throwing warnings.
-- Needed to bump `event-listener` for https://github.com/worldcoin/orb-software/pull/1334