### PR TITLE
fix(ci): add explicit least-privilege permissions to workflows missing them

### DIFF
--- a/.github/workflows/delete-tmp-release.yaml
+++ b/.github/workflows/delete-tmp-release.yaml
@@ -1,4 +1,8 @@
 name: Delete Expired Releases
+
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   workflow_call:

--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -1,4 +1,9 @@
 name: Nix CI
+
+permissions:
+  contents: read
+  actions: read
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -1,4 +1,8 @@
 name: Python CI
+
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,10 @@ on:
           - artifact
         default: artifact
 
+permissions:
+  contents: read
+  actions: read
+
 env:
   CRATE: ${{ inputs.crate }}
   BUILD_AARCH64: ${{ inputs.build_aarch64 }}
@@ -207,6 +211,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
     needs:
       - release-name
       - test

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -1,4 +1,9 @@
 name: Rust CI
+
+permissions:
+  contents: read
+  actions: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Github actions complain about permission, this PR fixes the security warning.

## Workflow does not contain permissions

If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.