### PR TITLE
fix: pin the revision of a teeclave-trustzone-sdk crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7072,7 +7072,7 @@ dependencies = [
 [[package]]
 name = "optee-teec-sys"
 version = "0.7.0"
-source = "git+https://github.com/TheButlah/teaclave-trustzone-sdk?branch=tfh#2b6ca05f8b38496c201cf635032dcce3cfedb3d7"
+source = "git+https://github.com/TheButlah/teaclave-trustzone-sdk?rev=2b6ca05f8b38496c201cf635032dcce3cfedb3d7#2b6ca05f8b38496c201cf635032dcce3cfedb3d7"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,9 +241,10 @@ default-features = false
 features = ["rustls-tls", "stream"]
 version = "0.12.24"
 
+# This crate uses 'tfh' branch on fork of an upstream project. Pin its 'rev' to protect from supply chain attacks.
 [patch.crates-io.optee-teec-sys]
-branch = "tfh"
 git = "https://github.com/TheButlah/teaclave-trustzone-sdk"
+rev = "2b6ca05f8b38496c201cf635032dcce3cfedb3d7"
 
 # increase the optimization of third party crates in dev builds.
 # [profile.dev.package."*"]


### PR DESCRIPTION
crate `teeclave-trustzone-sdk`  uses `tfh` branch on fork of an upstream project. Pin its revision to protect from supply chain attacks.