### PR TITLE
fix(jobs-agent): validate relay message sender before dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7572,6 +7572,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
+ "tracing-subscriber",
  "uuid 1.19.0",
  "zbus",
  "zbus_systemd",

--- a/orb-jobs-agent/Cargo.toml
+++ b/orb-jobs-agent/Cargo.toml
@@ -77,6 +77,7 @@ serial_test = "3.2.0"
 test-utils.workspace = true
 test-with.workspace = true
 tokio = { workspace = true, features = ["sync", "test-util"] }
+tracing-subscriber.workspace = true
 uuid = { version = "1.17.0", features = ["v4"] }
 mockall.workspace = true
 portpicker = "0.1.1"

--- a/orb-jobs-agent/src/job_system/client.rs
+++ b/orb-jobs-agent/src/job_system/client.rs
@@ -8,11 +8,27 @@ use orb_relay_messages::{
     jobs::v1::{
         JobCancel, JobExecution, JobExecutionUpdate, JobNotify, JobRequestNext,
     },
-    prost::{Message, Name},
+    prost::{DecodeError, Message, Name},
     prost_types::Any,
-    relay::entity::EntityType,
+    relay::{entity::EntityType, Entity},
 };
+use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{error, info, warn};
+
+/// Sender labels are attacker controlled and unbounded; truncate before logging.
+const MAX_LOGGED_LABEL_CHARS: usize = 128;
+
+/// Log the first few unexpected senders, then only every
+/// `UNEXPECTED_SENDER_LOG_EVERY`-th one, so warn volume never scales 1:1 with
+/// unsolicited traffic. NOTE: the counter is global, not per-sender -- a noisy
+/// unexpected sender can delay first-log evidence of a second distinct one;
+/// accepted for the shadow window (a per-sender map would grow unbounded on
+/// attacker-chosen keys).
+const UNEXPECTED_SENDER_LOG_BURST: u64 = 10;
+const UNEXPECTED_SENDER_LOG_EVERY: u64 = 100;
+
+/// Process-local count of inbound messages from unexpected senders.
+static UNEXPECTED_SENDERS: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct JobClient {
@@ -42,75 +58,71 @@ impl JobClient {
 
     pub async fn listen_for_job(&self) -> Result<JobExecution, orb_relay_client::Err> {
         loop {
-            match self.relay_client.recv().await {
-                Ok(msg) => {
-                    let any = match Any::decode(msg.payload.as_slice()) {
-                        Ok(any) => any,
-                        Err(e) => {
-                            error!("error decoding message: {:?}", e);
-                            continue;
-                        }
-                    };
-                    if any.type_url == JobNotify::type_url() {
-                        match JobNotify::decode(any.value.as_slice()) {
-                            Ok(job_notify) => {
-                                info!("received JobNotify: {:?}", job_notify);
-                                let _ = self.request_next_job().await;
-                            }
-                            Err(e) => {
-                                error!("error decoding JobNotify: {:?}", e);
-                            }
-                        }
-                    } else if any.type_url == JobExecution::type_url() {
-                        match JobExecution::decode(any.value.as_slice()) {
-                            Ok(job) => {
-                                info!(
-                                    job_id = %job.job_id,
-                                    job_execution_id = %job.job_execution_id,
-                                    job_document = %redact_job_document(&job.job_document),
-                                    should_cancel = job.should_cancel,
-                                    "received JobExecution"
-                                );
-                                return Ok(job);
-                            }
-                            Err(e) => {
-                                error!("error decoding JobExecution: {:?}", e);
-                            }
-                        }
-                    } else if any.type_url == JobCancel::type_url() {
-                        match JobCancel::decode(any.value.as_slice()) {
-                            Ok(job_cancel) => {
-                                info!(
-                                    job_execution_id = %job_cancel.job_execution_id,
-                                    "received JobCancel"
-                                );
-                                let cancelled = self
-                                    .job_registry
-                                    .cancel_job(&job_cancel.job_execution_id)
-                                    .await;
-                                if cancelled {
-                                    info!(
-                                        job_execution_id = %job_cancel.job_execution_id,
-                                        "Successfully cancelled job"
-                                    );
-                                } else {
-                                    warn!(
-                                        job_execution_id = %job_cancel.job_execution_id,
-                                        "Attempted to cancel non-existent or already completed job"
-                                    );
-                                }
-                            }
-                            Err(e) => {
-                                error!("error decoding JobCancel: {:?}", e);
-                            }
-                        }
-                    } else {
-                        error!("received unexpected message type: {:?}", any.type_url);
-                    }
-                }
+            let msg = match self.relay_client.recv().await {
+                Ok(msg) => msg,
                 Err(e) => {
                     error!("error receiving from relay: {:?}", e);
                     return Err(e);
+                }
+            };
+
+            // Only the configured job server may drive job execution, cancellation,
+            // or request-next; messages from any other sender are dropped before
+            // their payload is decoded.
+            if !is_authorized_sender(
+                &msg.from,
+                &self.target_service_id,
+                &self.relay_namespace,
+            ) {
+                log_unexpected_sender(&msg.from);
+                continue;
+            }
+
+            match classify_inbound(&msg.payload) {
+                InboundDecision::Notify(job_notify) => {
+                    info!("received JobNotify: {:?}", job_notify);
+                    let _ = self.request_next_job().await;
+                }
+
+                InboundDecision::Execution(job) => {
+                    info!(
+                        job_id = %job.job_id,
+                        job_execution_id = %job.job_execution_id,
+                        job_document = %redact_job_document(&job.job_document),
+                        should_cancel = job.should_cancel,
+                        "received JobExecution"
+                    );
+                    return Ok(job);
+                }
+
+                InboundDecision::Cancel(job_cancel) => {
+                    info!(
+                        job_execution_id = %job_cancel.job_execution_id,
+                        "received JobCancel"
+                    );
+                    let cancelled = self
+                        .job_registry
+                        .cancel_job(&job_cancel.job_execution_id)
+                        .await;
+                    if cancelled {
+                        info!(
+                            job_execution_id = %job_cancel.job_execution_id,
+                            "Successfully cancelled job"
+                        );
+                    } else {
+                        warn!(
+                            job_execution_id = %job_cancel.job_execution_id,
+                            "Attempted to cancel non-existent or already completed job"
+                        );
+                    }
+                }
+
+                InboundDecision::Undecodable { msg_name, err } => {
+                    error!("error decoding {}: {:?}", msg_name, err);
+                }
+
+                InboundDecision::UnknownType(type_url) => {
+                    error!("received unexpected message type: {:?}", type_url);
                 }
             }
         }
@@ -218,6 +230,105 @@ impl JobClient {
     }
 }
 
+/// What the inbound step decided about a single relay message.
+#[derive(Debug)]
+enum InboundDecision {
+    Notify(JobNotify),
+    Execution(JobExecution),
+    Cancel(JobCancel),
+    Undecodable {
+        msg_name: &'static str,
+        err: DecodeError,
+    },
+    UnknownType(String),
+}
+
+/// Whether `from` matches the configured job server.
+///
+/// `from` is a sender-supplied label rather than verified identity (authenticity
+/// is enforced by the relay server), so this is defense-in-depth against any
+/// entity other than the configured job server reaching the decoders and the
+/// side effects behind them (job execution, cancellation, request-next).
+fn is_authorized_sender(
+    from: &Entity,
+    target_service_id: &str,
+    relay_namespace: &str,
+) -> bool {
+    // prost exposes `entity_type` as a raw i32; compare the same way the relay
+    // client itself does.
+    EntityType::try_from(from.entity_type) == Ok(EntityType::Service)
+        && from.id == target_service_id
+        && from.namespace == relay_namespace
+}
+
+/// Decodes an inbound relay message and classifies it by payload type.
+fn classify_inbound(payload: &[u8]) -> InboundDecision {
+    let any = match Any::decode(payload) {
+        Ok(any) => any,
+        Err(err) => {
+            return InboundDecision::Undecodable {
+                msg_name: "message",
+                err,
+            }
+        }
+    };
+
+    if any.type_url == JobNotify::type_url() {
+        match JobNotify::decode(any.value.as_slice()) {
+            Ok(job_notify) => InboundDecision::Notify(job_notify),
+            Err(err) => InboundDecision::Undecodable {
+                msg_name: "JobNotify",
+                err,
+            },
+        }
+    } else if any.type_url == JobExecution::type_url() {
+        match JobExecution::decode(any.value.as_slice()) {
+            Ok(job) => InboundDecision::Execution(job),
+            Err(err) => InboundDecision::Undecodable {
+                msg_name: "JobExecution",
+                err,
+            },
+        }
+    } else if any.type_url == JobCancel::type_url() {
+        match JobCancel::decode(any.value.as_slice()) {
+            Ok(job_cancel) => InboundDecision::Cancel(job_cancel),
+            Err(err) => InboundDecision::Undecodable {
+                msg_name: "JobCancel",
+                err,
+            },
+        }
+    } else {
+        InboundDecision::UnknownType(any.type_url)
+    }
+}
+
+/// Logs a rejected message -- never its payload -- and only for the first few
+/// occurrences plus every `UNEXPECTED_SENDER_LOG_EVERY`-th one thereafter.
+fn log_unexpected_sender(from: &Entity) {
+    let unexpected_total = UNEXPECTED_SENDERS.fetch_add(1, Ordering::Relaxed) + 1;
+
+    if unexpected_total > UNEXPECTED_SENDER_LOG_BURST
+        && !unexpected_total.is_multiple_of(UNEXPECTED_SENDER_LOG_EVERY)
+    {
+        return;
+    }
+
+    warn!(
+        // `?` so control characters in the attacker-chosen labels are escaped
+        sender_id = ?truncate_label(&from.id),
+        sender_namespace = ?truncate_label(&from.namespace),
+        sender_entity_type = ?EntityType::try_from(from.entity_type),
+        unexpected_total,
+        "rejected relay message from unexpected sender"
+    );
+}
+
+/// Truncates by chars: byte slicing would panic mid-codepoint and let a sender
+/// take down the recv loop.
+fn truncate_label(label: &str) -> String {
+    label.chars().take(MAX_LOGGED_LABEL_CHARS).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -308,5 +419,145 @@ mod tests {
         // Test that default JobRequestNext has empty ignore_job_execution_ids
         let default_request = JobRequestNext::default();
         assert!(default_request.ignore_job_execution_ids.is_empty());
+    }
+
+    const TARGET_SERVICE_ID: &str = "fleet-cmdr";
+    const RELAY_NAMESPACE: &str = "test-namespace";
+
+    fn job_server() -> Entity {
+        Entity {
+            id: TARGET_SERVICE_ID.to_string(),
+            entity_type: EntityType::Service as i32,
+            namespace: RELAY_NAMESPACE.to_string(),
+        }
+    }
+
+    fn execution_payload() -> Vec<u8> {
+        Any::from_msg(&JobExecution {
+            job_id: "job".to_string(),
+            job_execution_id: "exec".to_string(),
+            job_document: "orb_details".to_string(),
+            should_cancel: false,
+        })
+        .unwrap()
+        .encode_to_vec()
+    }
+
+    fn classify(payload: &[u8]) -> InboundDecision {
+        classify_inbound(payload)
+    }
+
+    fn authorized(from: &Entity) -> bool {
+        is_authorized_sender(from, TARGET_SERVICE_ID, RELAY_NAMESPACE)
+    }
+
+    #[test]
+    fn job_server_execution_is_accepted() {
+        let decision = classify(&execution_payload());
+
+        let InboundDecision::Execution(job) = decision else {
+            panic!("expected Execution, got {decision:?}");
+        };
+        assert_eq!(job.job_execution_id, "exec");
+    }
+
+    #[test]
+    fn job_server_notify_is_accepted() {
+        let payload = Any::from_msg(&JobNotify::default())
+            .unwrap()
+            .encode_to_vec();
+
+        assert!(matches!(classify(&payload), InboundDecision::Notify(_)));
+    }
+
+    #[test]
+    fn job_server_cancel_is_accepted() {
+        let payload = Any::from_msg(&JobCancel {
+            job_execution_id: "exec".to_string(),
+        })
+        .unwrap()
+        .encode_to_vec();
+
+        let decision = classify(&payload);
+
+        let InboundDecision::Cancel(cancel) = decision else {
+            panic!("expected Cancel, got {decision:?}");
+        };
+        assert_eq!(cancel.job_execution_id, "exec");
+    }
+
+    #[test]
+    fn job_server_garbage_payload_is_undecodable() {
+        assert!(matches!(
+            classify(&[0xff, 0xff, 0xff, 0xff]),
+            InboundDecision::Undecodable { .. }
+        ));
+    }
+
+    /// Unauthorized senders are rejected by `listen_for_job` before their
+    /// payload is decoded.
+    #[test]
+    fn unexpected_senders_are_rejected() {
+        let unexpected = [
+            (
+                "wrong id",
+                Entity {
+                    id: "unexpected-service".to_string(),
+                    ..job_server()
+                },
+            ),
+            (
+                "wrong namespace",
+                Entity {
+                    namespace: "other-namespace".to_string(),
+                    ..job_server()
+                },
+            ),
+            (
+                "app",
+                Entity {
+                    entity_type: EntityType::App as i32,
+                    ..job_server()
+                },
+            ),
+            (
+                "orb",
+                Entity {
+                    entity_type: EntityType::Orb as i32,
+                    ..job_server()
+                },
+            ),
+            (
+                "unspecified",
+                Entity {
+                    entity_type: EntityType::Unspecified as i32,
+                    ..job_server()
+                },
+            ),
+            (
+                "out of range entity type",
+                Entity {
+                    entity_type: 42,
+                    ..job_server()
+                },
+            ),
+        ];
+
+        assert!(authorized(&job_server()), "the job server itself must pass");
+        for (case, from) in unexpected {
+            assert!(
+                !authorized(&from),
+                "{case}: expected the sender to be flagged as unauthorized"
+            );
+        }
+    }
+
+    #[test]
+    fn logged_sender_labels_are_truncated_char_safely() {
+        // multi-byte chars: byte slicing at 128 would panic mid-codepoint
+        let label = "é".repeat(200);
+        let truncated = truncate_label(&label);
+
+        assert_eq!(truncated.chars().count(), MAX_LOGGED_LABEL_CHARS);
     }
 }

--- a/orb-jobs-agent/src/job_system/client.rs
+++ b/orb-jobs-agent/src/job_system/client.rs
@@ -12,23 +12,49 @@ use orb_relay_messages::{
     prost_types::Any,
     relay::{entity::EntityType, Entity},
 };
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 use tracing::{error, info, warn};
 
-/// Sender labels are attacker controlled and unbounded; truncate before logging.
-const MAX_LOGGED_LABEL_CHARS: usize = 128;
+#[derive(Debug, Default)]
+struct UnexpectedSenders {
+    count: AtomicU64,
+}
 
-/// Log the first few unexpected senders, then only every
-/// `UNEXPECTED_SENDER_LOG_EVERY`-th one, so warn volume never scales 1:1 with
-/// unsolicited traffic. NOTE: the counter is global, not per-sender -- a noisy
-/// unexpected sender can delay first-log evidence of a second distinct one;
-/// accepted for the shadow window (a per-sender map would grow unbounded on
-/// attacker-chosen keys).
-const UNEXPECTED_SENDER_LOG_BURST: u64 = 10;
-const UNEXPECTED_SENDER_LOG_EVERY: u64 = 100;
+impl UnexpectedSenders {
+    const LOG_BURST: u64 = 10;
+    const LOG_EVERY: u64 = 100;
+    const MAX_LOGGED_LABEL_CHARS: usize = 128;
 
-/// Process-local count of inbound messages from unexpected senders.
-static UNEXPECTED_SENDERS: AtomicU64 = AtomicU64::new(0);
+    fn record(&self, from: &Entity) {
+        let unexpected_total = self.count.fetch_add(1, Ordering::Relaxed) + 1;
+
+        if !Self::should_log(unexpected_total) {
+            return;
+        }
+
+        warn!(
+            // `?` so control characters in the attacker-chosen labels are escaped
+            sender_id = ?Self::truncate_label(&from.id),
+            sender_namespace = ?Self::truncate_label(&from.namespace),
+            sender_entity_type = ?EntityType::try_from(from.entity_type),
+            unexpected_total,
+            "rejected relay message from unexpected sender"
+        );
+    }
+
+    fn should_log(count: u64) -> bool {
+        count <= Self::LOG_BURST || count.is_multiple_of(Self::LOG_EVERY)
+    }
+
+    /// Truncates by chars: byte slicing would panic mid-codepoint and let a sender
+    /// take down the recv loop.
+    fn truncate_label(label: &str) -> String {
+        label.chars().take(Self::MAX_LOGGED_LABEL_CHARS).collect()
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct JobClient {
@@ -37,6 +63,7 @@ pub struct JobClient {
     relay_namespace: String,
     job_registry: JobRegistry,
     job_config: JobConfig,
+    unexpected_senders: Arc<UnexpectedSenders>,
 }
 
 impl JobClient {
@@ -53,6 +80,7 @@ impl JobClient {
             relay_namespace: relay_namespace.to_string(),
             job_registry,
             job_config,
+            unexpected_senders: Arc::new(UnexpectedSenders::default()),
         }
     }
 
@@ -74,11 +102,11 @@ impl JobClient {
                 &self.target_service_id,
                 &self.relay_namespace,
             ) {
-                log_unexpected_sender(&msg.from);
+                self.unexpected_senders.record(&msg.from);
                 continue;
             }
 
-            match classify_inbound(&msg.payload) {
+            match InboundDecision::from(msg.payload.as_slice()) {
                 InboundDecision::Notify(job_notify) => {
                     info!("received JobNotify: {:?}", job_notify);
                     let _ = self.request_next_job().await;
@@ -261,72 +289,47 @@ fn is_authorized_sender(
         && from.namespace == relay_namespace
 }
 
-/// Decodes an inbound relay message and classifies it by payload type.
-fn classify_inbound(payload: &[u8]) -> InboundDecision {
-    let any = match Any::decode(payload) {
-        Ok(any) => any,
-        Err(err) => {
-            return InboundDecision::Undecodable {
-                msg_name: "message",
-                err,
+impl From<&[u8]> for InboundDecision {
+    /// Decodes an inbound relay message and classifies it by payload type.
+    fn from(payload: &[u8]) -> Self {
+        let any = match Any::decode(payload) {
+            Ok(any) => any,
+            Err(err) => {
+                return Self::Undecodable {
+                    msg_name: "message",
+                    err,
+                }
             }
-        }
-    };
+        };
 
-    if any.type_url == JobNotify::type_url() {
-        match JobNotify::decode(any.value.as_slice()) {
-            Ok(job_notify) => InboundDecision::Notify(job_notify),
-            Err(err) => InboundDecision::Undecodable {
-                msg_name: "JobNotify",
-                err,
-            },
+        if any.type_url == JobNotify::type_url() {
+            match JobNotify::decode(any.value.as_slice()) {
+                Ok(job_notify) => Self::Notify(job_notify),
+                Err(err) => Self::Undecodable {
+                    msg_name: "JobNotify",
+                    err,
+                },
+            }
+        } else if any.type_url == JobExecution::type_url() {
+            match JobExecution::decode(any.value.as_slice()) {
+                Ok(job) => Self::Execution(job),
+                Err(err) => Self::Undecodable {
+                    msg_name: "JobExecution",
+                    err,
+                },
+            }
+        } else if any.type_url == JobCancel::type_url() {
+            match JobCancel::decode(any.value.as_slice()) {
+                Ok(job_cancel) => Self::Cancel(job_cancel),
+                Err(err) => Self::Undecodable {
+                    msg_name: "JobCancel",
+                    err,
+                },
+            }
+        } else {
+            Self::UnknownType(any.type_url)
         }
-    } else if any.type_url == JobExecution::type_url() {
-        match JobExecution::decode(any.value.as_slice()) {
-            Ok(job) => InboundDecision::Execution(job),
-            Err(err) => InboundDecision::Undecodable {
-                msg_name: "JobExecution",
-                err,
-            },
-        }
-    } else if any.type_url == JobCancel::type_url() {
-        match JobCancel::decode(any.value.as_slice()) {
-            Ok(job_cancel) => InboundDecision::Cancel(job_cancel),
-            Err(err) => InboundDecision::Undecodable {
-                msg_name: "JobCancel",
-                err,
-            },
-        }
-    } else {
-        InboundDecision::UnknownType(any.type_url)
     }
-}
-
-/// Logs a rejected message -- never its payload -- and only for the first few
-/// occurrences plus every `UNEXPECTED_SENDER_LOG_EVERY`-th one thereafter.
-fn log_unexpected_sender(from: &Entity) {
-    let unexpected_total = UNEXPECTED_SENDERS.fetch_add(1, Ordering::Relaxed) + 1;
-
-    if unexpected_total > UNEXPECTED_SENDER_LOG_BURST
-        && !unexpected_total.is_multiple_of(UNEXPECTED_SENDER_LOG_EVERY)
-    {
-        return;
-    }
-
-    warn!(
-        // `?` so control characters in the attacker-chosen labels are escaped
-        sender_id = ?truncate_label(&from.id),
-        sender_namespace = ?truncate_label(&from.namespace),
-        sender_entity_type = ?EntityType::try_from(from.entity_type),
-        unexpected_total,
-        "rejected relay message from unexpected sender"
-    );
-}
-
-/// Truncates by chars: byte slicing would panic mid-codepoint and let a sender
-/// take down the recv loop.
-fn truncate_label(label: &str) -> String {
-    label.chars().take(MAX_LOGGED_LABEL_CHARS).collect()
 }
 
 #[cfg(test)]
@@ -443,17 +446,13 @@ mod tests {
         .encode_to_vec()
     }
 
-    fn classify(payload: &[u8]) -> InboundDecision {
-        classify_inbound(payload)
-    }
-
     fn authorized(from: &Entity) -> bool {
         is_authorized_sender(from, TARGET_SERVICE_ID, RELAY_NAMESPACE)
     }
 
     #[test]
     fn job_server_execution_is_accepted() {
-        let decision = classify(&execution_payload());
+        let decision = InboundDecision::from(execution_payload().as_slice());
 
         let InboundDecision::Execution(job) = decision else {
             panic!("expected Execution, got {decision:?}");
@@ -467,7 +466,10 @@ mod tests {
             .unwrap()
             .encode_to_vec();
 
-        assert!(matches!(classify(&payload), InboundDecision::Notify(_)));
+        assert!(matches!(
+            InboundDecision::from(payload.as_slice()),
+            InboundDecision::Notify(_)
+        ));
     }
 
     #[test]
@@ -478,7 +480,7 @@ mod tests {
         .unwrap()
         .encode_to_vec();
 
-        let decision = classify(&payload);
+        let decision = InboundDecision::from(payload.as_slice());
 
         let InboundDecision::Cancel(cancel) = decision else {
             panic!("expected Cancel, got {decision:?}");
@@ -489,7 +491,7 @@ mod tests {
     #[test]
     fn job_server_garbage_payload_is_undecodable() {
         assert!(matches!(
-            classify(&[0xff, 0xff, 0xff, 0xff]),
+            InboundDecision::from([0xff, 0xff, 0xff, 0xff].as_slice()),
             InboundDecision::Undecodable { .. }
         ));
     }
@@ -556,8 +558,24 @@ mod tests {
     fn logged_sender_labels_are_truncated_char_safely() {
         // multi-byte chars: byte slicing at 128 would panic mid-codepoint
         let label = "é".repeat(200);
-        let truncated = truncate_label(&label);
+        let truncated = UnexpectedSenders::truncate_label(&label);
 
-        assert_eq!(truncated.chars().count(), MAX_LOGGED_LABEL_CHARS);
+        assert_eq!(
+            truncated.chars().count(),
+            UnexpectedSenders::MAX_LOGGED_LABEL_CHARS
+        );
+    }
+
+    #[test]
+    fn unexpected_sender_log_throttle() {
+        assert!(UnexpectedSenders::should_log(1));
+        assert!(UnexpectedSenders::should_log(UnexpectedSenders::LOG_BURST));
+        assert!(!UnexpectedSenders::should_log(
+            UnexpectedSenders::LOG_BURST + 1
+        ));
+        assert!(UnexpectedSenders::should_log(UnexpectedSenders::LOG_EVERY));
+        assert!(!UnexpectedSenders::should_log(
+            UnexpectedSenders::LOG_EVERY + 1
+        ));
     }
 }

--- a/orb-jobs-agent/tests/common/fixture.rs
+++ b/orb-jobs-agent/tests/common/fixture.rs
@@ -323,6 +323,12 @@ impl JobAgentFixture {
 
         let ticket = self.job_queue.enqueue(request).await;
 
+        self.send_notify().await;
+
+        ticket
+    }
+
+    pub async fn send_notify(&self) {
         let payload = Any::from_msg(&JobNotify::default())
             .unwrap()
             .encode_to_vec();
@@ -338,8 +344,6 @@ impl JobAgentFixture {
             )
             .await
             .unwrap();
-
-        ticket
     }
 
     pub async fn cancel_job(&self, job_execution_id: impl Into<String>) {

--- a/orb-jobs-agent/tests/unauthorized_sender.rs
+++ b/orb-jobs-agent/tests/unauthorized_sender.rs
@@ -1,0 +1,225 @@
+//! The agent must reject relay messages from anything other than the configured
+//! job server, and keep serving the job server afterwards.
+
+use common::fixture::JobAgentFixture;
+use orb_jobs_agent::{
+    job_system::{ctx::JobExecutionUpdateExt, handler::JobHandler},
+    shell::Host,
+};
+use orb_relay_client::{Amount, Client, ClientOpts, QoS, SendMessage};
+use orb_relay_messages::{
+    jobs::v1::JobExecution, prost::Message, prost_types::Any, relay::entity::EntityType,
+};
+use std::{
+    fmt::{self, Write as _},
+    sync::{Arc, Mutex, OnceLock},
+    time::Duration,
+};
+use tokio::{sync::Notify, task, time};
+use tracing::{
+    field::{Field, Visit},
+    Event, Subscriber,
+};
+use tracing_subscriber::{
+    layer::{Context, SubscriberExt},
+    util::SubscriberInitExt,
+    Layer,
+};
+
+mod common;
+
+const LEGIT_CMD: &str = "ping";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn rejects_job_execution_from_unexpected_service_id() {
+    // Arrange
+    let capture = capture();
+    let fx = JobAgentFixture::with_namespace("unauthorized_sender_id").await;
+    spawn_agent(&fx);
+
+    let attacker = attacker_client(&fx, "unexpected-service", EntityType::Service);
+
+    // Act
+    send_job_execution(&attacker, &fx, "exec-unexpected-service").await;
+    // positive agent-side signal: it saw the message and rejected the sender
+    capture.wait_for_rejection(&["unexpected-service"]).await;
+
+    let legit = fx.enqueue_job(LEGIT_CMD).await;
+    time::timeout(Duration::from_secs(60), legit.wait_for_completion())
+        .await
+        .expect("legit job never completed");
+
+    // Assert: the rejected job never ran; the agent kept serving the server
+    assert_only_legit_updates(&fx, &legit.exec_id).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn rejects_job_execution_from_job_server_id_with_wrong_entity_type() {
+    // Arrange
+    let capture = capture();
+    let fx = JobAgentFixture::with_namespace("unauthorized_sender_type").await;
+    spawn_agent(&fx);
+
+    // same id and namespace as the job server, so only the entity type differs
+    // (a distinct relay routing key, so the fixture's own client stays connected)
+    let attacker =
+        attacker_client(&fx, &fx.settings.target_service_id, EntityType::App);
+
+    // Act
+    send_job_execution(&attacker, &fx, "exec-wrong-entity-type").await;
+    capture
+        .wait_for_rejection(&[&fx.settings.target_service_id, "App"])
+        .await;
+
+    let legit = fx.enqueue_job(LEGIT_CMD).await;
+    time::timeout(Duration::from_secs(60), legit.wait_for_completion())
+        .await
+        .expect("legit job never completed");
+
+    // Assert: the rejected job never ran; the agent kept serving the server
+    assert_only_legit_updates(&fx, &legit.exec_id).await;
+}
+
+fn spawn_agent(fx: &JobAgentFixture) {
+    let deps = fx.deps(Host);
+
+    task::spawn(
+        JobHandler::builder()
+            .parallel(LEGIT_CMD, async |ctx| Ok(ctx.success().stdout("pong")))
+            .build(deps)
+            .run(),
+    );
+}
+
+/// A second relay client, mirroring the fixture's own `ClientOpts`.
+fn attacker_client(fx: &JobAgentFixture, id: &str, entity_type: EntityType) -> Client {
+    let opts = ClientOpts::entity(entity_type)
+        .id(id.to_string())
+        .namespace(fx.settings.relay_namespace.clone())
+        .endpoint(fx.settings.relay_host.clone())
+        .auth(fx.settings.auth.clone())
+        .max_connection_attempts(Amount::Val(3))
+        .connection_timeout(Duration::from_secs(1))
+        .heartbeat(Duration::from_secs(u64::MAX))
+        .ack_timeout(Duration::from_secs(1))
+        .build();
+
+    let (client, _handle) = Client::connect(opts);
+
+    client
+}
+
+async fn send_job_execution(
+    client: &Client,
+    fx: &JobAgentFixture,
+    job_execution_id: &str,
+) {
+    let job = JobExecution {
+        job_id: LEGIT_CMD.to_string(),
+        job_execution_id: job_execution_id.to_string(),
+        job_document: LEGIT_CMD.to_string(),
+        should_cancel: false,
+    };
+
+    // the fixture relay decodes every payload as `Any` and panics otherwise
+    let payload = Any::from_msg(&job).unwrap().encode_to_vec();
+
+    // bounded so a broken relay ack fails the test instead of hanging it
+    time::timeout(
+        Duration::from_secs(30),
+        client.send(
+            SendMessage::to(EntityType::Orb)
+                .id(fx.settings.orb_id.to_string())
+                .namespace(&fx.settings.relay_namespace)
+                .qos(QoS::AtLeastOnce)
+                .payload(payload),
+        ),
+    )
+    .await
+    .expect("relay send timed out")
+    .unwrap();
+}
+
+/// Proves the agent reported only the job server's job -- and, since the legit
+/// job ran after the rejection, that it kept listening.
+async fn assert_only_legit_updates(fx: &JobAgentFixture, legit_exec_id: &str) {
+    let updates = fx.execution_updates.read().await;
+
+    assert!(
+        !updates.is_empty()
+            && updates.iter().all(|u| u.job_execution_id == legit_exec_id),
+        "agent acted on a job from an unexpected sender: {updates:?}"
+    );
+    assert!(updates.iter().any(|u| u.std_out == "pong"));
+}
+
+/// Captured `tracing` events, used to observe the agent rejecting a sender.
+#[derive(Default)]
+struct Capture {
+    events: Mutex<Vec<String>>,
+    pushed: Notify,
+}
+
+impl Capture {
+    /// Waits until an event containing every `needle` is captured. Bounded, so a
+    /// missing rejection fails the test instead of hanging it.
+    async fn wait_for_rejection(&self, needles: &[&str]) {
+        let wait = time::timeout(Duration::from_secs(30), async {
+            loop {
+                // registered before the check so a concurrent push is not missed
+                let pushed = self.pushed.notified();
+
+                if self.events.lock().unwrap().iter().any(|e| {
+                    e.contains("unexpected sender")
+                        && needles.iter().all(|n| e.contains(n))
+                }) {
+                    return;
+                }
+
+                pushed.await;
+            }
+        });
+
+        assert!(
+            wait.await.is_ok(),
+            "agent never logged a rejection matching {needles:?}"
+        );
+    }
+}
+
+/// The global subscriber can only be installed once per test binary, and the
+/// cases in this file share it. `fixture::init_tracing` is deliberately not used:
+/// it installs the orb-telemetry subscriber instead.
+fn capture() -> &'static Arc<Capture> {
+    static CAPTURE: OnceLock<Arc<Capture>> = OnceLock::new();
+
+    CAPTURE.get_or_init(|| {
+        let capture = Arc::new(Capture::default());
+
+        tracing_subscriber::registry()
+            .with(CaptureLayer(capture.clone()))
+            .init();
+
+        capture
+    })
+}
+
+struct CaptureLayer(Arc<Capture>);
+
+impl<S: Subscriber> Layer<S> for CaptureLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut fields = String::new();
+        event.record(&mut FieldWriter(&mut fields));
+
+        self.0.events.lock().unwrap().push(fields);
+        self.0.pushed.notify_waiters();
+    }
+}
+
+struct FieldWriter<'a>(&'a mut String);
+
+impl Visit for FieldWriter<'_> {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        let _ = write!(self.0, "{}={:?} ", field.name(), value);
+    }
+}

--- a/orb-jobs-agent/tests/unauthorized_sender.rs
+++ b/orb-jobs-agent/tests/unauthorized_sender.rs
@@ -80,6 +80,36 @@ async fn rejects_job_execution_from_job_server_id_with_wrong_entity_type() {
     assert_only_legit_updates(&fx, &legit.exec_id).await;
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn job_notify_flow_survives_rejected_job_execution() {
+    let capture = capture();
+    let fx = JobAgentFixture::with_namespace("rejection_then_notify").await;
+    spawn_agent(&fx);
+
+    let attacker =
+        attacker_client(&fx, "unexpected-service-before-notify", EntityType::Service);
+    send_job_execution(&attacker, &fx, "exec-before-notify").await;
+    capture
+        .wait_for_rejection(&["unexpected-service-before-notify"])
+        .await;
+
+    let legit = fx
+        .job_queue
+        .enqueue(JobExecution {
+            job_id: LEGIT_CMD.to_string(),
+            job_execution_id: "exec-after-rejection".to_string(),
+            job_document: LEGIT_CMD.to_string(),
+            should_cancel: false,
+        })
+        .await;
+    fx.send_notify().await;
+    time::timeout(Duration::from_secs(60), legit.wait_for_completion())
+        .await
+        .expect("legit job never completed");
+
+    assert_only_legit_updates(&fx, &legit.exec_id).await;
+}
+
 fn spawn_agent(fx: &JobAgentFixture) {
     let deps = fx.deps(Host);
 


### PR DESCRIPTION
The jobs agent dispatched relay `JobNotify`/`JobExecution`/`JobCancel` without checking `msg.from` — any relay entity that can address the Orb in the jobs namespace could run privileged jobs or cancel live ones.

Fix: new `is_authorized_sender` (Service + configured `target_service_id` + configured `relay_namespace`) evaluated before any payload decode; anything else is dropped with a bounded, escaped rejection log (payload never logged). Fleet-safety basis: the relay routes by identity triple and a client sends with the identity it connected as, so the job-server provably owns the configured triple — otherwise the agent's own `JobRequestNext` would never reach it today. Sender-label authenticity itself is relay-server work (SEC-2708).

Tests: authorization matrix + payload classification units; adversarial integration tests (second relay client as `unexpected-service`, and `fleet-cmdr` with the wrong entity type) assert the rejection log fires, the rejected job never runs, and the agent keeps serving the legitimate server. Full suite green natively.

Mitigates: VULN-6325 (fixed); external disclosure report (Sep 2026), sender-validation finding. Complements SEC-2708.
