### PR TITLE
fix: bump crate version 0.0.0 -> 0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7167,7 +7167,7 @@ dependencies = [
 
 [[package]]
 name = "orb-backend-status"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "async-tempfile",
  "bon",
@@ -7515,7 +7515,7 @@ version = "0.0.0"
 
 [[package]]
 name = "orb-jobs-agent"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "async-tempfile",
  "async-trait",
@@ -7570,7 +7570,7 @@ dependencies = [
 
 [[package]]
 name = "orb-jwk-util"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7644,7 +7644,7 @@ dependencies = [
 
 [[package]]
 name = "orb-ota-backend"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "axum 0.8.6",
  "clap",
@@ -7774,7 +7774,7 @@ dependencies = [
 
 [[package]]
 name = "orb-se050"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "bon",
  "clap",
@@ -7796,7 +7796,7 @@ dependencies = [
 
 [[package]]
 name = "orb-se050-reprovision"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "bon",
@@ -7928,7 +7928,7 @@ dependencies = [
 
 [[package]]
 name = "orb-speed-test"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -8281,7 +8281,7 @@ dependencies = [
 
 [[package]]
 name = "orb-zbus-proxies-cli"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/jwk-util/Cargo.toml
+++ b/jwk-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-jwk-util"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
 description = "CLI utility for manipulating Json Web Keys"
 publish = false

--- a/orb-backend-status/Cargo.toml
+++ b/orb-backend-status/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-backend-status"
-version = "0.0.0"
+version = "0.0.1"
 description = "Systemd service that receives orb status and periodicallyprovides it to the Orb backend"
 authors = ["Paul Quinn <paulquinn00@users.noreply.github.com>"]
 publish = false

--- a/orb-jobs-agent/Cargo.toml
+++ b/orb-jobs-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-jobs-agent"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Paul Quinn <paulquinn00@users.noreply.github.com>"]
 description = "Worldcoin Jobs Agent"
 publish = false

--- a/ota-backend/Cargo.toml
+++ b/ota-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-ota-backend"
-version = "0.0.0"
+version = "0.0.1"
 description = "Internal tooling for OTAs"
 authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
 publish = false

--- a/se050-reprovision/Cargo.toml
+++ b/se050-reprovision/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-se050-reprovision"
-version = "0.0.0"
+version = "0.0.1"
 description = "Oneshot service that reprovisions the SE050 secure element"
 authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
 publish = false

--- a/se050/Cargo.toml
+++ b/se050/Cargo.toml
@@ -2,7 +2,7 @@
 name = "orb-se050"
 description = "se050 utilities"
 authors = ["Ryan Butler <thebutlah@users.noreply.github.com>"]
-version = "0.0.0"
+version = "0.0.1"
 publish = false
 
 edition.workspace = true

--- a/speed-test/Cargo.toml
+++ b/speed-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-speed-test"
-version = "0.0.0"
+version = "0.0.1"
 authors = ["Popov Philipp <filipp.popov@toolsforhumanity.com>"]
 description = "Network speed test utility for Orb"
 publish = false

--- a/zbus-proxies/cli/Cargo.toml
+++ b/zbus-proxies/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orb-zbus-proxies-cli"
-version = "0.0.0"
+version = "0.0.1"
 description = "CLI tool to generate zbus proxies for third party services"
 publish = false
 


### PR DESCRIPTION
This commit is a prepartion for adding Android build. Android packaging
system uses 'package.version' and it does not work if version is 0.0.0.
