### PR TITLE
feat(orb-health): include overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7669,6 +7669,8 @@ name = "orb-health"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
+ "rustix 0.38.44",
+ "tempfile",
  "tokio",
  "tracing",
  "walkdir",

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,10 @@ ignore = [
 	{ id = "RUSTSEC-2026-0104", reason = "transitive dep via aws-sdk and reqwest 0.11, low severity, upgrade blocked by upstream" },
 	{ id = "RUSTSEC-2026-0118", reason = "no upgrade available, is merely DoS" },
 	{ id = "RUSTSEC-2026-0119", reason = "no upgrade available, is merely DoS" },
+	# lru 0.12 and 0.13 are pulled in by aws-sdk-s3 and iroh. The fix is only
+	# available in lru 0.18.2, outside their semver constraints. Exploitation also
+	# requires a cache key with a panicking Drop implementation and catching that panic.
+	{ id = "RUSTSEC-2026-0253", reason = "transitive dep via aws-sdk-s3 and iroh; no compatible upgrade available and exploit requires a panicking key destructor" },
 ]
 unmaintained = "workspace" # only warn for direct dependencies (not transitive ones)
 version = 2

--- a/orb-health/Cargo.toml
+++ b/orb-health/Cargo.toml
@@ -9,6 +9,10 @@ rust-version.workspace = true
 
 [dependencies]
 color-eyre.workspace = true
+rustix = { workspace = true, features = ["fs"] }
 tokio.workspace = true
 tracing.workspace = true
 walkdir.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/orb-health/src/file_sizes.rs
+++ b/orb-health/src/file_sizes.rs
@@ -1,43 +1,197 @@
-use color_eyre::eyre::Result;
-use std::path::PathBuf;
+use color_eyre::eyre::{eyre, Result};
+use rustix::fs::statvfs;
+use std::collections::HashSet;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
 use tokio::task;
 use tracing::{error, info};
 use walkdir::WalkDir;
 
 const PERSISTENT: &str = "/usr/persistent";
+const STAT_BLOCK_SIZE: u64 = 512;
+
+#[derive(Debug)]
+struct FileUsage {
+    path: PathBuf,
+    logical_bytes: u64,
+    allocated_bytes: u64,
+    device: u64,
+    inode: u64,
+}
+
+#[derive(Debug)]
+struct Usage {
+    total_bytes: u64,
+    used_bytes: u64,
+    available_bytes: u64,
+    allocated_file_bytes: u64,
+    overhead_bytes: u64,
+    scan_errors: usize,
+    files: Vec<FileUsage>,
+}
 
 pub async fn run() -> Result<()> {
     task::spawn_blocking(|| collect(PERSISTENT)).await?
 }
 
 fn collect(root: &str) -> Result<()> {
-    let root = PathBuf::from(root);
-    let mut entries = Vec::new();
+    let root = Path::new(root);
+    let usage = usage(root)?;
 
-    for entry in WalkDir::new(root).follow_links(false) {
+    info!(
+        "Filesystem in {}: {} total bytes, {} used bytes, {} available bytes",
+        root.display(),
+        usage.total_bytes,
+        usage.used_bytes,
+        usage.available_bytes
+    );
+    info!(
+        "Filesystem overhead in {}: {} bytes ({} used bytes - {} allocated file bytes; {} scan errors)",
+        root.display(),
+        usage.overhead_bytes,
+        usage.used_bytes,
+        usage.allocated_file_bytes,
+        usage.scan_errors
+    );
+
+    for file in usage.files {
+        info!(
+            "{}: {} logical bytes, {} allocated bytes",
+            file.path.display(),
+            file.logical_bytes,
+            file.allocated_bytes
+        );
+    }
+
+    Ok(())
+}
+
+fn usage(root: &Path) -> Result<Usage> {
+    let mut entries = Vec::new();
+    let mut scan_errors = 0;
+
+    for entry in WalkDir::new(root)
+        .follow_links(false)
+        .same_file_system(true)
+    {
         let entry = match entry {
             Ok(e) => e,
             Err(e) => {
                 error!("failed to read entry: {e}");
+                scan_errors += 1;
                 continue;
             }
         };
 
         if entry.file_type().is_file() {
             match entry.metadata() {
-                Ok(meta) => entries.push((entry.into_path(), meta.len())),
+                Ok(meta) => entries.push(FileUsage {
+                    path: entry.into_path(),
+                    logical_bytes: meta.len(),
+                    allocated_bytes: meta.blocks().saturating_mul(STAT_BLOCK_SIZE),
+                    device: meta.dev(),
+                    inode: meta.ino(),
+                }),
                 Err(e) => {
-                    error!(path = %entry.path().display(), "failed to read metadata: {e}")
+                    error!(path = %entry.path().display(), "failed to read metadata: {e}");
+                    scan_errors += 1;
                 }
             }
         }
     }
 
-    entries.sort_unstable_by(|a, b| b.1.cmp(&a.1));
+    entries.sort_unstable_by(|a, b| {
+        b.allocated_bytes
+            .cmp(&a.allocated_bytes)
+            .then_with(|| b.logical_bytes.cmp(&a.logical_bytes))
+            .then_with(|| a.path.cmp(&b.path))
+    });
 
-    for (path, size_bytes) in entries {
-        info!("{}: {size_bytes} bytes", path.display());
+    let mut seen_files = HashSet::new();
+    let allocated_file_bytes = entries
+        .iter()
+        .filter(|entry| seen_files.insert((entry.device, entry.inode)))
+        .try_fold(0_u64, |total, entry| {
+            total
+                .checked_add(entry.allocated_bytes)
+                .ok_or_else(|| eyre!("allocated file size overflow"))
+        })?;
+
+    let stats = statvfs(root)?;
+    let fragment_size = if stats.f_frsize == 0 {
+        stats.f_bsize
+    } else {
+        stats.f_frsize
+    };
+    if fragment_size == 0 {
+        return Err(eyre!("filesystem reported a block size of zero"));
     }
 
-    Ok(())
+    let total_bytes = stats
+        .f_blocks
+        .checked_mul(fragment_size)
+        .ok_or_else(|| eyre!("filesystem total size overflow"))?;
+    let used_bytes = stats
+        .f_blocks
+        .saturating_sub(stats.f_bfree)
+        .checked_mul(fragment_size)
+        .ok_or_else(|| eyre!("filesystem used size overflow"))?;
+    let available_bytes = stats
+        .f_bavail
+        .checked_mul(fragment_size)
+        .ok_or_else(|| eyre!("filesystem available size overflow"))?;
+    let overhead_bytes = used_bytes.saturating_sub(allocated_file_bytes);
+
+    if allocated_file_bytes > used_bytes {
+        error!(
+            allocated_file_bytes,
+            used_bytes, "allocated file size exceeds filesystem used size"
+        );
+    }
+
+    Ok(Usage {
+        total_bytes,
+        used_bytes,
+        available_bytes,
+        allocated_file_bytes,
+        overhead_bytes,
+        scan_errors,
+        files: entries,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn reports_logical_and_allocated_file_sizes() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("file");
+        fs::write(&path, vec![0_u8; 8192]).unwrap();
+
+        let usage = usage(tempdir.path()).unwrap();
+
+        assert_eq!(usage.files.len(), 1);
+        assert_eq!(usage.files[0].path, path);
+        assert_eq!(usage.files[0].logical_bytes, 8192);
+        assert!(usage.files[0].allocated_bytes >= 8192);
+        assert_eq!(usage.allocated_file_bytes, usage.files[0].allocated_bytes);
+    }
+
+    #[test]
+    fn counts_hardlinked_file_allocation_once() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let original = tempdir.path().join("original");
+        let hardlink = tempdir.path().join("hardlink");
+        fs::write(&original, vec![0_u8; 8192]).unwrap();
+        fs::hard_link(&original, &hardlink).unwrap();
+
+        let usage = usage(tempdir.path()).unwrap();
+
+        assert_eq!(usage.files.len(), 2);
+        assert_eq!(usage.allocated_file_bytes, usage.files[0].allocated_bytes);
+    }
 }


### PR DESCRIPTION
# Improve storage reporting

The service now reports:

  - Filesystem total, used, and available space
  - Filesystem overhead/unattributed usage
  - Logical and allocated size for every regular file
  - File-scan errors

 ## Logical vs allocated size

Logical size is the amount of data visible when reading the file—equivalent to `stat.st_size` or the size shown by `ls -l`.

Allocated size is the storage attributed to the file by the filesystem—equivalent to `stat.st_blocks × 512` or approximately what du reports.

They can differ because:
  - Files normally consume whole filesystem blocks. A 4,228-byte file may occupy 8,192 bytes.
  - F2FS can store small files inline inside inode metadata.
  - Filesystem compression or preallocation may also affect allocation.

Allocated sizes help identify which files consume storage, but their sum does not equal df usage. Filesystem metadata, directories, checkpoints, reserved space, and F2FS garbage-collection state are included in filesystem usage but not attributed to regular files.

The available bytes value from `statvfs` is the authoritative answer for how much space applications can still use.