### PR TITLE
fix: clippy warning use of `default` to create a unit struct

### DIFF
--- a/orb-monitoring-auth/src/server/mod.rs
+++ b/orb-monitoring-auth/src/server/mod.rs
@@ -147,6 +147,7 @@ impl Dependencies {
             token_endpoint: "todo".into(),
             server_socket_path: DEFAULT_SOCKET.into(),
             dd_agent_uid: crate::DD_AGENT_UID,
+            #[allow(clippy::default_constructed_unit_structs)]
             clock: Clock::default(),
             dbus: zbus::Connection::session().await?,
             refresh_token_interval: Duration::from_hours(4),


### PR DESCRIPTION
Fix:
<img width="1964" height="456" alt="image" src="https://github.com/user-attachments/assets/8300265c-1cb1-42aa-bcaf-f37529291897" />
