### PR TITLE
fix(hil): the access to crates.io

### DIFF
--- a/nix/machines/hil-common.nix
+++ b/nix/machines/hil-common.nix
@@ -174,6 +174,10 @@ in
     # networking.proxy.default = "http://user:password@proxy:port/";
     # networking.proxy.noProxy = "127.0.0.1,localhost,internal.domain";
 
+    # crates.io blocks the default curl User-Agent used by fetchurl.
+    environment.variables.NIX_CURL_FLAGS = "--user-agent orb-software-nix-fetcher";
+    systemd.services.nix-daemon.environment.NIX_CURL_FLAGS = "--user-agent orb-software-nix-fetcher";
+
     # Enable networking
     networking.networkmanager.enable = true;
     networking.networkmanager.ensureProfiles.profiles = lib.attrsets.mergeAttrsList [


### PR DESCRIPTION
some crates like qdl-rs aren't accessible without the trick