### PR TITLE
fix(connd): advertise BLE device as Orb

### DIFF
--- a/orb-connd/src/ble/mod.rs
+++ b/orb-connd/src/ble/mod.rs
@@ -113,7 +113,7 @@ pub async fn advertiser(ctx: mini::Ctx<Args>) -> Result<()> {
 
                 let advertisement = Advertisement {
                     advertisement_type: Type::Broadcast,
-                    local_name: Some(format!("ORB-{}", ctx.zenoh.orb_id())),
+                    local_name: Some("Orb".to_owned()),
                     service_data: service_data.clone(),
                     timeout: Some(Duration::ZERO),
                     ..Default::default()

--- a/orb-connd/src/ble/mod.rs
+++ b/orb-connd/src/ble/mod.rs
@@ -113,6 +113,7 @@ pub async fn advertiser(ctx: mini::Ctx<Args>) -> Result<()> {
 
                 let advertisement = Advertisement {
                     advertisement_type: Type::Broadcast,
+                    local_name: Some(format!("ORB-{}", ctx.zenoh.orb_id())),
                     service_data: service_data.clone(),
                     timeout: Some(Duration::ZERO),
                     ..Default::default()

--- a/orb-connd/src/connectivity_daemon.rs
+++ b/orb-connd/src/connectivity_daemon.rs
@@ -2,7 +2,7 @@ use crate::network_manager::NetworkManager;
 use crate::resolved::Resolved;
 use crate::service::{self, ConndService, ProfileStorage};
 use crate::{ble, modem, reporters, OrbCapabilities};
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::Result;
 use orb_info::orb_os_release::OrbOsRelease;
 use speare::mini::{self, OnErr};
 use speare::{Backoff, Limit};
@@ -71,7 +71,7 @@ pub async fn program(
         .await
         .inspect_err(|e| error!("failed to start connd zoci zenoh receiver: {e}"));
 
-    let _ = speare
+    speare
         .task_with()
         .on_err(OnErr::Restart {
             max: Limit::None,
@@ -97,7 +97,7 @@ pub async fn program(
     .await?;
 
     if let OrbCapabilities::CellularAndWifi = cap {
-        let _ = speare
+        speare
             .task_with()
             .on_err(OnErr::Restart {
                 max: 10.into(),

--- a/orb-jobs-agent/tests/docker/Dockerfile
+++ b/orb-jobs-agent/tests/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Install fsck and filesystem tools
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Set the BLE advertisement local name to `Orb`, without an Orb ID suffix.

Remove an unused import and two unit-value bindings reported by Clippy. Update the jobs-agent test fixture to Debian Bookworm: expired Bullseye security metadata prevented the fake-Orb image from building and caused four integration-test failures.

Validation on commit 6613108b: Linux Clippy passed; the full Rust test job passed (531 passed, 21 skipped). Rust formatting and a local build and smoke test of the fake-Orb Docker image also passed.