### PR TITLE
refactor: simplify OrbStatusApiV2 structure

### DIFF
--- a/oes/README.md
+++ b/oes/README.md
@@ -63,7 +63,7 @@ the same `OrbStatusApiV2` schema, but only the `oes` field is populated:
 ```rust
 struct OrbStatusApiV2 {
     oes_cached: bool, // true only whenever cached events are sent (every 30s)
-    oes: Option<Vec<Event>>,
+    oes: Vec<Event>,
     // ... all other fields omitted (all Optional) ...
 }
 

--- a/orb-backend-status/src/backend/status_req_builder.rs
+++ b/orb-backend-status/src/backend/status_req_builder.rs
@@ -176,7 +176,7 @@ impl CurrentStatus {
                     .collect()
             }),
             main_mcu: build_main_mcu_api(self),
-            oes: None,
+            oes: vec![],
             oes_cached: false,
             orb_stand_qr_id: self
                 .core_stats

--- a/orb-backend-status/src/backend/status_req_builder.rs
+++ b/orb-backend-status/src/backend/status_req_builder.rs
@@ -161,20 +161,19 @@ impl CurrentStatus {
                     })
                     .collect(),
             }),
-            hardware_states: self.hardware_states.as_ref().map(|states| {
-                states
-                    .iter()
-                    .map(|(k, v)| {
-                        (
-                            k.clone(),
-                            HardwareStateApiV2 {
-                                status: v.status.clone(),
-                                message: v.message.clone(),
-                            },
-                        )
-                    })
-                    .collect()
-            }),
+            hardware_states: self
+                .hardware_states
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        HardwareStateApiV2 {
+                            status: v.status.clone(),
+                            message: v.message.clone(),
+                        },
+                    )
+                })
+                .collect(),
             main_mcu: build_main_mcu_api(self),
             oes: vec![],
             oes_cached: false,

--- a/orb-backend-status/src/backend/types.rs
+++ b/orb-backend-status/src/backend/types.rs
@@ -27,8 +27,8 @@ pub struct OrbStatusApiV2 {
     // state events
     pub signup_state: Option<String>,
     // hardware states from zenoh
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hardware_states: Option<HashMap<String, HardwareStateApiV2>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub hardware_states: HashMap<String, HardwareStateApiV2>,
     // main mcu telemetry from zenoh
     #[serde(skip_serializing_if = "Option::is_none")]
     pub main_mcu: Option<MainMcuApiV2>,

--- a/orb-backend-status/src/backend/types.rs
+++ b/orb-backend-status/src/backend/types.rs
@@ -33,8 +33,8 @@ pub struct OrbStatusApiV2 {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub main_mcu: Option<MainMcuApiV2>,
     // orb event stream
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub oes: Option<Vec<Event>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub oes: Vec<Event>,
     pub oes_cached: bool,
     pub orb_stand_qr_id: Option<String>,
     pub orb_stand_qr_type: Option<String>,

--- a/orb-backend-status/src/dbus/intf_impl.rs
+++ b/orb-backend-status/src/dbus/intf_impl.rs
@@ -38,7 +38,7 @@ pub struct CurrentStatus {
     pub core_stats: Option<CoreStats>,
     pub signup_state: Option<SignupState>,
     pub connd_report: Option<ConndReport>,
-    pub hardware_states: Option<HashMap<String, HardwareState>>,
+    pub hardware_states: HashMap<String, HardwareState>,
     pub front_als: Option<AmbientLight>,
 }
 
@@ -219,11 +219,7 @@ impl BackendStatusImpl {
         let Ok(mut current_status) = self.current_status.lock() else {
             return;
         };
-        if states.is_empty() {
-            current_status.hardware_states = None;
-        } else {
-            current_status.hardware_states = Some(states);
-        }
+        current_status.hardware_states = states;
     }
 
     /// Update front ALS (Ambient Light Sensor) data from zenoh.

--- a/orb-backend-status/src/orb_event_stream/flusher.rs
+++ b/orb-backend-status/src/orb_event_stream/flusher.rs
@@ -92,7 +92,7 @@ async fn maybe_flush(client: &StatusClient, buffer: &mut Vec<Event>) {
 
 async fn flush_events(client: &StatusClient, events: &[Event]) -> eyre::Result<bool> {
     let req = OrbStatusApiV2 {
-        oes: Some(events.to_vec()),
+        oes: events.to_vec(),
         ..Default::default()
     };
 

--- a/orb-backend-status/src/sender.rs
+++ b/orb-backend-status/src/sender.rs
@@ -26,7 +26,7 @@ impl BackendSender {
     pub async fn send_snapshot(&self, snapshot: &CurrentStatus) -> Result<bool> {
         let mut req = snapshot.to_orb_status_api_v2_req().await;
         req.oes_cached = true;
-        req.oes = Some(self.oes.cached()?);
+        req.oes = self.oes.cached()?;
 
         let res = match self.client.req(req).await {
             Err(client::Err::MissingAttestToken | client::Err::NoConnectivity) => {


### PR DESCRIPTION
The outer `Option` is not necessary, if vector of events is empty, that is the same as `oes == None`.