### PR TITLE
fix: dont try to run flashing rig service if it is not there

### DIFF
--- a/nix/machines/orb-mini-runner.nix
+++ b/nix/machines/orb-mini-runner.nix
@@ -26,6 +26,12 @@ let
   ++ lib.optional config.worldcoin.jenkinsAgent.enable "jenkins-agent-user";
 in
 {
+  options.worldcoin.flashingRig.enable = lib.mkOption {
+    type = lib.types.bool;
+    default = false;
+    description = "Whether to run the QDL flashing rig service on this HIL.";
+  };
+
   config = lib.mkIf (config.worldcoin.orbPlatform == "mini") {
     services.displayManager.autoLogin = {
       enable = true;
@@ -73,7 +79,7 @@ in
       ];
     });
 
-    systemd.user.services.flashing-rig = {
+    systemd.user.services.flashing-rig = lib.mkIf config.worldcoin.flashingRig.enable {
       description = "QDL Flashing Rig";
       after = [ "graphical-session.target" ];
       wants = [ "graphical-session.target" ];

--- a/nix/machines/worldcoin-hil-munich-1/configuration.nix
+++ b/nix/machines/worldcoin-hil-munich-1/configuration.nix
@@ -19,6 +19,7 @@
 
   worldcoin.orbId = "muc1mini";
   worldcoin.orbPlatform = "mini";
+  worldcoin.flashingRig.enable = true;
 
   environment.etc."worldcoin/orb.yaml" = {
     text = ''


### PR DESCRIPTION
All orb-hils are trying to start flashing-rig service, even if it is not installed on the device, that creates noise in the log.

<img width="2874" height="106" alt="image" src="https://github.com/user-attachments/assets/abf761a0-04ce-41b1-bbd6-ca31c07c1ff2" />

Make the `flashing-rig` service conditional and only enable it where it is needed.

