### PR TITLE
feat: add a command to check if the crate is supported

### DIFF
--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -152,11 +152,18 @@ jobs:
 
       - name: Configure cargo to exclude platform-specific crates
         run: |
-          tmp=($(ci/rust_ci_helper.py excludes))
+          crates="$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[].name')"
           EXCLUDES=""
-          for e in ${tmp[@]}; do
-            EXCLUDES+="--exclude ${e} "
-          done
+          while IFS= read -r c; do
+            status=0
+            cargo x crate-supported "$c" >/dev/null || status=$?
+            if [[ $status -eq 1 ]]; then
+              EXCLUDES+="--exclude ${c} "
+            elif [[ $status -ne 0 ]]; then
+              echo "cargo x crate-supported failed unexpectedly for '${c}' (exit ${status})" >&2
+              exit 1
+            fi
+          done <<<"$crates"
           echo EXCLUDES="${EXCLUDES}" >>${GITHUB_ENV}
           cat ${GITHUB_ENV}
       - name: Cargo Nextest

--- a/ci/rust_ci_helper.py
+++ b/ci/rust_ci_helper.py
@@ -69,20 +69,6 @@ def find_flavored_crates(*, workspace_crates):
     return {n: p for n, p in workspace_crates.items() if predicate(p)}
 
 
-def find_unsupported_platform_crates(*, host_platform, workspace_crates):
-    def predicate(package):
-        unsupported_targets = (
-            (package.get("metadata") or {})
-            .get("orb", {})
-            .get("unsupported_targets", {})
-        )
-        if not unsupported_targets:
-            return False
-        return host_platform in unsupported_targets
-
-    return {n: p for n, p in workspace_crates.items() if predicate(p)}
-
-
 def workspace_crates():
     command = "cargo metadata --format-version=1 --no-deps --frozen --offline"
     cmd_output = run_with_stdout(command)
@@ -93,14 +79,6 @@ def workspace_crates():
     result = {p["name"]: p for p in tmp}
     assert len(tmp) == len(result)  # sanity check
     return result
-
-
-def get_target_triple():
-    cmd_output = run_with_stdout("rustc -vV").strip().split("\n")
-    for s in cmd_output:
-        if s.startswith("host:"):
-            return s.split(" ")[1]
-    raise Exception("no target triple detected")
 
 
 def build_crate_with_features(*, cargo_profile, targets, features):
@@ -217,11 +195,6 @@ def main():
     )
     build.set_defaults(entry_point=subcmd_build_linux_artifacts)
 
-    excludes = subparsers.add_parser(
-        "excludes", description="Detects crates that should be excluded when building"
-    )
-    excludes.set_defaults(entry_point=subcmd_excludes)
-
     args = parser.parse_args()
     args.entry_point(args)
 
@@ -293,16 +266,6 @@ def subcmd_build_linux_artifacts(args):
                 crate=crate,
                 flavor=flavor_name,
             )
-
-
-def subcmd_excludes(args):
-    """entry point for `excludes` subcommand"""
-    wksp_crates = workspace_crates()
-    host = get_target_triple()
-    excludes = find_unsupported_platform_crates(
-        host_platform=host, workspace_crates=wksp_crates
-    )
-    stdout(" ".join(sorted([c for c in excludes])))
 
 
 if __name__ == "__main__":

--- a/xtask/build.rs
+++ b/xtask/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    let host = std::env::var("HOST").expect("cargo always sets HOST for build scripts");
+    println!("cargo:rustc-env=HOST_TRIPLE={host}");
+}

--- a/xtask/src/cmd/mod.rs
+++ b/xtask/src/cmd/mod.rs
@@ -2,6 +2,7 @@ pub mod build;
 pub mod deb;
 pub mod deploy;
 pub mod pre_commit;
+pub mod target;
 pub mod test;
 pub mod test_watch;
 

--- a/xtask/src/cmd/target.rs
+++ b/xtask/src/cmd/target.rs
@@ -1,0 +1,63 @@
+use cargo_metadata::{Metadata, MetadataCommand};
+use clap::Args as ClapArgs;
+use color_eyre::{eyre::eyre, Result};
+use std::collections::BTreeSet;
+
+/// Names of workspace packages whose `[package.metadata.orb]
+/// unsupported_targets` lists `target` (same mechanism
+/// `ci/rust_ci_helper.py` uses for its Darwin exclusions). A `BTreeSet` so
+/// callers get both a fast `.contains()` and a deterministic, sorted
+/// iteration order for printing.
+pub fn unsupported_packages(md: &Metadata, target: &str) -> BTreeSet<String> {
+    md.workspace_packages()
+        .into_iter()
+        .filter(|pkg| {
+            pkg.metadata
+                .get("orb")
+                .and_then(|orb| orb.get("unsupported_targets"))
+                .and_then(|targets| targets.as_array())
+                .is_some_and(|targets| {
+                    targets.iter().any(|t| t.as_str() == Some(target))
+                })
+        })
+        .map(|pkg| pkg.name.as_str().to_owned())
+        .collect()
+}
+
+#[derive(ClapArgs, Debug)]
+pub struct SupportedArgs {
+    /// Crate to check.
+    pub pkg: String,
+    /// Target triple to check support for, e.g. `aarch64-linux-android`.
+    #[arg(long)]
+    pub target: String,
+}
+
+/// Whether `pkg` is excluded for `target` via `[package.metadata.orb]
+/// unsupported_targets`. Pure metadata inspection: doesn't build or package
+/// anything, so it's cheap enough for callers to use as an up-front branch
+/// instead of parsing a build's error output.
+///
+/// `Ok(true)`: is a workspace member and isn't excluded for `target`.
+/// `Ok(false)`: is a workspace member, but is explicitly excluded for
+/// `target` via `unsupported_targets`.
+/// `Err(..)`: no workspace member by that name (or `cargo metadata` failed).
+fn check_support(md: &Metadata, pkg: &str, target: &str) -> Result<bool> {
+    let is_member = md
+        .workspace_packages()
+        .into_iter()
+        .any(|p| p.name.as_str() == pkg);
+    if !is_member {
+        return Err(eyre!("`{pkg}` is not a workspace member"));
+    }
+
+    Ok(!unsupported_packages(md, target).contains(pkg))
+}
+
+/// Runs [`check_support`] against live `cargo metadata`.
+pub fn run_supported(args: SupportedArgs) -> Result<bool> {
+    let SupportedArgs { pkg, target } = args;
+    let md = MetadataCommand::new().no_deps().exec()?;
+
+    check_support(&md, &pkg, &target)
+}

--- a/xtask/src/cmd/target.rs
+++ b/xtask/src/cmd/target.rs
@@ -4,10 +4,9 @@ use color_eyre::{eyre::eyre, Result};
 use std::collections::BTreeSet;
 
 /// Names of workspace packages whose `[package.metadata.orb]
-/// unsupported_targets` lists `target` (same mechanism
-/// `ci/rust_ci_helper.py` uses for its Darwin exclusions). A `BTreeSet` so
-/// callers get both a fast `.contains()` and a deterministic, sorted
-/// iteration order for printing.
+/// unsupported_targets` lists `target`. A `BTreeSet` so callers get both a
+/// fast `.contains()` and a deterministic, sorted iteration order for
+/// printing.
 pub fn unsupported_packages(md: &Metadata, target: &str) -> BTreeSet<String> {
     md.workspace_packages()
         .into_iter()
@@ -29,7 +28,9 @@ pub struct SupportedArgs {
     /// Crate to check.
     pub pkg: String,
     /// Target triple to check support for, e.g. `aarch64-linux-android`.
-    #[arg(long)]
+    /// Defaults to the host triple, baked in at compile time by `build.rs`
+    /// from cargo's `HOST` env var.
+    #[arg(long, default_value = env!("HOST_TRIPLE"))]
     pub target: String,
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use color_eyre::Result;
-use x::cmd::{build, deb, deploy, pre_commit, test, test_watch};
+use x::cmd::{build, deb, deploy, pre_commit, target, test, test_watch};
 
 #[derive(Parser, Debug)]
 pub struct Cli {
@@ -13,6 +13,9 @@ enum Cmd {
     /// Build the select crate using `cargo zigbuild --release`. alias: 'b'
     #[command(alias = "b")]
     Build(build::Args),
+    /// Checks whether a crate is excluded via `[package.metadata.orb].unsupported_targets`.
+    /// Exit code: 0 = supported, 1 = unsupported, 2 = no such crate (or other error).
+    CrateSupported(target::SupportedArgs),
     /// Build the select crate using `cargo zigbuild --release`, then package it into a `.deb` using
     /// `cargo deb`
     Deb(deb::Args),
@@ -40,6 +43,20 @@ fn main() -> Result<()> {
 
     match cmd {
         Cmd::Build(args) => build::run(args),
+        Cmd::CrateSupported(args) => {
+            let (pkg, tgt) = (args.pkg.clone(), args.target.clone());
+            match target::run_supported(args) {
+                Ok(true) => Ok(()),
+                Ok(false) => {
+                    eprintln!("`{pkg}` is marked unsupported for {tgt}");
+                    std::process::exit(1);
+                }
+                Err(e) => {
+                    eprintln!("{e}");
+                    std::process::exit(2);
+                }
+            }
+        }
         Cmd::Deb(args) => deb::run(args),
         Cmd::PreCommit => pre_commit::run(),
         Cmd::Deploy(args) => deploy::run(args),


### PR DESCRIPTION
Not all crates build on all architectures(targets), some crates specify `[package.metadata.orb] unsupported_target` in Cargo.toml . To check if a crate is supported on a specific target, add a command `cargo x crate-supported`