### PR TITLE
refactor: add macro to use cmd() more conviently

### DIFF
--- a/xtask/src/cmd/build.rs
+++ b/xtask/src/cmd/build.rs
@@ -1,4 +1,4 @@
-use crate::cmd::cmd;
+use crate::cmd::{args, cmd};
 use clap::Args as ClapArgs;
 use color_eyre::Result;
 
@@ -12,14 +12,14 @@ pub struct Args {
 pub fn run(args: Args) -> Result<()> {
     let Args { pkg, target } = args;
 
-    cmd(&[
+    cmd(&args![
         "cargo",
         "zigbuild",
         "--target",
-        target.as_str(),
+        &target,
         "--release",
         "-p",
-        pkg.as_str(),
+        &pkg,
     ])?;
 
     Ok(())

--- a/xtask/src/cmd/deb.rs
+++ b/xtask/src/cmd/deb.rs
@@ -1,5 +1,5 @@
 use super::build;
-use crate::cmd::cmd;
+use crate::cmd::{args, cmd};
 use clap::Args as ClapArgs;
 use color_eyre::Result;
 
@@ -19,17 +19,17 @@ pub fn run(args: Args) -> Result<()> {
     })?;
 
     let path = format!("./target/deb/{pkg}.deb");
-    cmd(&[
+    cmd(&args![
         "cargo",
         "deb",
         "--no-build",
         "--no-strip",
         "-p",
-        pkg.as_str(),
+        &pkg,
         "--target",
-        target.as_str(),
+        &target,
         "-o",
-        path.as_str(),
+        &path,
     ])?;
     println!("\n{pkg} successfully packaged at {path}");
 

--- a/xtask/src/cmd/deploy.rs
+++ b/xtask/src/cmd/deploy.rs
@@ -1,6 +1,5 @@
 use super::build;
-use crate::cmd::cmd;
-use crate::cmd::deb;
+use crate::cmd::{args, cmd, deb};
 use cargo_metadata::MetadataCommand;
 use clap::Args as ClapArgs;
 use color_eyre::{eyre::eyre, Result};
@@ -53,35 +52,35 @@ fn deploy_deb(pkg: String) -> Result<()> {
     let remote_deb = format!("./{pkg}.deb");
 
     println!("\ncopying .deb file to orb");
-    cmd(&[
+    cmd(&args![
         "sshpass",
         "-p",
-        worldcoin_pw.as_str(),
+        &worldcoin_pw,
         "scp",
         "-o",
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        deb_path.as_str(),
-        scp_target.as_str(),
+        &deb_path,
+        &scp_target,
     ])?;
 
     println!("installing .deb pkg on orb\n");
-    cmd(&[
+    cmd(&args![
         "sshpass",
         "-p",
-        worldcoin_pw.as_str(),
+        &worldcoin_pw,
         "ssh",
         "-o",
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        host.as_str(),
+        &host,
         "sudo",
         "apt",
         "install",
         "--reinstall",
-        remote_deb.as_str(),
+        &remote_deb,
         "-y",
     ])?;
 
@@ -103,14 +102,14 @@ fn deploy_bin(pkg: String) -> Result<()> {
 
     let bin = get_crate_binary_name(&pkg)?;
 
-    cmd(&[
+    cmd(&args![
         "cargo",
         "zigbuild",
         "--target",
         target,
         "--release",
         "-p",
-        pkg.as_str(),
+        &pkg,
     ])?;
 
     let bin_path = format!("./target/{target}/release/{bin}");
@@ -120,36 +119,36 @@ fn deploy_bin(pkg: String) -> Result<()> {
     let install_target = format!("/usr/local/bin/{bin}");
 
     println!("\ncopying binary to orb");
-    cmd(&[
+    cmd(&args![
         "sshpass",
         "-p",
-        worldcoin_pw.as_str(),
+        &worldcoin_pw,
         "scp",
         "-o",
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        bin_path.as_str(),
-        scp_target.as_str(),
+        &bin_path,
+        &scp_target,
     ])?;
 
     println!("installing binary to /usr/local/bin on orb\n");
-    cmd(&[
+    cmd(&args![
         "sshpass",
         "-p",
-        worldcoin_pw.as_str(),
+        &worldcoin_pw,
         "ssh",
         "-o",
         "StrictHostKeyChecking=no",
         "-o",
         "UserKnownHostsFile=/dev/null",
-        host.as_str(),
+        &host,
         "sudo",
         "install",
         "-m",
         "0755",
-        remote_bin.as_str(),
-        install_target.as_str(),
+        &remote_bin,
+        &install_target,
     ])?;
 
     restart_services(&worldcoin_pw, &host, services)?;
@@ -164,7 +163,7 @@ fn restart_services(
 ) -> Result<()> {
     for service in services {
         println!("\nrestarting service {service} on orb\n");
-        cmd(&[
+        cmd(&args![
             "sshpass",
             "-p",
             worldcoin_pw,
@@ -177,7 +176,7 @@ fn restart_services(
             "sudo",
             "systemctl",
             "restart",
-            service.as_str(),
+            &service,
         ])?;
     }
 

--- a/xtask/src/cmd/mod.rs
+++ b/xtask/src/cmd/mod.rs
@@ -5,14 +5,35 @@ pub mod pre_commit;
 pub mod test;
 pub mod test_watch;
 
+use std::ffi::OsStr;
 use std::process::{Command, Stdio};
 
 use color_eyre::{eyre::eyre, Result};
 
-pub(crate) fn cmd(args: &[&str]) -> Result<()> {
+/// Builds a `[&OsStr; N]` from a mix of `&str`/`&String`/`&Path`/`&PathBuf`
+/// arguments - so a `cmd(&args![...])` call site can freely mix string
+/// literals and paths in one argument list.
+macro_rules! args {
+    ($($arg:expr),+ $(,)?) => {
+        [$(::std::convert::AsRef::<::std::ffi::OsStr>::as_ref($arg)),+]
+    };
+}
+pub(crate) use args;
+
+fn new_command<S: AsRef<OsStr>>(args: &[S]) -> Result<Command> {
     let (program, rest) = args.split_first().ok_or_else(|| eyre!("empty cmd"))?;
     let mut command = Command::new(program);
     command.args(rest);
+    // Force a consistent, unlocalized locale, so callers that pattern-match
+    // on a command's output text (e.g. android.rs's adb error checks)
+    // aren't broken by a localized message on some other machine.
+    command.env("LC_ALL", "C");
+
+    Ok(command)
+}
+
+pub(crate) fn cmd<S: AsRef<OsStr>>(args: &[S]) -> Result<()> {
+    let mut command = new_command(args)?;
     command
         .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -20,8 +41,23 @@ pub(crate) fn cmd(args: &[&str]) -> Result<()> {
 
     let status = command.status()?;
     if !status.success() {
-        return Err(eyre!("{program} exited with {status}"));
+        let program = command.get_program();
+        return Err(eyre!("{} exited with {status}", program.display()));
     }
 
     Ok(())
+}
+
+/// Like [`cmd`], but captures stdout/stderr instead of streaming them live -
+/// for callers running several of these concurrently (where interleaved
+/// output from independent processes would otherwise be unreadable), or
+/// that need to inspect *why* a command failed instead of just that it
+/// did. Returns [`std::process::Output`] as-is, regardless of exit status.
+#[allow(dead_code)]
+pub(crate) fn cmd_captured<S: AsRef<OsStr>>(
+    args: &[S],
+) -> Result<std::process::Output> {
+    let mut command = new_command(args)?;
+
+    Ok(command.output()?)
 }


### PR DESCRIPTION
cmd() accepts only '&str', but sometimes we want to pass a String or Path and we need to convert them in &str. That is not convenient. Create a macro to convert various types (&str, Path, PathBuf) into &OsStr and feed that in Command.

Example:

```
// before
cmd(&["cargo", "zigbuild", "--target", target.as_str(), "--release", "-p", pkg.as_str()])?;

// after
cmd(&args!["cargo", "zigbuild", "--target", &target, "--release", "-p", &pkg])?;
```