### PR TITLE
fix: add missing native libudev library

### DIFF
--- a/nix/machines/orb-mini-runner.nix
+++ b/nix/machines/orb-mini-runner.nix
@@ -53,6 +53,7 @@ in
       qdl-rs
       pkgs.android-tools
       pkgs.dejavu_fonts
+      pkgs.udev
     ];
 
     systemd.tmpfiles.rules = [


### PR DESCRIPTION
Fix the test run:

<img width="1452" height="1068" alt="image" src="https://github.com/user-attachments/assets/501f30bc-1286-4e1e-9775-52d5f30e8c32" />


Test run: https://github.com/worldcoin/orb-mini-utils/actions/runs/31233600018/job/93042026462