### PR TITLE
fix(attest): retry migrated key selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7153,7 +7153,6 @@ dependencies = [
  "url",
  "wiremock",
  "zbus",
- "zbus_systemd",
  "zenorb",
 ]
 

--- a/attest/Cargo.toml
+++ b/attest/Cargo.toml
@@ -40,7 +40,6 @@ tracing.workspace = true
 url = "2.2"
 zbus.workspace = true
 zenorb.workspace = true
-zbus_systemd = { workspace = true, features = ["systemd1"], optional = true }
 tempfile = "3.3"
 
 [build-dependencies]
@@ -57,4 +56,4 @@ systemd-units = [{ unit-name = "worldcoin-attest" }]
 
 [features]
 default = ["se050_key_migration"]
-se050_key_migration = ["dep:zbus_systemd"]
+se050_key_migration = []

--- a/attest/Cargo.toml
+++ b/attest/Cargo.toml
@@ -22,7 +22,7 @@ orb-build-info.workspace = true
 orb-const-concat.workspace = true
 orb-dogd.workspace = true
 orb-endpoints.workspace = true
-orb-info = { workspace = true, features = ["async", "orb-id"] }
+orb-info = { workspace = true, features = ["async", "orb-id", "orb-os-release"] }
 orb-security-utils = { workspace = true, features = ["reqwest"] }
 orb-telemetry.workspace = true
 prelude = { workspace = true, features = ["connectivity"] }

--- a/attest/src/lib.rs
+++ b/attest/src/lib.rs
@@ -11,7 +11,10 @@ use eyre::{self, bail, WrapErr};
 use futures::{FutureExt, StreamExt};
 use orb_build_info::{make_build_info, BuildInfo};
 use orb_dogd::{DogstatsdClient, MetricEmitter};
-use orb_info::OrbId;
+use orb_info::{
+    orb_os_release::{OrbOsPlatform, OrbOsRelease},
+    OrbId,
+};
 use prelude::connectivity::tracker::ConnectivityTracker;
 use secrecy::ExposeSecret;
 use std::default::Default;
@@ -37,6 +40,10 @@ pub async fn main() -> eyre::Result<()> {
     info!("Version: {}", BUILD_INFO.version);
 
     let orb_id = OrbId::read().await?;
+    let platform = OrbOsRelease::read()
+        .await
+        .wrap_err("failed to determine Orb platform")?
+        .orb_os_platform_type;
     let config = config::Config::new(config::default_backend(), orb_id.as_str());
 
     let force_refresh_token = Arc::new(Notify::new());
@@ -45,14 +52,18 @@ pub async fn main() -> eyre::Result<()> {
         .await
         .wrap_err("Initialization failed")?;
 
-    // Determine which SE050 key set is active before starting the token loop.
-    let new_keys_active = startup_key_selection(
-        orb_id.as_str(),
-        &config.auth_url,
-        &config.keys_challenge_url,
-        &config.keys_proof_url,
-    )
-    .await;
+    // SE050 key migration is Diamond-only; Pearl uses legacy keys.
+    let new_keys_active = if platform == OrbOsPlatform::Pearl {
+        false
+    } else {
+        startup_key_selection(
+            orb_id.as_str(),
+            &config.auth_url,
+            &config.keys_challenge_url,
+            &config.keys_proof_url,
+        )
+        .await
+    };
 
     if new_keys_active {
         info!("using {MIGRATED_IRIS_CODE_PUBKEY} as a signup key");

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -354,6 +354,29 @@ impl Challenge {
         })
     }
 
+    fn sign_with_recovery(&self, binary: &str) -> Result<Signature, SignError> {
+        let result = match self.sign_with_binary(binary) {
+            Err(SignError::NotProvisioned) => {
+                info!(binary, "SE050 is not provisioned, attempting recovery");
+                if let Err(error) = recover_se050_pub_key() {
+                    error!(%error, binary, "failed to recover SE050 keys");
+                    Err(SignError::NotProvisioned)
+                } else {
+                    info!(binary, "recovered SE050 keys, retrying signing");
+                    self.sign_with_binary(binary)
+                }
+            }
+            result => result,
+        };
+        handle_security_mcu_sign_result(&result);
+        result
+    }
+
+    #[tracing::instrument]
+    fn sign_with_migrated_key(&self) -> Result<Signature, SignError> {
+        self.sign_with_recovery("orb-sign-attestation-migrated")
+    }
+
     /// Try to sign the challenge using SE050. Could fail for multiple reasons,
     /// it is probably a good idea to retry signing.
     ///
@@ -361,17 +384,7 @@ impl Challenge {
     /// powercycle to recover the stuck SE050.
     #[tracing::instrument]
     pub fn sign(&self) -> Result<Signature, SignError> {
-        let result = self.sign_with_binary("orb-sign-attestation");
-        if matches!(&result, Err(SignError::NotProvisioned)) {
-            info!("SE050 is not provisioned, retry to recover it");
-            if let Err(error) = recover_se050_pub_key() {
-                error!(%error, "failed to recover SE050 keys");
-            } else {
-                info!("recovered SE050 keys");
-            }
-        }
-        handle_security_mcu_sign_result(&result);
-        result
+        self.sign_with_recovery("orb-sign-attestation")
     }
 }
 
@@ -760,25 +773,6 @@ struct ProofPayload {
     signature: String,
 }
 
-fn sign_with_migrated_key(challenge: &Challenge) -> Result<Signature, SignError> {
-    let result = match challenge.sign_with_binary("orb-sign-attestation-migrated") {
-        Err(SignError::NotProvisioned) => {
-            info!("SE050 is not provisioned, attempting recovery");
-
-            if let Err(error) = recover_se050_pub_key() {
-                error!(%error, "failed to recover SE050 keys");
-                Err(SignError::NotProvisioned)
-            } else {
-                info!("recovered SE050 keys, retrying signing");
-                challenge.sign_with_binary("orb-sign-attestation-migrated")
-            }
-        }
-        result => result,
-    };
-    handle_security_mcu_sign_result(&result);
-    result
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MigratedKeyProbe {
     Accepted,
@@ -877,7 +871,7 @@ async fn migrated_key_token_once(
             }
 
             let challenge = challenge.clone();
-            tokio::task::spawn_blocking(move || sign_with_migrated_key(&challenge))
+            tokio::task::spawn_blocking(move || challenge.sign_with_migrated_key())
                 .await
                 .map_err(RefreshTokenError::JoinError)?
                 .map_err(RefreshTokenError::SignError)

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -1012,28 +1012,89 @@ pub async fn submit_proof(
 
 #[cfg(test)]
 mod test {
+    use std::ffi::OsString;
     use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use crate::client;
 
     use super::{
-        AttestedKeysForSigning, ChallengeError, KeyInfoForSigning, RefreshTokenError,
-        SignError, MAX_TOKEN_DELAY, MIN_TOKEN_DELAY,
+        try_token_with_migrated_key, AttestedKeysForSigning, ChallengeError,
+        KeyInfoForSigning, RefreshTokenError, SignError, MAX_TOKEN_DELAY,
+        MIN_TOKEN_DELAY,
     };
     use data_encoding::BASE64;
     use reqwest::StatusCode;
     use secrecy::ExposeSecret;
+    use serial_test::serial;
     use wiremock::{
         matchers::{method, path},
-        Mock, MockServer, ResponseTemplate,
+        Mock, MockServer, Request, ResponseTemplate,
     };
 
-    const MOCK_ORB_SIGN_ATTESTATION: &str = r#"#!/bin/sh
-printf dmFsaWRzaWduYXR1cmU=
-"#;
+    const MIGRATED_MOCK_SIGNATURE: &[u8] = b"migrated-signature";
+    const LEGACY_MOCK_SIGNATURE: &[u8] = b"legacy-signature";
+
+    struct MockSigner {
+        _temp_dir: tempfile::TempDir,
+        original_path: OsString,
+    }
+
+    impl Drop for MockSigner {
+        fn drop(&mut self) {
+            // SAFETY: tests that modify PATH are serialized with `#[serial]`.
+            unsafe {
+                std::env::set_var("PATH", &self.original_path);
+            }
+        }
+    }
+
+    fn install_mock_signer(binary_name: &str, signature: &[u8]) -> MockSigner {
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let script = temp_dir.path().join(binary_name);
+        let script_contents =
+            format!("#!/bin/sh\nprintf '%s' '{}'\n", BASE64.encode(signature));
+        std::fs::write(&script, script_contents).unwrap();
+        std::fs::set_permissions(script, std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+
+        let paths = std::iter::once(PathBuf::from(temp_dir.path()))
+            .chain(std::env::split_paths(&original_path));
+        let path = std::env::join_paths(paths).unwrap();
+        // SAFETY: tests that modify PATH are serialized with `#[serial]`.
+        unsafe {
+            std::env::set_var("PATH", path);
+        }
+
+        MockSigner {
+            _temp_dir: temp_dir,
+            original_path,
+        }
+    }
+
+    async fn mount_transport_failure_once(
+        mock_server: &MockServer,
+        endpoint: &'static str,
+        error_kind: std::io::ErrorKind,
+        error_message: &'static str,
+    ) {
+        Mock::given(method("POST"))
+            .and(path(endpoint))
+            .respond_with_err(move |_: &Request| {
+                std::io::Error::new(error_kind, error_message)
+            })
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(mock_server)
+            .await;
+    }
+
     // A happy path
     #[tokio::test]
+    #[serial]
     async fn get_token() {
         let _ = orb_telemetry::TelemetryConfig::new().init();
 
@@ -1085,20 +1146,8 @@ printf dmFsaWRzaWduYXR1cmU=
 
         let clone_of_challenge = challenge.clone();
 
-        // Create a mock signing script orb-sign-attestation that returns pre-defined challenge and
-        // add it to PATH
-        let mut path = std::env::var("PATH").unwrap();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let script = temp_dir.path().join("orb-sign-attestation");
-        std::fs::write(&script, MOCK_ORB_SIGN_ATTESTATION).unwrap();
-        std::fs::set_permissions(script, std::fs::Permissions::from_mode(0o755))
-            .unwrap();
-        path.push(':');
-        path.push_str(temp_dir.path().to_str().unwrap());
-        // TODO: Find a better way
-        unsafe {
-            std::env::set_var("PATH", path);
-        }
+        let _mock_signer =
+            install_mock_signer("orb-sign-attestation", LEGACY_MOCK_SIGNATURE);
 
         // 2. sign challenge
         let signature = tokio::task::spawn_blocking(move || clone_of_challenge.sign())
@@ -1122,6 +1171,148 @@ printf dmFsaWRzaWduYXR1cmU=
         .await
         .unwrap();
         assert_eq!(server_token, token.token.expose_secret());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn try_token_with_migrated_key_happy_path() {
+        let mock_server = MockServer::start().await;
+        let orb_id = "TEST_ORB";
+        let challenge =
+            "challenge_token_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tokenchallenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "challenge": BASE64.encode(challenge.as_ref()),
+                "duration": 3600,
+                "expiryTime": "is not used by client",
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "token": "token_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+                    "duration": 36000,
+                    "expiryTime": "is not used by client",
+                }),
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let auth_url = mock_server
+            .uri()
+            .parse::<url::Url>()
+            .unwrap()
+            .join("/api/v1/")
+            .unwrap();
+        let _mock_signer = install_mock_signer(
+            "orb-sign-attestation-migrated",
+            MIGRATED_MOCK_SIGNATURE,
+        );
+
+        assert!(try_token_with_migrated_key(orb_id, &auth_url).await);
+    }
+
+    /// Regression test for ORBS-1788.
+    ///
+    /// Transient transport failures while fetching the challenge or submitting
+    /// its migrated-key signature must not be interpreted as backend rejection.
+    /// This test is expected to fail until the migrated-key probe retries both
+    /// transport failures.
+    #[tokio::test]
+    #[serial]
+    async fn migrated_key_transport_failures_must_not_select_legacy_signer() {
+        let mock_server = MockServer::start().await;
+        let orb_id = "TEST_ORB";
+        let challenge =
+            "challenge_token_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+        let challenge_response = serde_json::json!({
+            "challenge": BASE64.encode(challenge.as_ref()),
+            "duration": 3600,
+            "expiryTime": "is not used by client",
+        });
+
+        mount_transport_failure_once(
+            &mock_server,
+            "/api/v1/tokenchallenge",
+            std::io::ErrorKind::ConnectionReset,
+            "simulated connection reset by peer",
+        )
+        .await;
+
+        // This response is consumed by the migrated-key retry once implemented.
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tokenchallenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(challenge_response))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let received_signature = Arc::new(Mutex::new(None::<String>));
+        let received_signature_for_server = Arc::clone(&received_signature);
+        mount_transport_failure_once(
+            &mock_server,
+            "/api/v1/token",
+            std::io::ErrorKind::ConnectionAborted,
+            "simulated connection aborted while submitting signed challenge",
+        )
+        .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/token"))
+            .respond_with(move |request: &Request| {
+                let body: serde_json::Value = request
+                    .body_json()
+                    .expect("token request must contain valid JSON");
+                *received_signature_for_server.lock().unwrap() = body
+                    .get("signature")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned);
+
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "token": "token_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+                    "duration": 36000,
+                    "expiryTime": "is not used by client",
+                }))
+            })
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let auth_url = mock_server
+            .uri()
+            .parse::<url::Url>()
+            .unwrap()
+            .join("/api/v1/")
+            .unwrap();
+        let _migrated_signer = install_mock_signer(
+            "orb-sign-attestation-migrated",
+            MIGRATED_MOCK_SIGNATURE,
+        );
+        let mut migrated_key_selected =
+            try_token_with_migrated_key(orb_id, &auth_url).await;
+
+        assert!(
+            migrated_key_selected,
+            "transient challenge/token transport failure selected legacy keys"
+        );
+
+        let received_signature = received_signature
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("backend did not receive a token request");
+        let expected_migrated_signature = BASE64.encode(MIGRATED_MOCK_SIGNATURE);
+        assert_eq!(
+            received_signature, expected_migrated_signature,
+            "backend did not receive the migrated-key signature"
+        );
     }
 
     #[test]

--- a/attest/src/remote_api.rs
+++ b/attest/src/remote_api.rs
@@ -211,6 +211,26 @@ fn recover_se050_pub_key() -> std::io::Result<()> {
     Ok(())
 }
 
+fn handle_security_mcu_sign_result(result: &Result<Signature, SignError>) {
+    match result {
+        Err(error) if error.requires_security_mcu_cooldown() => {
+            let mut failures = SIGNING_FAILURE_ERROR_COUNT.write().unwrap();
+            *failures += 1;
+            if *failures == SIGNING_FAILURE_ERROR_COUNT_THRESHOLD {
+                if let Err(error) = powercycle_security_mcu() {
+                    error!(%error, "failed to powercycle Security MCU");
+                } else {
+                    info!("powercycled Security MCU to reset stuck SE050");
+                }
+            }
+        }
+        Ok(_) => {
+            *SIGNING_FAILURE_ERROR_COUNT.write().unwrap() = Saturating(0);
+        }
+        _ => {}
+    }
+}
+
 #[serde_as]
 #[derive(Deserialize, Clone)]
 #[allow(dead_code)]
@@ -342,32 +362,15 @@ impl Challenge {
     #[tracing::instrument]
     pub fn sign(&self) -> Result<Signature, SignError> {
         let result = self.sign_with_binary("orb-sign-attestation");
-        match &result {
-            Err(SignError::NotProvisioned) => {
-                info!("SE050 is not provisioned, retry to recover it");
-                if let Err(err) = recover_se050_pub_key() {
-                    error!("Failed to recover SE050 keys: {err}")
-                } else {
-                    info!("Recovered SE050 keys");
-                }
+        if matches!(&result, Err(SignError::NotProvisioned)) {
+            info!("SE050 is not provisioned, retry to recover it");
+            if let Err(error) = recover_se050_pub_key() {
+                error!(%error, "failed to recover SE050 keys");
+            } else {
+                info!("recovered SE050 keys");
             }
-
-            Err(e) if e.requires_security_mcu_cooldown() => {
-                let mut lock = SIGNING_FAILURE_ERROR_COUNT.write().unwrap();
-                *lock += 1;
-                if *lock == SIGNING_FAILURE_ERROR_COUNT_THRESHOLD {
-                    if let Err(err) = powercycle_security_mcu() {
-                        error!("Failed to powercycle Security MCU: {err}")
-                    } else {
-                        info!("Powercycled Security MCU, trying to reset stuck se050.");
-                    }
-                }
-            }
-            Ok(_) => {
-                *SIGNING_FAILURE_ERROR_COUNT.write().unwrap() = Saturating(0);
-            }
-            _ => {}
         }
+        handle_security_mcu_sign_result(&result);
         result
     }
 }
@@ -758,81 +761,208 @@ struct ProofPayload {
 }
 
 fn sign_with_migrated_key(challenge: &Challenge) -> Result<Signature, SignError> {
-    match challenge.sign_with_binary("orb-sign-attestation-migrated") {
+    let result = match challenge.sign_with_binary("orb-sign-attestation-migrated") {
         Err(SignError::NotProvisioned) => {
             info!("SE050 is not provisioned, attempting recovery");
 
-            if let Err(err) = recover_se050_pub_key() {
-                error!("Failed to recover SE050 keys: {err}");
-                return Err(SignError::NotProvisioned);
+            if let Err(error) = recover_se050_pub_key() {
+                error!(%error, "failed to recover SE050 keys");
+                Err(SignError::NotProvisioned)
+            } else {
+                info!("recovered SE050 keys, retrying signing");
+                challenge.sign_with_binary("orb-sign-attestation-migrated")
             }
-
-            info!("Recovered SE050 keys, retrying signing");
-            challenge.sign_with_binary("orb-sign-attestation-migrated")
         }
         result => result,
+    };
+    handle_security_mcu_sign_result(&result);
+    result
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MigratedKeyProbe {
+    Accepted,
+    BackendRejected,
+    Inconclusive,
+}
+
+#[cfg(not(test))]
+const MIGRATED_KEY_RETRY_DELAY: time::Duration = MIN_TOKEN_DELAY;
+#[cfg(test)]
+const MIGRATED_KEY_RETRY_DELAY: time::Duration = time::Duration::ZERO;
+
+fn is_retryable_backend_status(status: reqwest::StatusCode) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            reqwest::StatusCode::REQUEST_TIMEOUT
+                | reqwest::StatusCode::TOO_EARLY
+                | reqwest::StatusCode::TOO_MANY_REQUESTS
+        )
+}
+
+fn is_backend_communication_error(error: &RefreshTokenError) -> bool {
+    match error {
+        RefreshTokenError::ChallengeError(
+            ChallengeError::PostFailed(_) | ChallengeError::JsonParseFailed(_),
+        )
+        | RefreshTokenError::ChallengeExpired
+        | RefreshTokenError::TokenError(
+            TokenError::PostFailed(_)
+            | TokenError::JsonParseFailed(_)
+            | TokenError::EmptyResponse,
+        ) => true,
+        RefreshTokenError::ChallengeError(ChallengeError::ServerReturnedError(
+            status,
+            _,
+        ))
+        | RefreshTokenError::TokenError(TokenError::ServerReturnedError(status, _))
+            if is_retryable_backend_status(*status) =>
+        {
+            true
+        }
+        _ => false,
     }
 }
 
-/// Verify that the **backend** accepts the migrated SE050 key set for token
-/// issuance by performing a full challenge → sign (migrated) → token
-/// round-trip.
+fn is_backend_rejection(error: &RefreshTokenError) -> bool {
+    matches!(
+        error,
+        RefreshTokenError::TokenError(TokenError::ServerReturnedError(
+            reqwest::StatusCode::FORBIDDEN,
+            _
+        ))
+    )
+}
+
+fn is_se050_communication_error(error: &RefreshTokenError) -> bool {
+    matches!(
+        error,
+        RefreshTokenError::SignError(error)
+            if error.requires_security_mcu_cooldown()
+    )
+}
+
+async fn wait_before_migrated_key_retry(
+    error: &RefreshTokenError,
+    failure_class: &'static str,
+    delay: time::Duration,
+) {
+    warn!(
+        failure_class,
+        retry_delay_seconds = delay.as_secs(),
+        error = %error,
+        "migrated key probe failed; retrying"
+    );
+    sleep(delay).await;
+}
+
+async fn migrated_key_token_once(
+    orb_id: &str,
+    tokenchallenge_url: &Url,
+    token_url: &Url,
+) -> Result<Token, RefreshTokenError> {
+    let client = client::create();
+    let challenge = Challenge::request(&client, orb_id, tokenchallenge_url)
+        .await
+        .map_err(RefreshTokenError::ChallengeError)?;
+
+    let signature = retry(
+        NUMBER_OF_SIGNINIG_RETRIES,
+        MIGRATED_KEY_RETRY_DELAY,
+        "sign challenge with migrated key",
+        || async {
+            if challenge.expired() {
+                return Err(RefreshTokenError::ChallengeExpired);
+            }
+
+            let challenge = challenge.clone();
+            tokio::task::spawn_blocking(move || sign_with_migrated_key(&challenge))
+                .await
+                .map_err(RefreshTokenError::JoinError)?
+                .map_err(RefreshTokenError::SignError)
+        },
+    )
+    .await?;
+
+    if challenge.expired() {
+        return Err(RefreshTokenError::ChallengeExpired);
+    }
+
+    Token::request(&client, token_url, orb_id, &challenge, &signature)
+        .await
+        .map_err(RefreshTokenError::TokenError)
+}
+
+/// Checks whether the backend accepts tokens signed with the migrated key.
 ///
-/// Returns `true` only if the backend returns a valid token. A `false` result
-/// may mean the backend hasn't registered the migrated key yet (proof not yet
-/// submitted or not yet processed), or that the SE050 hardware doesn't have
-/// the migrated key at all.
-///
-/// Does NOT update `SIGNING_FAILURE_ERROR_COUNT` or trigger an MCU powercycle.
+/// Communication failures are retried until the probe reaches the backend.
 #[tracing::instrument]
-pub async fn try_token_with_migrated_key(orb_id: &str, auth_url: &Url) -> bool {
+pub(crate) async fn try_token_with_migrated_key(
+    orb_id: &str,
+    auth_url: &Url,
+) -> MigratedKeyProbe {
     let tokenchallenge_url = match auth_url.join("tokenchallenge") {
-        Ok(u) => u,
-        Err(e) => {
-            warn!("migrated key probe: failed to build challenge URL: {e}");
-            return false;
+        Ok(url) => url,
+        Err(error) => {
+            warn!(%error, "migrated key probe failed to build challenge URL");
+            return MigratedKeyProbe::Inconclusive;
         }
     };
     let token_url = match auth_url.join("token") {
-        Ok(u) => u,
-        Err(e) => {
-            warn!("migrated key probe: failed to build token URL: {e}");
-            return false;
+        Ok(url) => url,
+        Err(error) => {
+            warn!(%error, "migrated key probe failed to build token URL");
+            return MigratedKeyProbe::Inconclusive;
         }
     };
 
-    let client = client::create();
-    let challenge = match Challenge::request(&client, orb_id, &tokenchallenge_url).await
-    {
-        Ok(c) => c,
-        Err(e) => {
-            warn!("migrated key probe: challenge request failed: {e}");
-            return false;
-        }
-    };
+    let mut inconclusive_attempt = 0;
+    let mut retry_delay = MIGRATED_KEY_RETRY_DELAY;
 
-    let challenge_clone = challenge.clone();
-    let sig = match tokio::task::spawn_blocking(move || {
-        sign_with_migrated_key(&challenge_clone)
-    })
-    .await
-    {
-        Ok(Ok(sig)) => sig,
-        Ok(Err(e)) => {
-            warn!("migrated key probe: signing failed: {e}");
-            return false;
-        }
-        Err(e) => {
-            warn!("migrated key probe: spawn_blocking panicked: {e}");
-            return false;
-        }
-    };
+    loop {
+        match migrated_key_token_once(orb_id, &tokenchallenge_url, &token_url).await {
+            Ok(_) => return MigratedKeyProbe::Accepted,
+            Err(error) => {
+                if is_backend_rejection(&error) {
+                    return MigratedKeyProbe::BackendRejected;
+                }
 
-    match Token::request(&client, &token_url, orb_id, &challenge, &sig).await {
-        Ok(_) => true,
-        Err(e) => {
-            warn!("migrated key probe: token request failed (backend not yet activated): {e}");
-            false
+                if is_backend_communication_error(&error) {
+                    retry_delay = MIGRATED_KEY_RETRY_DELAY;
+                    wait_before_migrated_key_retry(
+                        &error,
+                        "backend_communication",
+                        retry_delay,
+                    )
+                    .await;
+                } else if is_se050_communication_error(&error) {
+                    // A communication failure only means the SE050 was temporarily unreachable.
+                    // Keep trying the migrated key; only a backend 403 selects the legacy key.
+                    wait_before_migrated_key_retry(
+                        &error,
+                        "se050_communication",
+                        MIGRATED_KEY_RETRY_DELAY,
+                    )
+                    .await;
+                } else {
+                    // Retry unknown failures for three full challenge/sign batches, then return
+                    // inconclusive so startup falls back to the legacy key.
+                    inconclusive_attempt += 1;
+                    if inconclusive_attempt >= NUMBER_OF_SIGNINIG_RETRIES {
+                        warn!(
+                            failure_class = "inconclusive",
+                            attempt = inconclusive_attempt,
+                            error = %error,
+                            "migrated key probe could not determine key state"
+                        );
+                        return MigratedKeyProbe::Inconclusive;
+                    }
+                    wait_before_migrated_key_retry(&error, "inconclusive", retry_delay)
+                        .await;
+                    retry_delay = (retry_delay * 2).min(MAX_TOKEN_DELAY);
+                }
+            }
         }
     }
 }
@@ -1015,15 +1145,14 @@ mod test {
     use std::ffi::OsString;
     use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
-    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use crate::client;
 
     use super::{
         try_token_with_migrated_key, AttestedKeysForSigning, ChallengeError,
-        KeyInfoForSigning, RefreshTokenError, SignError, MAX_TOKEN_DELAY,
-        MIN_TOKEN_DELAY,
+        KeyInfoForSigning, MigratedKeyProbe, RefreshTokenError, SignError,
+        MAX_TOKEN_DELAY, MIN_TOKEN_DELAY, SIGNING_FAILURE_ERROR_COUNT,
     };
     use data_encoding::BASE64;
     use reqwest::StatusCode;
@@ -1057,6 +1186,45 @@ mod test {
         let script = temp_dir.path().join(binary_name);
         let script_contents =
             format!("#!/bin/sh\nprintf '%s' '{}'\n", BASE64.encode(signature));
+        std::fs::write(&script, script_contents).unwrap();
+        std::fs::set_permissions(script, std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+
+        let paths = std::iter::once(PathBuf::from(temp_dir.path()))
+            .chain(std::env::split_paths(&original_path));
+        let path = std::env::join_paths(paths).unwrap();
+        // SAFETY: tests that modify PATH are serialized with `#[serial]`.
+        unsafe {
+            std::env::set_var("PATH", path);
+        }
+
+        MockSigner {
+            _temp_dir: temp_dir,
+            original_path,
+        }
+    }
+
+    fn install_mock_signer_with_failures(
+        binary_name: &str,
+        exit_codes: &[i32],
+        signature: &[u8],
+    ) -> MockSigner {
+        let original_path = std::env::var_os("PATH").unwrap_or_default();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let script = temp_dir.path().join(binary_name);
+        let mut script_contents = String::from("#!/bin/sh\n");
+
+        for (index, exit_code) in exit_codes.iter().enumerate() {
+            let marker = temp_dir.path().join(format!("attempt-{index}"));
+            script_contents.push_str(&format!(
+                "if [ ! -f '{}' ]; then touch '{}'; exit {exit_code}; fi\n",
+                marker.display(),
+                marker.display()
+            ));
+        }
+        script_contents
+            .push_str(&format!("printf '%s' '{}'\n", BASE64.encode(signature)));
+
         std::fs::write(&script, script_contents).unwrap();
         std::fs::set_permissions(script, std::fs::Permissions::from_mode(0o755))
             .unwrap();
@@ -1216,7 +1384,10 @@ mod test {
             MIGRATED_MOCK_SIGNATURE,
         );
 
-        assert!(try_token_with_migrated_key(orb_id, &auth_url).await);
+        assert_eq!(
+            try_token_with_migrated_key(orb_id, &auth_url).await,
+            MigratedKeyProbe::Accepted
+        );
     }
 
     /// Regression test for ORBS-1788.
@@ -1246,16 +1417,13 @@ mod test {
         )
         .await;
 
-        // This response is consumed by the migrated-key retry once implemented.
         Mock::given(method("POST"))
             .and(path("/api/v1/tokenchallenge"))
             .respond_with(ResponseTemplate::new(200).set_body_json(challenge_response))
-            .expect(1)
+            .expect(2)
             .mount(&mock_server)
             .await;
 
-        let received_signature = Arc::new(Mutex::new(None::<String>));
-        let received_signature_for_server = Arc::clone(&received_signature);
         mount_transport_failure_once(
             &mock_server,
             "/api/v1/token",
@@ -1270,10 +1438,14 @@ mod test {
                 let body: serde_json::Value = request
                     .body_json()
                     .expect("token request must contain valid JSON");
-                *received_signature_for_server.lock().unwrap() = body
+                let signature = body
                     .get("signature")
                     .and_then(serde_json::Value::as_str)
-                    .map(str::to_owned);
+                    .expect("token request must contain a signature");
+
+                if signature != BASE64.encode(MIGRATED_MOCK_SIGNATURE) {
+                    return ResponseTemplate::new(403);
+                }
 
                 ResponseTemplate::new(200).set_body_json(serde_json::json!({
                     "token": "token_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
@@ -1295,24 +1467,177 @@ mod test {
             "orb-sign-attestation-migrated",
             MIGRATED_MOCK_SIGNATURE,
         );
-        let mut migrated_key_selected =
-            try_token_with_migrated_key(orb_id, &auth_url).await;
+        let migrated_key_probe = try_token_with_migrated_key(orb_id, &auth_url).await;
 
-        assert!(
-            migrated_key_selected,
-            "transient challenge/token transport failure selected legacy keys"
-        );
-
-        let received_signature = received_signature
-            .lock()
-            .unwrap()
-            .clone()
-            .expect("backend did not receive a token request");
-        let expected_migrated_signature = BASE64.encode(MIGRATED_MOCK_SIGNATURE);
         assert_eq!(
-            received_signature, expected_migrated_signature,
-            "backend did not receive the migrated-key signature"
+            migrated_key_probe,
+            MigratedKeyProbe::Accepted,
+            "transient transport failures selected legacy keys"
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn token_forbidden_definitively_rejects_migrated_key() {
+        let mock_server = MockServer::start().await;
+        let orb_id = "TEST_ORB";
+        let challenge =
+            "challenge_token_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tokenchallenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "challenge": BASE64.encode(challenge.as_ref()),
+                "duration": 3600,
+                "expiryTime": "is not used by client",
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/token"))
+            .respond_with(ResponseTemplate::new(403))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let auth_url = mock_server
+            .uri()
+            .parse::<url::Url>()
+            .unwrap()
+            .join("/api/v1/")
+            .unwrap();
+        let _migrated_signer = install_mock_signer(
+            "orb-sign-attestation-migrated",
+            MIGRATED_MOCK_SIGNATURE,
+        );
+
+        assert_eq!(
+            try_token_with_migrated_key(orb_id, &auth_url).await,
+            MigratedKeyProbe::BackendRejected
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn se050_communication_failures_retry_until_migrated_key_works() {
+        *SIGNING_FAILURE_ERROR_COUNT.write().unwrap() = std::num::Saturating(0);
+
+        let mock_server = MockServer::start().await;
+        let orb_id = "TEST_ORB";
+        let challenge =
+            "challenge_token_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tokenchallenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "challenge": BASE64.encode(challenge.as_ref()),
+                "duration": 3600,
+                "expiryTime": "is not used by client",
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                serde_json::json!({
+                    "token": "token_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+                    "duration": 36000,
+                    "expiryTime": "is not used by client",
+                }),
+            ))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let auth_url = mock_server
+            .uri()
+            .parse::<url::Url>()
+            .unwrap()
+            .join("/api/v1/")
+            .unwrap();
+        let _migrated_signer = install_mock_signer_with_failures(
+            "orb-sign-attestation-migrated",
+            &[7, 2],
+            MIGRATED_MOCK_SIGNATURE,
+        );
+
+        assert_eq!(
+            try_token_with_migrated_key(orb_id, &auth_url).await,
+            MigratedKeyProbe::Accepted
+        );
+        assert_eq!(
+            *SIGNING_FAILURE_ERROR_COUNT.read().unwrap(),
+            std::num::Saturating(0)
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn non_communication_se050_failures_are_bounded() {
+        let mock_server = MockServer::start().await;
+        let orb_id = "TEST_ORB";
+        let challenge =
+            "challenge_token_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/tokenchallenge"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "challenge": BASE64.encode(challenge.as_ref()),
+                "duration": 3600,
+                "expiryTime": "is not used by client",
+            })))
+            .expect(3)
+            .mount(&mock_server)
+            .await;
+
+        let auth_url = mock_server
+            .uri()
+            .parse::<url::Url>()
+            .unwrap()
+            .join("/api/v1/")
+            .unwrap();
+        let _migrated_signer = install_mock_signer_with_failures(
+            "orb-sign-attestation-migrated",
+            &[3; 9],
+            MIGRATED_MOCK_SIGNATURE,
+        );
+
+        assert_eq!(
+            try_token_with_migrated_key(orb_id, &auth_url).await,
+            MigratedKeyProbe::Inconclusive
+        );
+    }
+
+    #[test]
+    fn security_mcu_cooldown_errors_are_classified() {
+        for error in [
+            SignError::SignFailed,
+            SignError::Timeout,
+            SignError::CommunicationError,
+        ] {
+            assert!(error.requires_security_mcu_cooldown());
+        }
+
+        assert!(!SignError::NotProvisioned.requires_security_mcu_cooldown());
+    }
+
+    #[test]
+    fn backend_retry_statuses_are_not_key_rejections() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_EARLY,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            assert!(super::is_retryable_backend_status(status));
+        }
+
+        assert!(!super::is_retryable_backend_status(StatusCode::BAD_REQUEST));
+        assert!(!super::is_retryable_backend_status(StatusCode::FORBIDDEN));
     }
 
     #[test]

--- a/attest/src/se050_migration.rs
+++ b/attest/src/se050_migration.rs
@@ -8,6 +8,9 @@ use crate::remote_api::{self, MigratedKeyProbe};
 const KEY_ACTIVATION_POLL_TIMEOUT: Duration = Duration::from_secs(60);
 const KEY_ACTIVATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
+/// Poll after proof submission until the backend accepts the migrated key.
+/// Only time spent receiving a definitive 403 counts toward the timeout;
+/// communication failures keep retrying inside the probe.
 async fn wait_for_migrated_key_activation(orb_id: &str, auth_url: &Url) -> bool {
     let mut rejected_for = Duration::ZERO;
 
@@ -33,12 +36,21 @@ async fn wait_for_migrated_key_activation(orb_id: &str, auth_url: &Url) -> bool 
     false
 }
 
+/// Determine which key set `orb-sign-attestation` should use.
+///
+/// 1. Attempt a complete challenge → migrated sign → token round-trip.
+/// 2. A valid token selects migrated keys. Only a token 403 starts proof submission.
+/// 3. Submit the attested migrated keys, then poll for backend activation.
+///
+/// Backend and SE050 communication failures are retried by the probe and never
+/// cause fallback to legacy keys.
 pub async fn startup_key_selection(
     orb_id: &str,
     auth_url: &Url,
     keys_challenge_url: &Url,
     keys_proof_url: &Url,
 ) -> bool {
+    // First check whether the backend already accepts the migrated key.
     match remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
         MigratedKeyProbe::Accepted => return true,
         MigratedKeyProbe::Inconclusive => {
@@ -48,6 +60,7 @@ pub async fn startup_key_selection(
         MigratedKeyProbe::BackendRejected => {}
     }
 
+    // A token 403 proved that the backend does not accept the migrated key yet.
     if let Err(error) =
         remote_api::submit_proof(orb_id, keys_challenge_url, keys_proof_url).await
     {
@@ -55,5 +68,6 @@ pub async fn startup_key_selection(
         return false;
     }
 
+    // Proof submission succeeded; wait for the backend to activate the new key.
     wait_for_migrated_key_activation(orb_id, auth_url).await
 }

--- a/attest/src/se050_migration.rs
+++ b/attest/src/se050_migration.rs
@@ -1,147 +1,59 @@
-use tracing::{info, warn};
+use std::time::Duration;
+
+use tracing::warn;
 use url::Url;
 
-use crate::remote_api;
+use crate::remote_api::{self, MigratedKeyProbe};
 
-/// How long to poll for migrated key activation after proof submission.
-const KEY_ACTIVATION_POLL_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(60);
-const KEY_ACTIVATION_POLL_INTERVAL: std::time::Duration =
-    std::time::Duration::from_secs(5);
-/// How long to wait between retries while waiting for the backend to become reachable.
-const BACKEND_REACHABILITY_RETRY_INTERVAL: std::time::Duration =
-    std::time::Duration::from_secs(5);
+const KEY_ACTIVATION_POLL_TIMEOUT: Duration = Duration::from_secs(60);
+const KEY_ACTIVATION_POLL_INTERVAL: Duration = Duration::from_secs(5);
 
-/// Returns `true` if `worldcoin-se050-provision.service` is in the `active`
-/// state, meaning SE050 has migrated keys.
-async fn se050_provision_service_active() -> bool {
-    use zbus_systemd::systemd1::{ManagerProxy, UnitProxy};
+async fn wait_for_migrated_key_activation(orb_id: &str, auth_url: &Url) -> bool {
+    let mut rejected_for = Duration::ZERO;
 
-    let Ok(conn) = zbus::Connection::system().await else {
-        warn!("SE050: failed to connect to system D-Bus");
-        return false;
-    };
-    let Ok(manager) = ManagerProxy::new(&conn).await else {
-        warn!("SE050: failed to create systemd ManagerProxy");
-        return false;
-    };
-    // GetUnit errors if the unit has never been loaded — treat as not active.
-    let Ok(unit_path) = manager
-        .get_unit("worldcoin-se050-provision.service".to_owned())
-        .await
-    else {
-        warn!("SE050: worldcoin-se050-provision.service not found in systemd");
-        return false;
-    };
-    let builder = match UnitProxy::builder(&conn).path(unit_path) {
-        Ok(b) => b,
-        Err(e) => {
-            warn!("SE050: invalid unit object path from systemd: {e}");
-            return false;
-        }
-    };
-    let Ok(unit) = builder.build().await else {
-        warn!("SE050: failed to create systemd UnitProxy");
-        return false;
-    };
-    unit.active_state().await.ok().as_deref() == Some("active")
-}
-
-/// Block until the token-challenge endpoint returns any response (success or
-/// server error). Retries indefinitely on network/connect errors — the caller
-/// cannot do anything useful without backend connectivity.
-async fn wait_for_backend_reachable(orb_id: &str, auth_url: &Url) {
-    let tokenchallenge_url = auth_url
-        .join("tokenchallenge")
-        .expect("auth_url must have a path");
-
-    loop {
-        let client = crate::client::create();
-        match remote_api::Challenge::request(&client, orb_id, &tokenchallenge_url).await
-        {
-            Ok(_) | Err(remote_api::ChallengeError::ServerReturnedError(..)) => {
-                info!("backend reachable");
-                return;
-            }
-            Err(e) => {
+    while rejected_for < KEY_ACTIVATION_POLL_TIMEOUT {
+        match remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
+            MigratedKeyProbe::Accepted => return true,
+            MigratedKeyProbe::Inconclusive => {
                 warn!(
-                    "backend not reachable ({e}), retrying in {}s",
-                    BACKEND_REACHABILITY_RETRY_INTERVAL.as_secs()
+                    "migrated key state remained inconclusive after proof submission; using legacy keys"
                 );
-                tokio::time::sleep(BACKEND_REACHABILITY_RETRY_INTERVAL).await;
+                return false;
+            }
+            MigratedKeyProbe::BackendRejected => {
+                tokio::time::sleep(KEY_ACTIVATION_POLL_INTERVAL).await;
+                rejected_for += KEY_ACTIVATION_POLL_INTERVAL;
             }
         }
     }
+
+    warn!(
+        "backend continued to reject migrated keys after proof submission; using legacy keys"
+    );
+    false
 }
 
-/// Determine which SE050 key set is active.
-///
-/// 1. Service check: if `worldcoin-se050-provision.service` is not active,
-///    SE050 has no migrated keys → return `false` immediately.
-/// 2. Wait until the backend is reachable (challenge endpoint responds).
-/// 3. Backend check: attempt a full challenge→sign(migrated)→token round-trip.
-///    If the backend returns a valid token, it already has the migrated key
-///    registered → return `true`.
-/// 4. Submit the NXP-attested proof so the backend registers the migrated key.
-/// 5. Poll the same backend round-trip until it succeeds or [`KEY_ACTIVATION_POLL_TIMEOUT`]
-///    elapses. "Activation" means the backend accepted the migrated key and
-///    returned a valid token.
 pub async fn startup_key_selection(
     orb_id: &str,
     auth_url: &Url,
     keys_challenge_url: &Url,
     keys_proof_url: &Url,
 ) -> bool {
-    // Service check: worldcoin-se050-provision.service encodes the answer to
-    // "does this Orb have migrated keys?" — it runs before us and stays active.
-    if !se050_provision_service_active().await {
-        info!("worldcoin-se050-provision.service not active, using legacy keys");
+    match remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
+        MigratedKeyProbe::Accepted => return true,
+        MigratedKeyProbe::Inconclusive => {
+            warn!("migrated key state is inconclusive; using legacy keys");
+            return false;
+        }
+        MigratedKeyProbe::BackendRejected => {}
+    }
+
+    if let Err(error) =
+        remote_api::submit_proof(orb_id, keys_challenge_url, keys_proof_url).await
+    {
+        warn!(%error, "migrated key proof submission failed; using legacy keys");
         return false;
     }
 
-    // Wait for connectivity: ensures the 60 s activation window is spent on
-    // actual key-state probes, not wasted on network unreachability.
-    wait_for_backend_reachable(orb_id, auth_url).await;
-
-    // Backend check: does the backend already accept the migrated key?
-    if remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
-        info!("backend already accepts migrated keys");
-        return true;
-    }
-
-    // Submit proof to register the migrated public key with the backend.
-    info!("migrated keys not yet accepted by backend, submitting key proof");
-    match remote_api::submit_proof(orb_id, keys_challenge_url, keys_proof_url).await {
-        Ok(()) => {
-            info!(
-                "key proof submitted, polling for backend activation (up to {}s)",
-                KEY_ACTIVATION_POLL_TIMEOUT.as_secs()
-            );
-        }
-        Err(e) => {
-            warn!("key proof submission failed: {e}; proceeding with legacy keys");
-            return false;
-        }
-    }
-
-    // Poll until the backend accepts a token signed with the migrated key.
-    // This is the definitive test: if the token endpoint returns 200, the
-    // backend has swapped the registered public key and migration is complete.
-    let deadline = tokio::time::Instant::now() + KEY_ACTIVATION_POLL_TIMEOUT;
-    loop {
-        if remote_api::try_token_with_migrated_key(orb_id, auth_url).await {
-            info!("backend now accepts migrated keys");
-            return true;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            break;
-        }
-        tokio::time::sleep(KEY_ACTIVATION_POLL_INTERVAL).await;
-    }
-
-    warn!(
-        "backend did not accept migrated keys after {}s; proceeding with legacy keys",
-        KEY_ACTIVATION_POLL_TIMEOUT.as_secs()
-    );
-    false
+    wait_for_migrated_key_activation(orb_id, auth_url).await
 }


### PR DESCRIPTION
Retry migrated key token issuance through transient backend and SE050 failures. Only a token endpoint 403 confirms migrated key rejection and starts the proof flow.

    New tests:
    - token_forbidden_definitively_rejects_migrated_key: confirms token 403 returns BackendRejected
    - se050_communication_failures_retry_until_migrated_key_works: confirms communication failures retry until migrated signing succeeds
    - non_communication_se050_failures_are_bounded: confirms unknown signing failures stop after nine attempts
    - security_mcu_cooldown_errors_are_classified: verifies errors counted toward MCU powercycling
    - backend_retry_statuses_are_not_key_rejections: verifies retryable HTTP statuses are not key rejections