### PR TITLE
fix(orb-connd): nm state cleanup

### DIFF
--- a/orb-connd/debian/worldcoin-connd.service
+++ b/orb-connd/debian/worldcoin-connd.service
@@ -20,6 +20,11 @@ SupplementaryGroups=worldcoin-dbus netdev tee
 Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/tmp/worldcoin_bus_socket
 Environment=RUST_BACKTRACE=1
 SyslogIdentifier=worldcoin-connd
+# NetworkManager creates these directories as root:root 0700. Repair directory
+# access before each start so connd can measure state and remove stale leases.
+# Keep file ownership and modes intact, including credentials and secret_key.
+ExecStartPre=+/usr/bin/install -d -o root -g orb-connd -m 0750 /usr/persistent/network-manager /usr/persistent/network-manager/connections
+ExecStartPre=+/usr/bin/install -d -o root -g orb-connd -m 0770 /usr/persistent/network-manager/varlib
 ExecStart=/usr/local/bin/orb-connd
 Restart=always
 RestartSec=3

--- a/orb-connd/src/service/mod.rs
+++ b/orb-connd/src/service/mod.rs
@@ -27,6 +27,7 @@ use wpa_conf::LegacyWpaConfig;
 mod dbus;
 mod mecard;
 mod netconfig;
+mod nm_state;
 mod wifi;
 mod wpa_conf;
 pub mod zoci;
@@ -76,7 +77,7 @@ impl ConndService {
     const DEFAULT_WIFI_PSK: &str = "easytotypehardtoguess";
     const DEFAULT_WIFI_IFACE: &str = "wlan0";
     const MAGIC_QR_TIMESPAN_MIN: i64 = 10;
-    const NM_STATE_MAX_SIZE_KB: u64 = 1024;
+    const NM_STATE_MAX_SIZE_BYTES: u64 = 1024 * 1024;
     const SECURE_STORAGE_KEY: &str = "nmprofiles";
 
     #[allow(clippy::too_many_arguments)]
@@ -369,60 +370,43 @@ impl ConndService {
         Ok(())
     }
 
-    /// returns true if anything was deleted because state was too big
     pub async fn ensure_nm_state_below_max_size(
         &self,
         usr_persistent: impl AsRef<Path>,
     ) -> Result<()> {
         let nm_dir = usr_persistent.as_ref().join(Self::NM_FOLDER);
-        let dir_size_kib = async || -> Result<u64> {
-            let mut total_bytes = 0u64;
-            let mut stack = vec![nm_dir.clone()];
-
-            while let Some(dir) = stack.pop() {
-                let mut dir = fs::read_dir(&dir).await?;
-
-                while let Some(e) = dir.next_entry().await? {
-                    let ft = e.file_type().await?;
-
-                    if ft.is_file() {
-                        total_bytes += e.metadata().await?.len();
-                    } else if ft.is_dir() {
-                        stack.push(e.path());
-                    }
-                }
-            }
-
-            Ok(total_bytes / 1024)
-        };
-
-        let get_state_size = async || -> Result<u64> {
-            let dir_size = dir_size_kib().await?;
-            let ss_size = match &self.profile_storage {
-            ProfileStorage::NetworkManager => 0,
-            ProfileStorage::SecureStorage(ss) => ss
-                .get(Self::SECURE_STORAGE_KEY.to_owned())
-                .await
-                .inspect_err(|e| error!("failed to read from secure storage when trying to calculate size: {e}"))
-                .ok()
-                .flatten()
-                .map(|bytes|bytes.len() / 1024)
-                .unwrap_or_default() as u64,
-            };
-
-            Ok(dir_size + ss_size)
-        };
-
-        let state_size = get_state_size().await?;
-        if state_size < Self::NM_STATE_MAX_SIZE_KB {
-            info!("{nm_dir:?} plus SecureStorage-{} is below 1024KiB. current size {state_size}KiB", Self::SECURE_STORAGE_KEY);
+        let state_size = self.nm_state_size(&nm_dir).await?;
+        if state_size < Self::NM_STATE_MAX_SIZE_BYTES {
             return Ok(());
         }
 
-        warn!("{nm_dir:?} plus SecureStorage-{} is above 1024KiB. current size {state_size}KiB. attempting to reduce size", Self::SECURE_STORAGE_KEY);
+        warn!(
+            path = %nm_dir.display(),
+            state_bytes = state_size,
+            max_bytes = Self::NM_STATE_MAX_SIZE_BYTES,
+            "NM state exceeds limit; removing DHCP leases and seen-bssids"
+        );
+
+        // A partial cleanup must not fall through to deleting saved networks.
+        nm_state::remove_disposable_files(&nm_dir.join("varlib")).await?;
+        let state_size = self.nm_state_size(&nm_dir).await?;
+        if state_size < Self::NM_STATE_MAX_SIZE_BYTES {
+            return Ok(());
+        }
+
+        warn!(
+            path = %nm_dir.display(),
+            state_bytes = state_size,
+            max_bytes = Self::NM_STATE_MAX_SIZE_BYTES,
+            "NM state still exceeds limit after file cleanup; removing excess Wi-Fi profiles"
+        );
 
         // remove excess wifi profiles
-        let mut wifi_profiles = self.nm.list_wifi_profiles().await?;
+        let mut wifi_profiles = self
+            .nm
+            .list_wifi_profiles()
+            .await
+            .wrap_err("failed to list Wi-Fi profiles during NM state cleanup")?;
         wifi_profiles.sort_by_key(|p| p.priority);
 
         let profiles_to_keep = 2;
@@ -433,43 +417,45 @@ impl ConndService {
                 continue;
             }
 
-            self.nm.remove_profile(&profile.id).await?;
+            self.nm
+                .remove_profile(&profile.uuid)
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed to remove NM profile {} during cleanup",
+                        profile.uuid
+                    )
+                })?;
         }
 
-        self.commit_profiles_to_storage().await?;
+        self.commit_profiles_to_storage()
+            .await
+            .wrap_err("failed to persist Wi-Fi profiles after NM state cleanup")?;
 
-        // remove dhcp leases and seen-bssids
-        let varlib = usr_persistent.as_ref().join(Self::NM_FOLDER).join("varlib");
-
-        let seen_bssids = varlib.join("seen-bssids");
-        let mut to_delete = vec![seen_bssids];
-
-        let mut varlib = fs::read_dir(&varlib).await?;
-        while let Some(entry) = varlib.next_entry().await? {
-            let ft = entry.file_type().await?;
-            if !ft.is_file() {
-                continue;
-            }
-
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "lease") {
-                to_delete.push(path);
-            }
-        }
-
-        for filepath in to_delete {
-            fs::remove_file(filepath).await?;
-        }
-
-        let dir_size = get_state_size().await?;
-        if dir_size < Self::NM_STATE_MAX_SIZE_KB {
-            info!("successfully reduced nm state size to {dir_size}kB");
+        let state_size = self.nm_state_size(&nm_dir).await?;
+        if state_size < Self::NM_STATE_MAX_SIZE_BYTES {
             Ok(())
         } else {
             Err(eyre!(
-                "directory too big even after wiping files. size: {dir_size}kB"
+                "NM state at {} still exceeds limit after cleanup: {state_size} bytes, limit {} bytes",
+                nm_dir.display(),
+                Self::NM_STATE_MAX_SIZE_BYTES,
             ))
         }
+    }
+
+    async fn nm_state_size(&self, nm_dir: &Path) -> Result<u64> {
+        let allocated_bytes = nm_state::allocated_size(nm_dir).await?;
+        let stored_bytes = match &self.profile_storage {
+            ProfileStorage::NetworkManager => 0,
+            ProfileStorage::SecureStorage(ss) => ss
+                .get(Self::SECURE_STORAGE_KEY.to_owned())
+                .await
+                .wrap_err("failed to read nmprofiles from secure storage while measuring NM state")?
+                .map_or(0, |bytes| bytes.len() as u64),
+        };
+
+        Ok(allocated_bytes + stored_bytes)
     }
 
     async fn connect_to_wifi(&self, ssid: &str) -> Result<AccessPoint> {

--- a/orb-connd/src/service/mod.rs
+++ b/orb-connd/src/service/mod.rs
@@ -375,8 +375,20 @@ impl ConndService {
         usr_persistent: impl AsRef<Path>,
     ) -> Result<()> {
         let nm_dir = usr_persistent.as_ref().join(Self::NM_FOLDER);
-        let state_size = self.nm_state_size(&nm_dir).await?;
+        let allocated_bytes = nm_state::allocated_size(&nm_dir).await?;
+        // Reclaim oversized local state even when secure storage is unavailable.
+        let state_size = if allocated_bytes >= Self::NM_STATE_MAX_SIZE_BYTES {
+            allocated_bytes
+        } else {
+            allocated_bytes + self.stored_profile_size().await?
+        };
         if state_size < Self::NM_STATE_MAX_SIZE_BYTES {
+            tracing::trace!(
+                "NM state at {} is below limit ({state_size} bytes < {} bytes); skipping cleanup",
+                nm_dir.display(),
+                Self::NM_STATE_MAX_SIZE_BYTES,
+            );
+
             return Ok(());
         }
 
@@ -384,13 +396,21 @@ impl ConndService {
             path = %nm_dir.display(),
             state_bytes = state_size,
             max_bytes = Self::NM_STATE_MAX_SIZE_BYTES,
-            "NM state exceeds limit; removing DHCP leases and seen-bssids"
+            "NM state at {} exceeds limit ({state_size} bytes >= {} bytes); removing DHCP leases and seen-bssids",
+            nm_dir.display(),
+            Self::NM_STATE_MAX_SIZE_BYTES,
         );
 
         // A partial cleanup must not fall through to deleting saved networks.
         nm_state::remove_disposable_files(&nm_dir.join("varlib")).await?;
         let state_size = self.nm_state_size(&nm_dir).await?;
         if state_size < Self::NM_STATE_MAX_SIZE_BYTES {
+            tracing::trace!(
+                "NM state cleanup at {} succeeded after removing disposable files ({state_size} bytes < {} bytes); keeping saved Wi-Fi profiles",
+                nm_dir.display(),
+                Self::NM_STATE_MAX_SIZE_BYTES,
+            );
+
             return Ok(());
         }
 
@@ -398,7 +418,9 @@ impl ConndService {
             path = %nm_dir.display(),
             state_bytes = state_size,
             max_bytes = Self::NM_STATE_MAX_SIZE_BYTES,
-            "NM state still exceeds limit after file cleanup; removing excess Wi-Fi profiles"
+            "NM state at {} still exceeds limit after file cleanup ({state_size} bytes >= {} bytes); removing excess Wi-Fi profiles",
+            nm_dir.display(),
+            Self::NM_STATE_MAX_SIZE_BYTES,
         );
 
         // remove excess wifi profiles
@@ -434,6 +456,12 @@ impl ConndService {
 
         let state_size = self.nm_state_size(&nm_dir).await?;
         if state_size < Self::NM_STATE_MAX_SIZE_BYTES {
+            tracing::trace!(
+                "NM state cleanup at {} succeeded after removing excess Wi-Fi profiles ({state_size} bytes < {} bytes)",
+                nm_dir.display(),
+                Self::NM_STATE_MAX_SIZE_BYTES,
+            );
+
             Ok(())
         } else {
             Err(eyre!(
@@ -446,6 +474,11 @@ impl ConndService {
 
     async fn nm_state_size(&self, nm_dir: &Path) -> Result<u64> {
         let allocated_bytes = nm_state::allocated_size(nm_dir).await?;
+
+        Ok(allocated_bytes + self.stored_profile_size().await?)
+    }
+
+    async fn stored_profile_size(&self) -> Result<u64> {
         let stored_bytes = match &self.profile_storage {
             ProfileStorage::NetworkManager => 0,
             ProfileStorage::SecureStorage(ss) => ss
@@ -455,7 +488,7 @@ impl ConndService {
                 .map_or(0, |bytes| bytes.len() as u64),
         };
 
-        Ok(allocated_bytes + stored_bytes)
+        Ok(stored_bytes)
     }
 
     async fn connect_to_wifi(&self, ssid: &str) -> Result<AccessPoint> {

--- a/orb-connd/src/service/nm_state.rs
+++ b/orb-connd/src/service/nm_state.rs
@@ -1,0 +1,258 @@
+use color_eyre::eyre::{ensure, Context, Result};
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use tokio::{fs, io};
+
+pub(super) async fn allocated_size(root: &Path) -> Result<u64> {
+    let metadata = fs::symlink_metadata(root).await.wrap_err_with(|| {
+        format!("failed to inspect NM state directory {}", root.display())
+    })?;
+    ensure!(
+        metadata.is_dir(),
+        "NM state path is not a directory: {}",
+        root.display()
+    );
+
+    let mut allocated_bytes = metadata.blocks() * 512;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        let mut entries = match fs::read_dir(&path).await {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound && path != root => continue,
+            Err(e) => {
+                return Err(e).wrap_err_with(|| {
+                    format!("failed to read NM state directory {}", path.display())
+                });
+            }
+        };
+
+        while let Some(entry) = entries.next_entry().await.wrap_err_with(|| {
+            format!("failed to enumerate NM state directory {}", path.display())
+        })? {
+            let metadata = match entry.metadata().await {
+                Ok(metadata) => metadata,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+                Err(e) => {
+                    return Err(e).wrap_err_with(|| {
+                        format!(
+                            "failed to inspect NM state entry {}",
+                            entry.path().display()
+                        )
+                    });
+                }
+            };
+
+            if metadata.is_file() || metadata.is_dir() {
+                allocated_bytes += metadata.blocks() * 512;
+            }
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            }
+        }
+    }
+
+    Ok(allocated_bytes)
+}
+
+pub(super) async fn remove_disposable_files(varlib: &Path) -> Result<()> {
+    let metadata = match fs::symlink_metadata(varlib).await {
+        Ok(metadata) => metadata,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(e) => {
+            return Err(e).wrap_err_with(|| {
+                format!("failed to inspect NM lease directory {}", varlib.display())
+            });
+        }
+    };
+    ensure!(
+        metadata.is_dir(),
+        "NM lease path is not a directory: {}",
+        varlib.display()
+    );
+
+    let mut entries = fs::read_dir(varlib).await.wrap_err_with(|| {
+        format!("failed to read NM lease directory {}", varlib.display())
+    })?;
+    let mut to_delete = Vec::new();
+    while let Some(entry) = entries.next_entry().await.wrap_err_with(|| {
+        format!(
+            "failed to enumerate NM lease directory {}",
+            varlib.display()
+        )
+    })? {
+        let path = entry.path();
+        if entry.file_name() != "seen-bssids"
+            && !path.extension().is_some_and(|ext| ext == "lease")
+        {
+            continue;
+        }
+        let file_type = match entry.file_type().await {
+            Ok(file_type) => file_type,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(e).wrap_err_with(|| {
+                    format!("failed to inspect NM disposable file {}", path.display())
+                });
+            }
+        };
+        if file_type.is_file() {
+            to_delete.push(path);
+        }
+    }
+
+    remove_files(to_delete).await
+}
+
+async fn remove_files(paths: Vec<PathBuf>) -> Result<()> {
+    let mut first_error = None;
+    let mut failed = 0;
+    let mut removed = 0;
+    for path in paths {
+        match fs::remove_file(&path).await {
+            Ok(()) => removed += 1,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => (),
+            Err(e) => {
+                failed += 1;
+                first_error.get_or_insert_with(|| {
+                    color_eyre::Report::from(e).wrap_err(format!(
+                        "failed to remove NM state file {}",
+                        path.display()
+                    ))
+                });
+            }
+        }
+    }
+
+    if let Some(error) = first_error {
+        return Err(error.wrap_err(format!(
+            "partial NM state cleanup: {removed} files removed, {failed} deletions failed"
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_tempfile::TempDir;
+
+    #[tokio::test]
+    async fn it_counts_allocated_space_without_following_symlinks() {
+        let dir = TempDir::new().await.unwrap();
+        let state = dir.join("state");
+        fs::create_dir(&state).await.unwrap();
+        fs::write(state.join("small.lease"), [1; 4097])
+            .await
+            .unwrap();
+        let allocated = allocated_size(&state).await.unwrap();
+        assert!(allocated > 4097);
+
+        let outside = dir.join("outside");
+        fs::create_dir(&outside).await.unwrap();
+        fs::write(outside.join("large"), vec![1; 2 * 1024 * 1024])
+            .await
+            .unwrap();
+        fs::symlink(&outside, state.join("linked-directory"))
+            .await
+            .unwrap();
+        fs::symlink(outside.join("large"), state.join("linked-file"))
+            .await
+            .unwrap();
+
+        // Directory allocation can grow when adding entries; the target must not count.
+        assert!(allocated_size(&state).await.unwrap() < 1024 * 1024);
+    }
+
+    #[tokio::test]
+    async fn it_removes_leases_without_seen_bssids_and_preserves_other_state() {
+        let dir = TempDir::new().await.unwrap();
+        for name in [
+            "old.lease",
+            "secret_key",
+            "NetworkManager.state",
+            "timestamps",
+        ] {
+            fs::write(dir.join(name), name).await.unwrap();
+        }
+        let nested = dir.join("nested");
+        fs::create_dir(&nested).await.unwrap();
+        fs::write(nested.join("keep.lease"), "keep").await.unwrap();
+        fs::symlink(dir.join("secret_key"), dir.join("linked.lease"))
+            .await
+            .unwrap();
+
+        remove_disposable_files(dir.as_ref()).await.unwrap();
+        remove_disposable_files(dir.as_ref()).await.unwrap();
+
+        assert!(!fs::try_exists(dir.join("old.lease")).await.unwrap());
+        for name in ["secret_key", "NetworkManager.state", "timestamps"] {
+            assert_eq!(fs::read_to_string(dir.join(name)).await.unwrap(), name);
+        }
+        assert_eq!(
+            fs::read_to_string(nested.join("keep.lease")).await.unwrap(),
+            "keep"
+        );
+        assert!(fs::symlink_metadata(dir.join("linked.lease"))
+            .await
+            .unwrap()
+            .is_symlink());
+
+        fs::write(dir.join("seen-bssids"), "history").await.unwrap();
+        remove_disposable_files(dir.as_ref()).await.unwrap();
+        assert!(!fs::try_exists(dir.join("seen-bssids")).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn it_handles_missing_files_and_not_aborts() {
+        let dir = TempDir::new().await.unwrap();
+        let lease = dir.join("old.lease");
+        fs::write(&lease, "lease").await.unwrap();
+
+        remove_files(vec![dir.join("already-removed.lease"), lease.clone()])
+            .await
+            .unwrap();
+
+        assert!(!fs::try_exists(lease).await.unwrap());
+        remove_disposable_files(&dir.join("missing-varlib"))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn it_reports_context_on_failure_and_continues_deletion() {
+        let dir = TempDir::new().await.unwrap();
+        let invalid = dir.join("not-a-file.lease");
+        fs::create_dir(&invalid).await.unwrap();
+        let lease = dir.join("old.lease");
+        fs::write(&lease, "lease").await.unwrap();
+
+        let error = remove_files(vec![invalid.clone(), lease.clone()])
+            .await
+            .unwrap_err();
+
+        let error = format!("{error:?}");
+        assert!(
+            error.contains("1 files removed, 1 deletions failed"),
+            "{error}"
+        );
+        assert!(error.contains("failed to remove NM state file"), "{error}");
+        assert!(error.contains(invalid.to_str().unwrap()), "{error}");
+        assert!(!fs::try_exists(lease).await.unwrap());
+        assert!(fs::try_exists(invalid).await.unwrap());
+    }
+
+    #[tokio::test]
+
+    async fn it_reports_invalid_state_dir_path() {
+        let dir = TempDir::new().await.unwrap();
+        let missing = dir.join("missing");
+        let error = allocated_size(&missing).await.unwrap_err();
+        assert!(format!("{error:?}").contains(missing.to_str().unwrap()));
+
+        let link = dir.join("linked-varlib");
+        fs::symlink(dir.as_ref(), &link).await.unwrap();
+        assert!(allocated_size(&link).await.is_err());
+        assert!(remove_disposable_files(&link).await.is_err());
+    }
+}

--- a/orb-connd/src/service/nm_state.rs
+++ b/orb-connd/src/service/nm_state.rs
@@ -139,15 +139,20 @@ mod tests {
 
     #[tokio::test]
     async fn it_counts_allocated_space_without_following_symlinks() {
+        // Arrange
         let dir = TempDir::new().await.unwrap();
         let state = dir.join("state");
         fs::create_dir(&state).await.unwrap();
         fs::write(state.join("small.lease"), [1; 4097])
             .await
             .unwrap();
+        // Act
         let allocated = allocated_size(&state).await.unwrap();
+
+        // Assert
         assert!(allocated > 4097);
 
+        // Arrange
         let outside = dir.join("outside");
         fs::create_dir(&outside).await.unwrap();
         fs::write(outside.join("large"), vec![1; 2 * 1024 * 1024])
@@ -160,12 +165,17 @@ mod tests {
             .await
             .unwrap();
 
+        // Act
+        let allocated = allocated_size(&state).await.unwrap();
+
+        // Assert
         // Directory allocation can grow when adding entries; the target must not count.
-        assert!(allocated_size(&state).await.unwrap() < 1024 * 1024);
+        assert!(allocated < 1024 * 1024);
     }
 
     #[tokio::test]
     async fn it_removes_leases_without_seen_bssids_and_preserves_other_state() {
+        // Arrange
         let dir = TempDir::new().await.unwrap();
         for name in [
             "old.lease",
@@ -182,9 +192,11 @@ mod tests {
             .await
             .unwrap();
 
+        // Act
         remove_disposable_files(dir.as_ref()).await.unwrap();
         remove_disposable_files(dir.as_ref()).await.unwrap();
 
+        // Assert
         assert!(!fs::try_exists(dir.join("old.lease")).await.unwrap());
         for name in ["secret_key", "NetworkManager.state", "timestamps"] {
             assert_eq!(fs::read_to_string(dir.join(name)).await.unwrap(), name);
@@ -198,39 +210,50 @@ mod tests {
             .unwrap()
             .is_symlink());
 
+        // Arrange
         fs::write(dir.join("seen-bssids"), "history").await.unwrap();
+
+        // Act
         remove_disposable_files(dir.as_ref()).await.unwrap();
+
+        // Assert
         assert!(!fs::try_exists(dir.join("seen-bssids")).await.unwrap());
     }
 
     #[tokio::test]
     async fn it_handles_missing_files_and_not_aborts() {
+        // Arrange
         let dir = TempDir::new().await.unwrap();
         let lease = dir.join("old.lease");
         fs::write(&lease, "lease").await.unwrap();
 
+        // Act
         remove_files(vec![dir.join("already-removed.lease"), lease.clone()])
             .await
             .unwrap();
-
-        assert!(!fs::try_exists(lease).await.unwrap());
         remove_disposable_files(&dir.join("missing-varlib"))
             .await
             .unwrap();
+
+        // Assert
+        assert!(!fs::try_exists(lease).await.unwrap());
     }
 
     #[tokio::test]
     async fn it_reports_context_on_failure_and_continues_deletion() {
+        // Arrange
         let dir = TempDir::new().await.unwrap();
         let invalid = dir.join("not-a-file.lease");
         fs::create_dir(&invalid).await.unwrap();
         let lease = dir.join("old.lease");
         fs::write(&lease, "lease").await.unwrap();
 
+        // Act
         let error = remove_files(vec![invalid.clone(), lease.clone()])
             .await
             .unwrap_err();
 
+        // Assert
         let error = format!("{error:?}");
         assert!(
             error.contains("1 files removed, 1 deletions failed"),
@@ -245,14 +268,26 @@ mod tests {
     #[tokio::test]
 
     async fn it_reports_invalid_state_dir_path() {
+        // Arrange
         let dir = TempDir::new().await.unwrap();
         let missing = dir.join("missing");
+
+        // Act
         let error = allocated_size(&missing).await.unwrap_err();
+
+        // Assert
         assert!(format!("{error:?}").contains(missing.to_str().unwrap()));
 
+        // Arrange
         let link = dir.join("linked-varlib");
         fs::symlink(dir.as_ref(), &link).await.unwrap();
-        assert!(allocated_size(&link).await.is_err());
-        assert!(remove_disposable_files(&link).await.is_err());
+
+        // Act
+        let size_result = allocated_size(&link).await;
+        let cleanup_result = remove_disposable_files(&link).await;
+
+        // Assert
+        assert!(size_result.is_err());
+        assert!(cleanup_result.is_err());
     }
 }

--- a/orb-connd/tests/fixture.rs
+++ b/orb-connd/tests/fixture.rs
@@ -65,11 +65,11 @@ pub struct FxHandle {
     zenorb: Zenorb,
     zenoh_router_socket: PathBuf,
 
-    dbus: zbus::Connection,
+    pub dbus: zbus::Connection,
     pub nm: NetworkManager,
 
     pub secure_storage: SecureStorage,
-    secure_storage_cancel_token: CancellationToken,
+    pub secure_storage_cancel_token: CancellationToken,
 
     pub dogstatsd: Agent,
     dogstatsd_tempdir: TempDir,

--- a/orb-connd/tests/profile_management.rs
+++ b/orb-connd/tests/profile_management.rs
@@ -3,11 +3,12 @@ use fixture::Fixture;
 use futures::TryStreamExt;
 use orb_connd::{
     network_manager::{WifiProfile, WifiSec},
-    service::zoci::WifiProfileDto,
+    service::{zoci::WifiProfileDto, ConndService, ProfileStorage},
     OrbCapabilities,
 };
 use orb_info::orb_os_release::{OrbOsPlatform, OrbRelease};
 use serde_json::json;
+use std::time::Duration;
 use tokio::fs;
 use tokio_stream::wrappers::ReadDirStream;
 use zenorb::zoci::ReplyExt;
@@ -252,6 +253,7 @@ async fn it_wipes_dhcp_leases_and_seen_bssids_if_too_big() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn it_cleans_allocated_lease_space_without_deleting_saved_profiles() {
+    // Arrange
     let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
         .release(OrbRelease::Prod)
         .build()
@@ -290,6 +292,7 @@ async fn it_cleans_allocated_lease_space_without_deleting_saved_profiles() {
         .await
         .unwrap();
 
+    // Act
     let handle = fx
         .run_with()
         .secure_storage(secure_storage)
@@ -297,6 +300,7 @@ async fn it_cleans_allocated_lease_space_without_deleting_saved_profiles() {
         .call()
         .await;
 
+    // Assert
     let nm_profiles = handle.nm.list_wifi_profiles().await.unwrap();
     assert_eq!(nm_profiles.len(), profiles.len() + 1);
     for profile in &profiles {
@@ -323,6 +327,102 @@ async fn it_cleans_allocated_lease_space_without_deleting_saved_profiles() {
         fs::read_to_string(varlib.join("secret_key")).await.unwrap(),
         "preserve-identity"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_cleans_leases_without_evicting_profiles_when_secure_storage_fails() {
+    // Arrange
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
+        .release(OrbRelease::Prod)
+        .build()
+        .await;
+    let handle = fx.run().await;
+    for n in 0..4 {
+        handle
+            .zenoh()
+            .command(
+                "connd/job/wifi_add",
+                json!({
+                    "ssid": format!("saved-{n}"),
+                    "sec": "Wpa2Psk",
+                    "pwd": "1234567890"
+                }),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+    }
+
+    let connd = ConndService::new(
+        handle.dbus.clone(),
+        handle.nm.clone(),
+        OrbRelease::Prod,
+        OrbCapabilities::WifiOnly,
+        Duration::from_secs(1),
+        &fx.usr_persistent,
+        ProfileStorage::SecureStorage(handle.secure_storage.clone()),
+    )
+    .await
+    .unwrap();
+    let mut before: Vec<_> = handle
+        .nm
+        .list_wifi_profiles()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.uuid)
+        .collect();
+    before.sort();
+    assert_eq!(before.len(), 5);
+
+    handle.secure_storage_cancel_token.cancel();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while handle.secure_storage.get("nmprofiles".into()).await.is_ok() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("stopped secure storage must return an error");
+
+    let varlib = fx.usr_persistent.join("network-manager").join("varlib");
+    fs::create_dir_all(&varlib).await.unwrap();
+    let lease = varlib.join("old.lease");
+    fs::write(&lease, vec![1; 2 * 1024 * 1024]).await.unwrap();
+    // Keep local state above the limit after lease deletion to exercise the
+    // guard against profile eviction when secure storage cannot be measured.
+    let other_state = varlib.join("NetworkManager.state");
+    fs::write(&other_state, vec![1; 2 * 1024 * 1024])
+        .await
+        .unwrap();
+
+    // Act
+    let error = tokio::time::timeout(
+        Duration::from_secs(5),
+        connd.ensure_nm_state_below_max_size(&fx.usr_persistent),
+    )
+    .await
+    .expect("local cleanup must finish despite the secure-storage failure")
+    .unwrap_err();
+
+    // Assert
+    assert!(
+        format!("{error:?}").contains("failed to read nmprofiles from secure storage")
+    );
+    assert!(!fs::try_exists(&lease).await.unwrap());
+    assert_eq!(
+        fs::read(&other_state).await.unwrap(),
+        vec![1; 2 * 1024 * 1024]
+    );
+    let mut after: Vec<_> = handle
+        .nm
+        .list_wifi_profiles()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|p| p.uuid)
+        .collect();
+    after.sort();
+    assert_eq!(before, after);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/orb-connd/tests/profile_management.rs
+++ b/orb-connd/tests/profile_management.rs
@@ -2,7 +2,9 @@
 use fixture::Fixture;
 use futures::TryStreamExt;
 use orb_connd::{
-    network_manager::WifiSec, service::zoci::WifiProfileDto, OrbCapabilities,
+    network_manager::{WifiProfile, WifiSec},
+    service::zoci::WifiProfileDto,
+    OrbCapabilities,
 };
 use orb_info::orb_os_release::{OrbOsPlatform, OrbRelease};
 use serde_json::json;
@@ -246,6 +248,81 @@ async fn it_wipes_dhcp_leases_and_seen_bssids_if_too_big() {
     }
 
     assert!(dir.is_empty())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn it_cleans_allocated_lease_space_without_deleting_saved_profiles() {
+    let mut fx = Fixture::platform(OrbOsPlatform::Diamond)
+        .release(OrbRelease::Prod)
+        .build()
+        .await;
+
+    let profiles: Vec<_> = (0..4)
+        .map(|n| WifiProfile {
+            id: format!("saved-{n}"),
+            uuid: uuid::Uuid::new_v4().to_string(),
+            ssid: format!("saved-{n}"),
+            sec: WifiSec::Wpa2Psk,
+            psk: "1234567890".into(),
+            autoconnect: true,
+            priority: n,
+            hidden: false,
+            path: String::new(),
+        })
+        .collect();
+    let mut bytes = Vec::new();
+    ciborium::ser::into_writer(&profiles, &mut bytes).unwrap();
+    let (secure_storage, secure_storage_cancel_token) = fx.run_secure_storage().await;
+    secure_storage
+        .put("nmprofiles".into(), bytes)
+        .await
+        .unwrap();
+
+    let varlib = fx.usr_persistent.join("network-manager").join("varlib");
+    fs::create_dir_all(&varlib).await.unwrap();
+    // Contents total less than 1 MiB, but their allocated space exceeds the limit.
+    for n in 0..160 {
+        fs::write(varlib.join(format!("{n}.lease")), [1; 4097])
+            .await
+            .unwrap();
+    }
+    fs::write(varlib.join("secret_key"), "preserve-identity")
+        .await
+        .unwrap();
+
+    let handle = fx
+        .run_with()
+        .secure_storage(secure_storage)
+        .secure_storage_cancel_token(secure_storage_cancel_token)
+        .call()
+        .await;
+
+    let nm_profiles = handle.nm.list_wifi_profiles().await.unwrap();
+    assert_eq!(nm_profiles.len(), profiles.len() + 1);
+    for profile in &profiles {
+        assert!(nm_profiles.iter().any(|p| p.ssid == profile.ssid));
+    }
+    let bytes = handle
+        .secure_storage
+        .get("nmprofiles".into())
+        .await
+        .unwrap()
+        .unwrap();
+    let stored: Vec<WifiProfile> = ciborium::de::from_reader(bytes.as_slice()).unwrap();
+    assert_eq!(stored.len(), profiles.len() + 1);
+    for profile in &profiles {
+        assert!(stored.iter().any(|p| p.ssid == profile.ssid));
+    }
+
+    for n in 0..160 {
+        assert!(!fs::try_exists(varlib.join(format!("{n}.lease")))
+            .await
+            .unwrap());
+    }
+    assert_eq!(
+        fs::read_to_string(varlib.join("secret_key")).await.unwrap(),
+        "preserve-identity"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]


### PR DESCRIPTION
orb-connd runs as orb-connd (sorry), but `NetworkManager` creates its persistent directories as `root:root 0700.` This caused startup cleanup to fail with `Permissiondenied`, allowing lease files to accumulate.

This change:

  - Repairs directory permissions before each connd start, preserving individual file ownership and modes. ( we kinda do the same in attest)
  - Measures allocated disk space rather than file contents.
  - Removes leases and seen-bssids before considering saved-profile eviction.
  - Tolerates missing files and does not fail on that

Filesystem operations are extracted into `nm_state.rs` but feel free to argue that it shouldn't.