### PR TITLE
fix: _FORTIFY_SOURCE requires compiling with optimization (-O)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,6 +249,14 @@ git = "https://github.com/TheButlah/teaclave-trustzone-sdk"
 # [profile.dev.package."*"]
 # opt-level = 2
 
+# glibc's _FORTIFY_SOURCE requires -O, so the shim's C code (built by cc-rs in
+# its build.rs) must not compile at opt-level 0, even in dev builds.
+[profile.dev.package.orb-bidiff-squashfs-shim]
+opt-level = 2
+
+[profile.test.package.orb-bidiff-squashfs-shim]
+opt-level = 2
+
 # What we use when producing artifacts to distribute
 [profile.artifact]
 debug = false


### PR DESCRIPTION
Fixes this build warning:

```
warning: orb-bidiff-squashfs-shim@0.0.0: In file included from /nix/store/1v9ggwkpb0xy708s11s1g9fhinn3b06r-glibc-2.40-66-dev/include/fcntl.h:25,
warning: orb-bidiff-squashfs-shim@0.0.0:                  from shim.c:1:
warning: orb-bidiff-squashfs-shim@0.0.0: /nix/store/1v9ggwkpb0xy708s11s1g9fhinn3b06r-glibc-2.40-66-dev/include/features.h:422:4: warning: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Wcpp]
warning: orb-bidiff-squashfs-shim@0.0.0:   422 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
warning: orb-bidiff-squashfs-shim@0.0.0:       |    ^~~~~~~
```