### PR TITLE
fix(update-agent): checked arithmetic for raw block-device write bounds

### DIFF
--- a/update-agent/src/update/raw.rs
+++ b/update-agent/src/update/raw.rs
@@ -1,4 +1,4 @@
-use eyre::{ensure, WrapErr as _};
+use eyre::{ensure, eyre, WrapErr as _};
 use orb_dogd::MetricEmitter;
 use orb_update_agent_core::{components, Slot};
 use std::io::{self, Seek as _, Write};
@@ -7,6 +7,43 @@ use tracing::debug;
 use super::Update;
 
 const METRIC_NAME: &str = "orb.platform.update.component.raw";
+
+/// Resolves the byte offset at which `src_len` bytes may be written to a block device of
+/// `block_dev_len` bytes, or errors if that write would not fit.
+///
+/// `size` and `offset` come from the claim's `system_components`, so this arithmetic
+/// must not be allowed to wrap: no build profile enables overflow checks, and a wrapped
+/// sum turns the bounds check into a no-op that permits a write past the end of the
+/// device. Kept free of any device handle so it can be unit tested off-target.
+fn checked_write_bounds(
+    size: u64,
+    offset: u64,
+    redundant: bool,
+    slot: Slot,
+    src_len: u64,
+    block_dev_len: u64,
+) -> eyre::Result<u64> {
+    let offset = if slot == Slot::B && redundant {
+        size.checked_add(offset).ok_or_else(|| {
+            eyre!(
+                "redundant slot B offset overflows u64: size {size} + offset {offset}"
+            )
+        })?
+    } else {
+        offset
+    };
+
+    let write_end = src_len.checked_add(offset).ok_or_else(|| {
+        eyre!("write range overflows u64: source length {src_len} + offset {offset}")
+    })?;
+    ensure!(
+        block_dev_len >= write_end,
+        "block device is too small to write {src_len} bytes starting at offset {offset}: \
+         device length is {block_dev_len}",
+    );
+
+    Ok(offset)
+}
 
 impl Update for components::Raw {
     fn update<R, M>(&self, slot: Slot, mut src: R, metrics: &M) -> eyre::Result<()>
@@ -41,19 +78,15 @@ impl Update for components::Raw {
 
         debug!("-- updating with device length {:?}", block_dev_len);
 
-        let offset = if slot == Slot::B && self.is_redundant() {
-            self.size + self.offset
-        } else {
-            self.offset
-        };
-        debug!("-- setting up offset to be {:?}", offset);
-
-        ensure!(
-            block_dev_len >= src_len + offset,
-            "block device is too small to write {} bytes starting at offset {}",
+        let offset = checked_write_bounds(
+            self.size,
+            self.offset,
+            self.is_redundant(),
+            slot,
             src_len,
-            offset,
-        );
+            block_dev_len,
+        )?;
+        debug!("-- setting up offset to be {:?}", offset);
         debug!("-- device passed length check");
 
         block_dev
@@ -90,5 +123,58 @@ impl Update for components::Raw {
             .inspect_err(|e| tracing::error!("metric emit failed: {e:#?}"));
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_redundant_component_writes_at_its_offset() {
+        for slot in [Slot::A, Slot::B] {
+            assert_eq!(
+                checked_write_bounds(100, 1000, false, slot, 50, 2000).unwrap(),
+                1000
+            );
+        }
+    }
+
+    #[test]
+    fn redundant_component_writes_slot_b_after_slot_a() {
+        assert_eq!(
+            checked_write_bounds(100, 1000, true, Slot::A, 50, 2000).unwrap(),
+            1000
+        );
+        assert_eq!(
+            checked_write_bounds(100, 1000, true, Slot::B, 50, 2000).unwrap(),
+            1100
+        );
+    }
+
+    #[test]
+    fn write_ending_exactly_at_the_end_of_the_device_is_allowed() {
+        assert_eq!(
+            checked_write_bounds(0, 900, false, Slot::A, 100, 1000).unwrap(),
+            900
+        );
+    }
+
+    #[test]
+    fn write_exceeding_the_device_is_rejected() {
+        assert!(checked_write_bounds(0, 900, false, Slot::A, 101, 1000).is_err());
+    }
+
+    #[test]
+    fn overflowing_redundant_slot_offset_is_rejected() {
+        assert!(checked_write_bounds(u64::MAX, 1, true, Slot::B, 0, u64::MAX).is_err());
+    }
+
+    #[test]
+    fn overflowing_write_range_is_rejected() {
+        // Wrapping `src_len + offset` to 0 would make the bounds check trivially pass.
+        assert!(
+            checked_write_bounds(0, 1, false, Slot::A, u64::MAX, u64::MAX).is_err()
+        );
     }
 }


### PR DESCRIPTION
`Raw::update` computed `size + offset` and `src_len + offset` with unchecked u64 adds; release builds wrap (no overflow-checks profile), so crafted unsigned `system_components` values could wrap past the block-device bounds check.

Fix: bounds math extracted into pure `checked_write_bounds` using `checked_add`; unchanged behavior for valid inputs. Tests cover both overflow cases, exact-fit, and redundant slots (run in Linux CI).

Mitigates: u64-wrap element of VULN-6331/6332; external disclosure report (Sep 2026), unchecked-arithmetic finding. Pre-existing residual (slot-A spill within device bounds): ORBS-1763. Part 2/3 of claim hardening.
